### PR TITLE
Update README.md regarding building for RAK devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ You will be able to find additional guides and components at [my site](https://b
 ## RAK Wireless Board Support in PlatformIO
 
 Before building/flashing the RAK4631 targets in this project, there is, unfortunately, some patching you have to do to your platformIO packages to make it work. There is a guide here on the process:
-   https://learn.rakwireless.com/hc/en-us/articles/26687276346775-How-To-Perform-Installation-of-Board-Support-Package-in-PlatformIO
-   
+   [RAK Wireless: How to Perform Installation of Board Support Package in PlatformIO](https://learn.rakwireless.com/hc/en-us/articles/26687276346775-How-To-Perform-Installation-of-Board-Support-Package-in-PlatformIO)
+
+After building, you will need to convert the output firmware.hex file into a .uf2 file you can copy over to your RAK4631 device (after doing a full erase) by using the command `uf2conv.py -f 0xADA52840 -c firmware.hex` with the python script available from:
+   [GitHub: Microsoft - uf2](https://github.com/Microsoft/uf2/blob/master/utils/uf2conv.py)
 


### PR DESCRIPTION
Added small section under RAK compatibility for info on how to convert hex to uf2, with link to Microsoft GitHub uf2conv python script. Cleaned up how links display in that section.