### PR TITLE
Fix double pairing prompt for ESP32

### DIFF
--- a/src/helpers/esp32/SerialBLEInterface.cpp
+++ b/src/helpers/esp32/SerialBLEInterface.cpp
@@ -12,7 +12,6 @@ void SerialBLEInterface::begin(const char* device_name, uint32_t pin_code) {
 
   // Create the BLE Device
   BLEDevice::init(device_name);
-  BLEDevice::setEncryptionLevel(ESP_BLE_SEC_ENCRYPT_MITM);
   BLEDevice::setSecurityCallbacks(this);
   BLEDevice::setMTU(MAX_FRAME_SIZE);
 


### PR DESCRIPTION
After fixing the BLE pairing pin, a fun side effect when connecting to ESP32 from Android, was that the pairing dialog would show twice.

This was caused by the microcontroller trying to pair with the phone, and then the phone trying to pair with the microcontroller.

This PR sets it so the encryption is configured at the characteristic level, rather than device connection level, so the pairing process is started by the phone to microcontroller, rather than microcontroller to phone...