### PR TITLE
Fix BLE Pin for ESP32 and nRF52

### DIFF
--- a/src/helpers/esp32/SerialBLEInterface.cpp
+++ b/src/helpers/esp32/SerialBLEInterface.cpp
@@ -12,13 +12,13 @@ void SerialBLEInterface::begin(const char* device_name, uint32_t pin_code) {
 
   // Create the BLE Device
   BLEDevice::init(device_name);
-  BLEDevice::setEncryptionLevel(ESP_BLE_SEC_ENCRYPT);
+  BLEDevice::setEncryptionLevel(ESP_BLE_SEC_ENCRYPT_MITM);
   BLEDevice::setSecurityCallbacks(this);
   BLEDevice::setMTU(MAX_FRAME_SIZE);
 
   BLESecurity  sec;
   sec.setStaticPIN(pin_code);
-  sec.setAuthenticationMode(ESP_LE_AUTH_REQ_SC_BOND);
+  sec.setAuthenticationMode(ESP_LE_AUTH_REQ_SC_MITM_BOND);
 
   //BLEDevice::setPower(ESP_PWR_LVL_N8);
 
@@ -31,11 +31,11 @@ void SerialBLEInterface::begin(const char* device_name, uint32_t pin_code) {
 
   // Create a BLE Characteristic
   pTxCharacteristic = pService->createCharacteristic(CHARACTERISTIC_UUID_TX, BLECharacteristic::PROPERTY_READ | BLECharacteristic::PROPERTY_NOTIFY);
-  pTxCharacteristic->setAccessPermissions(ESP_GATT_PERM_READ_ENCRYPTED);
+  pTxCharacteristic->setAccessPermissions(ESP_GATT_PERM_READ_ENC_MITM);
   pTxCharacteristic->addDescriptor(new BLE2902());
 
   BLECharacteristic * pRxCharacteristic = pService->createCharacteristic(CHARACTERISTIC_UUID_RX, BLECharacteristic::PROPERTY_WRITE);
-  pRxCharacteristic->setAccessPermissions(ESP_GATT_PERM_WRITE_ENCRYPTED);
+  pRxCharacteristic->setAccessPermissions(ESP_GATT_PERM_WRITE_ENC_MITM);
   pRxCharacteristic->setCallbacks(this);
 
   pServer->getAdvertising()->addServiceUUID(SERVICE_UUID);

--- a/src/helpers/nrf52/SerialBLEInterface.cpp
+++ b/src/helpers/nrf52/SerialBLEInterface.cpp
@@ -10,6 +10,7 @@ void SerialBLEInterface::begin(const char* device_name, uint32_t pin_code) {
   Bluefruit.setTxPower(4);    // Check bluefruit.h for supported values
   Bluefruit.setName(device_name);
 
+  Bluefruit.Security.setMITM(true);
   Bluefruit.Security.setPIN(charpin);
 
   // To be consistent OTA DFU should be added first if it exists
@@ -52,6 +53,7 @@ void SerialBLEInterface::enable() {
   clearBuffers();
 
   // Configure and start the BLE Uart service
+  bleuart.setPermission(SECMODE_ENC_WITH_MITM, SECMODE_ENC_WITH_MITM);
   bleuart.begin();
 
   // Start advertising


### PR DESCRIPTION
This PR fixes the issue where anyone can connect to a device without entering the configured PIN.

This switches the security modes so the "Just Works" BLE pairing method is disabled, which forces the user to have to enter a pin to be able to pair.

I've tested on the following devices:

- RAK4631, with BLE Companion Firmware
- Heltec v3, with BLE Companion Firmware

I also found a bug in my mobile app, in which it doesn't disconnect from the BLE device when pairing fails. This contributed to the issue where devices would not be discoverable. This has been patched for the next app update.

There is also one more bug, which I believe is in firmware, but this needs some more investigation. There is a case where the device sometimes gets into a state where it doesn't start advertising again, so it's not discoverable. Only workaround for that is to reboot the micro controller, unless we can track it down in firmware.