### PR TITLE
Fixes BLE advertising after pairing failure

### DIFF
--- a/src/helpers/esp32/SerialBLEInterface.cpp
+++ b/src/helpers/esp32/SerialBLEInterface.cpp
@@ -226,6 +226,7 @@ size_t SerialBLEInterface::checkRecvFrame(uint8_t dest[]) {
   }
 
   if (checkAdvRestart) {
+    delay(1000); // need to wait a bit for device to disconnect, otherwise advertising wont start again
     if (pServer->getConnectedCount() == 0) {
       BLE_DEBUG_PRINTLN("SerialBLEInterface -> re-starting advertising");
       pServer->getAdvertising()->start();  // re-Start advertising


### PR DESCRIPTION
When pairing with an ESP32 device, if you cancel the pairing process, or enter the wrong pin, most of the time the device never starts advertising itself again. This means the user has to restart the board to be able to pair again.

It seems like it's just a timing issue, as adding in this short sleep before checking connection count, I have not been able to get it stuck in the non-advertising state anymore.

The nRF52 boards, more specifically the RAK4631, doesn't appear to have this issue. So I haven't added the delay for that board.

Hopefully this is the last of the BLE patches, for now ;)