### PR TITLE
added CMD_REBOOT to companion radio

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -110,6 +110,7 @@ static uint32_t _atoi(const char* sp) {
 #define CMD_SHARE_CONTACT         16
 #define CMD_EXPORT_CONTACT        17
 #define CMD_IMPORT_CONTACT        18
+#define CMD_REBOOT                19
 
 #define RESP_CODE_OK                0
 #define RESP_CODE_ERR               1
@@ -788,6 +789,8 @@ public:
         _phy->setOutputPower(_prefs.tx_power_dbm);
         writeOKFrame(); 
       }
+    } else if (cmd_frame[0] == CMD_REBOOT) {
+      board.reboot();
     } else {
       writeErrFrame();
       MESH_DEBUG_PRINTLN("ERROR: unknown command: %02X", cmd_frame[0]);


### PR DESCRIPTION
This PR adds a new command, `CMD_REBOOT` to the Companion Radio firmware.

- `CMD_REBOOT`: `19`

Currently when setting a new advert name, the user needs to reboot the board before it updates the name advertised over BLE.

It would be good to automatically update that as well, when the `CMD_SET_ADVERT_NAME` is received, but the reboot command is also useful as some boards may not be easily accessible.