### PR TITLE
add new commands to companion firmware to import and export identity

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -121,6 +121,8 @@ static uint32_t _atoi(const char* sp) {
 #define CMD_GET_BATTERY_VOLTAGE   20
 #define CMD_SET_TUNING_PARAMS     21
 #define CMD_DEVICE_QEURY          22
+#define CMD_EXPORT_PRIVATE_KEY    23
+#define CMD_IMPORT_PRIVATE_KEY    24
 
 #define RESP_CODE_OK                0
 #define RESP_CODE_ERR               1
@@ -136,6 +138,7 @@ static uint32_t _atoi(const char* sp) {
 #define RESP_CODE_EXPORT_CONTACT   11
 #define RESP_CODE_BATTERY_VOLTAGE  12   // a reply to a CMD_GET_BATTERY_VOLTAGE
 #define RESP_CODE_DEVICE_INFO      13   // a reply to CMD_DEVICE_QEURY
+#define RESP_CODE_PRIVATE_KEY      14   // a reply to CMD_EXPORT_PRIVATE_KEY
 
 // these are _pushed_ to client app at any time
 #define PUSH_CODE_ADVERT            0x80
@@ -163,6 +166,7 @@ struct NodePrefs {  // persisted to file
 class MyMesh : public BaseChatMesh {
   FILESYSTEM* _fs;
   RADIO_CLASS* _phy;
+  IdentityStore* _identity_store;
   NodePrefs _prefs;
   uint32_t expected_ack_crc;  // TODO: keep table of expected ACKs
   mesh::GroupChannel* _public;
@@ -182,6 +186,26 @@ class MyMesh : public BaseChatMesh {
   };
   int offline_queue_len;
   Frame offline_queue[OFFLINE_QUEUE_SIZE];
+
+  void initIdentityStore(FILESYSTEM& fs) {
+  #if defined(NRF52_PLATFORM)
+    _identity_store = new IdentityStore(fs, "");
+  #else
+    _identity_store = new IdentityStore(fs, "/identity");
+  #endif
+  }
+
+  void loadMainIdentity(mesh::RNG& trng) {
+    if(!_identity_store->load("_main", self_id)){
+      self_id = mesh::LocalIdentity(&trng);  // create new random identity
+      saveMainIdentity(self_id);
+    }
+  }
+
+  bool saveMainIdentity(mesh::LocalIdentity identity) {
+    self_id = identity;
+    return _identity_store->save("_main", identity);
+  }
 
   void loadContacts() {
     if (_fs->exists("/contacts3")) {
@@ -495,15 +519,8 @@ public:
 
     BaseChatMesh::begin();
 
-  #if defined(NRF52_PLATFORM)
-    IdentityStore store(fs, "");
-  #else
-    IdentityStore store(fs, "/identity");
-  #endif
-    if (!store.load("_main", self_id)) {
-      self_id = mesh::LocalIdentity(&trng);  // create new random identity
-      store.save("_main", self_id);
-    }
+    initIdentityStore(fs);
+    loadMainIdentity(trng);
 
     // load persisted prefs
     if (_fs->exists("/node_prefs")) {
@@ -844,6 +861,21 @@ public:
       uint16_t battery_millivolts = board.getBattMilliVolts();
       memcpy(&reply[1], &battery_millivolts, 2);
       _serial->writeFrame(reply, 3);
+    } else if (cmd_frame[0] == CMD_EXPORT_PRIVATE_KEY) {
+      uint8_t reply[65];
+      reply[0] = RESP_CODE_PRIVATE_KEY;
+      uint8_t private_key[64];
+      self_id.writeTo(private_key, 64);
+      memcpy(&reply[1], &private_key, 64);
+      _serial->writeFrame(reply, 65);
+    } else if (cmd_frame[0] == CMD_IMPORT_PRIVATE_KEY && len >= 65) {
+      mesh::LocalIdentity identity = mesh::LocalIdentity();
+      identity.readFrom(&cmd_frame[1], 64);
+      if(saveMainIdentity(identity)){
+        writeOKFrame();
+      } else {
+        writeErrFrame();
+      }
     } else {
       writeErrFrame();
       MESH_DEBUG_PRINTLN("ERROR: unknown command: %02X", cmd_frame[0]);


### PR DESCRIPTION
This PR adds two new commands to import and export the main identity private key in the Companion Radio firmware.

`CMD_EXPORT_PRIVATE_KEY`: `23`
`CMD_IMPORT_PRIVATE_KEY`: `24`
`RESP_CODE_PRIVATE_KEY` : `14`

- `CMD_EXPORT_PRIVATE_KEY` replies with `RESP_CODE_PRIVATE_KEY` containing the 64 byte main identity key.
- `CMD_IMPORT_PRIVATE_KEY` accepts a 64 byte private key which is loaded and saved as the main identity key.

Could possibly be renamed to `CMD_EXPORT_IDENTITY_PRIVATE_KEY`, but naming is internal only...

I opted to leave out the public key from the export, as the firmware can derive it from the private key on import.