### PR TITLE
Add nRF52 S140 SoftDevice Header Files

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -482,6 +482,8 @@ extends = nrf52_base
 platform_packages = framework-arduinoadafruitnrf52
 build_flags = ${nrf52_base.build_flags} 
   -I src/helpers/nrf52
+  -I variants/t1000-e/s140_nrf52_7.3.0_API/include
+  -I variants/t1000-e/s140_nrf52_7.3.0_API/include/nrf52
 lib_ignore =
   BluetoothOTA
   lvgl

--- a/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble.h
+++ b/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble.h
@@ -1,0 +1,679 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+  @addtogroup BLE_COMMON BLE SoftDevice Common
+  @{
+  @defgroup ble_api Events, type definitions and API calls
+  @{
+
+  @brief Module independent events, type definitions and API calls for the BLE SoftDevice.
+
+ */
+
+#ifndef BLE_H__
+#define BLE_H__
+
+#include <stdint.h>
+#include "nrf_svc.h"
+#include "nrf_error.h"
+#include "ble_err.h"
+#include "ble_gap.h"
+#include "ble_l2cap.h"
+#include "ble_gatt.h"
+#include "ble_gattc.h"
+#include "ble_gatts.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @addtogroup BLE_COMMON_ENUMERATIONS Enumerations
+ * @{ */
+
+/**
+ * @brief Common API SVC numbers.
+ */
+enum BLE_COMMON_SVCS
+{
+  SD_BLE_ENABLE = BLE_SVC_BASE,         /**< Enable and initialize the BLE stack */
+  SD_BLE_EVT_GET,                       /**< Get an event from the pending events queue. */
+  SD_BLE_UUID_VS_ADD,                   /**< Add a Vendor Specific base UUID. */
+  SD_BLE_UUID_DECODE,                   /**< Decode UUID bytes. */
+  SD_BLE_UUID_ENCODE,                   /**< Encode UUID bytes. */
+  SD_BLE_VERSION_GET,                   /**< Get the local version information (company ID, Link Layer Version, Link Layer Subversion). */
+  SD_BLE_USER_MEM_REPLY,                /**< User Memory Reply. */
+  SD_BLE_OPT_SET,                       /**< Set a BLE option. */
+  SD_BLE_OPT_GET,                       /**< Get a BLE option. */
+  SD_BLE_CFG_SET,                       /**< Add a configuration to the BLE stack. */
+  SD_BLE_UUID_VS_REMOVE,                /**< Remove a Vendor Specific base UUID. */
+};
+
+/**
+ * @brief BLE Module Independent Event IDs.
+ */
+enum BLE_COMMON_EVTS
+{
+  BLE_EVT_USER_MEM_REQUEST = BLE_EVT_BASE + 0,   /**< User Memory request. See @ref ble_evt_user_mem_request_t 
+                                                   \n Reply with @ref sd_ble_user_mem_reply. */
+  BLE_EVT_USER_MEM_RELEASE = BLE_EVT_BASE + 1,   /**< User Memory release. See @ref ble_evt_user_mem_release_t */
+};
+
+/**@brief BLE Connection Configuration IDs.
+ *
+ * IDs that uniquely identify a connection configuration.
+ */
+enum BLE_CONN_CFGS
+{
+    BLE_CONN_CFG_GAP   = BLE_CONN_CFG_BASE + 0, /**< BLE GAP specific connection configuration. */
+    BLE_CONN_CFG_GATTC = BLE_CONN_CFG_BASE + 1, /**< BLE GATTC specific connection configuration. */
+    BLE_CONN_CFG_GATTS = BLE_CONN_CFG_BASE + 2, /**< BLE GATTS specific connection configuration. */
+    BLE_CONN_CFG_GATT  = BLE_CONN_CFG_BASE + 3, /**< BLE GATT specific connection configuration. */
+    BLE_CONN_CFG_L2CAP = BLE_CONN_CFG_BASE + 4, /**< BLE L2CAP specific connection configuration. */
+};
+
+/**@brief BLE Common Configuration IDs.
+ *
+ * IDs that uniquely identify a common configuration.
+ */
+enum BLE_COMMON_CFGS
+{
+  BLE_COMMON_CFG_VS_UUID = BLE_CFG_BASE, /**< Vendor specific base UUID configuration */
+};
+
+/**@brief Common Option IDs.
+ * IDs that uniquely identify a common option.
+ */
+enum BLE_COMMON_OPTS
+{
+  BLE_COMMON_OPT_PA_LNA          = BLE_OPT_BASE + 0, /**< PA and LNA options */
+  BLE_COMMON_OPT_CONN_EVT_EXT    = BLE_OPT_BASE + 1, /**< Extended connection events option */
+  BLE_COMMON_OPT_EXTENDED_RC_CAL = BLE_OPT_BASE + 2, /**< Extended RC calibration option */
+};
+
+/** @} */
+
+/** @addtogroup BLE_COMMON_DEFINES Defines
+ * @{ */
+
+/** @brief  Required pointer alignment for BLE Events.
+*/
+#define BLE_EVT_PTR_ALIGNMENT    4
+
+/** @brief  Leaves the maximum of the two arguments.
+*/
+#define BLE_MAX(a, b) ((a) < (b) ? (b) : (a))
+
+/** @brief  Maximum possible length for BLE Events.
+ * @note The highest value used for @ref ble_gatt_conn_cfg_t::att_mtu in any connection configuration shall be used as a parameter.
+ * If that value has not been configured for any connections then @ref BLE_GATT_ATT_MTU_DEFAULT must be used instead.
+*/
+#define BLE_EVT_LEN_MAX(ATT_MTU) ( \
+    offsetof(ble_evt_t, evt.gattc_evt.params.prim_srvc_disc_rsp.services) + ((ATT_MTU) - 1) / 4 * sizeof(ble_gattc_service_t) \
+)
+
+/** @defgroup BLE_USER_MEM_TYPES User Memory Types
+ * @{ */
+#define BLE_USER_MEM_TYPE_INVALID               0x00  /**< Invalid User Memory Types. */
+#define BLE_USER_MEM_TYPE_GATTS_QUEUED_WRITES   0x01  /**< User Memory for GATTS queued writes. */
+/** @} */
+
+/** @defgroup BLE_UUID_VS_COUNTS Vendor Specific base UUID counts
+ * @{
+ */
+#define BLE_UUID_VS_COUNT_DEFAULT 10  /**< Default VS UUID count. */
+#define BLE_UUID_VS_COUNT_MAX     254 /**< Maximum VS UUID count. */
+/** @} */
+
+/** @defgroup BLE_COMMON_CFG_DEFAULTS Configuration defaults.
+ * @{
+ */
+#define BLE_CONN_CFG_TAG_DEFAULT  0    /**< Default configuration tag, SoftDevice default connection configuration. */
+
+/** @} */
+
+/** @} */
+
+/** @addtogroup BLE_COMMON_STRUCTURES Structures
+ * @{ */
+
+/**@brief User Memory Block. */
+typedef struct
+{
+  uint8_t          *p_mem;      /**< Pointer to the start of the user memory block. */
+  uint16_t          len;        /**< Length in bytes of the user memory block. */
+} ble_user_mem_block_t;
+
+/**@brief Event structure for @ref BLE_EVT_USER_MEM_REQUEST. */
+typedef struct
+{
+  uint8_t                     type;     /**< User memory type, see @ref BLE_USER_MEM_TYPES. */
+} ble_evt_user_mem_request_t;
+
+/**@brief Event structure for @ref BLE_EVT_USER_MEM_RELEASE. */
+typedef struct
+{
+  uint8_t                     type;       /**< User memory type, see @ref BLE_USER_MEM_TYPES. */
+  ble_user_mem_block_t        mem_block;  /**< User memory block */
+} ble_evt_user_mem_release_t;
+
+/**@brief Event structure for events not associated with a specific function module. */
+typedef struct
+{
+  uint16_t conn_handle;                                 /**< Connection Handle on which this event occurred. */
+  union
+  {
+    ble_evt_user_mem_request_t      user_mem_request;    /**< User Memory Request Event Parameters. */
+    ble_evt_user_mem_release_t      user_mem_release;    /**< User Memory Release Event Parameters. */
+  } params;                                              /**< Event parameter union. */
+} ble_common_evt_t;
+
+/**@brief BLE Event header. */
+typedef struct
+{
+  uint16_t evt_id;                /**< Value from a BLE_<module>_EVT series. */
+  uint16_t evt_len;               /**< Length in octets including this header. */
+} ble_evt_hdr_t;
+
+/**@brief Common BLE Event type, wrapping the module specific event reports. */
+typedef struct
+{
+  ble_evt_hdr_t header;           /**< Event header. */
+  union
+  {
+    ble_common_evt_t  common_evt; /**< Common Event, evt_id in BLE_EVT_* series. */
+    ble_gap_evt_t     gap_evt;    /**< GAP originated event, evt_id in BLE_GAP_EVT_* series. */
+    ble_gattc_evt_t   gattc_evt;  /**< GATT client originated event, evt_id in BLE_GATTC_EVT* series. */
+    ble_gatts_evt_t   gatts_evt;  /**< GATT server originated event, evt_id in BLE_GATTS_EVT* series. */
+    ble_l2cap_evt_t   l2cap_evt;  /**< L2CAP originated event, evt_id in BLE_L2CAP_EVT* series. */
+  } evt;                          /**< Event union. */
+} ble_evt_t;
+
+
+/**
+ * @brief Version Information.
+ */
+typedef struct
+{
+  uint8_t   version_number;    /**< Link Layer Version number. See https://www.bluetooth.org/en-us/specification/assigned-numbers/link-layer for assigned values. */
+  uint16_t  company_id;        /**< Company ID, Nordic Semiconductor's company ID is 89 (0x0059) (https://www.bluetooth.org/apps/content/Default.aspx?doc_id=49708). */
+  uint16_t  subversion_number; /**< Link Layer Sub Version number, corresponds to the SoftDevice Config ID or Firmware ID (FWID). */
+} ble_version_t;
+
+/**
+ * @brief Configuration parameters for the PA and LNA.
+ */
+typedef struct
+{
+     uint8_t enable :1;      /**< Enable toggling for this amplifier */
+     uint8_t active_high :1; /**< Set the pin to be active high */
+     uint8_t gpio_pin :6;    /**< The GPIO pin to toggle for this amplifier */
+} ble_pa_lna_cfg_t;
+
+/**
+ * @brief PA & LNA GPIO toggle configuration
+ *
+ * This option configures the SoftDevice to toggle pins when the radio is active for use with a power amplifier and/or
+ * a low noise amplifier.
+ *
+ * Toggling the pins is achieved by using two PPI channels and a GPIOTE channel. The hardware channel IDs are provided
+ * by the application and should be regarded as reserved as long as any PA/LNA toggling is enabled.
+ *
+ * @note  @ref sd_ble_opt_get is not supported for this option.
+ * @note  Setting this option while the radio is in use (i.e. any of the roles are active) may have undefined consequences
+ * and must be avoided by the application.
+ */
+typedef struct
+{
+   ble_pa_lna_cfg_t pa_cfg;   /**< Power Amplifier configuration */
+   ble_pa_lna_cfg_t lna_cfg;  /**< Low Noise Amplifier configuration */
+
+   uint8_t ppi_ch_id_set;     /**< PPI channel used for radio pin setting */
+   uint8_t ppi_ch_id_clr;     /**< PPI channel used for radio pin clearing */
+   uint8_t gpiote_ch_id;      /**< GPIOTE channel used for radio pin toggling */
+} ble_common_opt_pa_lna_t;
+
+/**
+ * @brief Configuration of extended BLE connection events.
+ *
+ * When enabled the SoftDevice will dynamically extend the connection event when possible.
+ *
+ * The connection event length is controlled by the connection configuration as set by @ref ble_gap_conn_cfg_t::event_length.
+ * The connection event can be extended if there is time to send another packet pair before the start of the next connection interval,
+ * and if there are no conflicts with other BLE roles requesting radio time.
+ *
+ * @note @ref sd_ble_opt_get is not supported for this option.
+ */
+typedef struct
+{
+   uint8_t enable : 1; /**< Enable extended BLE connection events, disabled by default. */
+} ble_common_opt_conn_evt_ext_t;
+
+/**
+ * @brief Enable/disable extended RC calibration.
+ *
+ * If extended RC calibration is enabled and the internal RC oscillator (@ref NRF_CLOCK_LF_SRC_RC) is used as the SoftDevice
+ * LFCLK source, the SoftDevice as a peripheral will by default try to increase the receive window if two consecutive packets
+ * are not received. If it turns out that the packets were not received due to clock drift, the RC calibration is started.
+ * This calibration comes in addition to the periodic calibration that is configured by @ref sd_softdevice_enable(). When
+ * using only peripheral connections, the periodic calibration can therefore be configured with a much longer interval as the
+ * peripheral will be able to detect and adjust automatically to clock drift, and calibrate on demand.
+ *
+ * If extended RC calibration is disabled and the internal RC oscillator is used as the SoftDevice LFCLK source, the
+ * RC oscillator is calibrated periodically as configured by @ref sd_softdevice_enable().
+ *
+ * @note @ref sd_ble_opt_get is not supported for this option.
+ */
+typedef struct
+{
+   uint8_t enable : 1; /**< Enable extended RC calibration, enabled by default. */
+} ble_common_opt_extended_rc_cal_t;
+
+/**@brief Option structure for common options. */
+typedef union
+{
+  ble_common_opt_pa_lna_t          pa_lna;          /**< Parameters for controlling PA and LNA pin toggling. */
+  ble_common_opt_conn_evt_ext_t    conn_evt_ext;    /**< Parameters for enabling extended connection events. */
+  ble_common_opt_extended_rc_cal_t extended_rc_cal; /**< Parameters for enabling extended RC calibration. */
+} ble_common_opt_t;
+
+/**@brief Common BLE Option type, wrapping the module specific options. */
+typedef union
+{
+  ble_common_opt_t  common_opt;         /**< COMMON options, opt_id in @ref BLE_COMMON_OPTS series. */
+  ble_gap_opt_t     gap_opt;            /**< GAP option, opt_id in @ref BLE_GAP_OPTS series. */
+  ble_gattc_opt_t   gattc_opt;          /**< GATTC option, opt_id in @ref BLE_GATTC_OPTS series. */
+} ble_opt_t;
+
+/**@brief BLE connection configuration type, wrapping the module specific configurations, set with
+ * @ref sd_ble_cfg_set.
+ *
+ * @note Connection configurations don't have to be set.
+ * In the case that no configurations has been set, or fewer connection configurations has been set than enabled connections,
+ * the default connection configuration will be automatically added for the remaining connections.
+ * When creating connections with the default configuration, @ref BLE_CONN_CFG_TAG_DEFAULT should be used in
+ * place of @ref ble_conn_cfg_t::conn_cfg_tag.
+ *
+ * @sa sd_ble_gap_adv_start()
+ * @sa sd_ble_gap_connect()
+ *
+ * @mscs
+ * @mmsc{@ref BLE_CONN_CFG}
+ * @endmscs
+
+ */
+typedef struct
+{
+  uint8_t              conn_cfg_tag;        /**< The application chosen tag it can use with the
+                                                 @ref sd_ble_gap_adv_start() and @ref sd_ble_gap_connect() calls
+                                                 to select this configuration when creating a connection.
+                                                 Must be different for all connection configurations added and not @ref BLE_CONN_CFG_TAG_DEFAULT. */
+  union {
+    ble_gap_conn_cfg_t   gap_conn_cfg;      /**< GAP connection configuration, cfg_id is @ref BLE_CONN_CFG_GAP. */
+    ble_gattc_conn_cfg_t gattc_conn_cfg;    /**< GATTC connection configuration, cfg_id is @ref BLE_CONN_CFG_GATTC. */
+    ble_gatts_conn_cfg_t gatts_conn_cfg;    /**< GATTS connection configuration, cfg_id is @ref BLE_CONN_CFG_GATTS. */
+    ble_gatt_conn_cfg_t  gatt_conn_cfg;     /**< GATT connection configuration, cfg_id is @ref BLE_CONN_CFG_GATT. */
+    ble_l2cap_conn_cfg_t l2cap_conn_cfg;    /**< L2CAP connection configuration, cfg_id is @ref BLE_CONN_CFG_L2CAP. */
+  } params;                                 /**< Connection configuration union. */
+} ble_conn_cfg_t;
+
+/**
+ * @brief Configuration of Vendor Specific base UUIDs, set with @ref sd_ble_cfg_set.
+ *
+ * @retval ::NRF_ERROR_INVALID_PARAM Too many UUIDs configured.
+ */
+typedef struct
+{
+  uint8_t vs_uuid_count; /**< Number of 128-bit Vendor Specific base UUID bases to allocate memory for.
+                              Default value is @ref BLE_UUID_VS_COUNT_DEFAULT. Maximum value is
+                              @ref BLE_UUID_VS_COUNT_MAX. */
+} ble_common_cfg_vs_uuid_t;
+
+/**@brief Common BLE Configuration type, wrapping the common configurations. */
+typedef union
+{
+  ble_common_cfg_vs_uuid_t  vs_uuid_cfg;  /**< Vendor Specific base UUID configuration, cfg_id is @ref BLE_COMMON_CFG_VS_UUID. */
+} ble_common_cfg_t;
+
+/**@brief BLE Configuration type, wrapping the module specific configurations. */
+typedef union
+{
+  ble_conn_cfg_t    conn_cfg;   /**< Connection specific configurations, cfg_id in @ref BLE_CONN_CFGS series. */
+  ble_common_cfg_t  common_cfg; /**< Global common configurations, cfg_id in @ref BLE_COMMON_CFGS series. */
+  ble_gap_cfg_t     gap_cfg;    /**< Global GAP configurations, cfg_id in @ref BLE_GAP_CFGS series. */
+  ble_gatts_cfg_t   gatts_cfg;  /**< Global GATTS configuration, cfg_id in @ref BLE_GATTS_CFGS series. */
+} ble_cfg_t;
+
+/** @} */
+
+/** @addtogroup BLE_COMMON_FUNCTIONS Functions
+ * @{ */
+
+/**@brief Enable the BLE stack
+ *
+ * @param[in, out] p_app_ram_base   Pointer to a variable containing the start address of the
+ *                                  application RAM region (APP_RAM_BASE). On return, this will
+ *                                  contain the minimum start address of the application RAM region
+ *                                  required by the SoftDevice for this configuration.
+ * @warning After this call, the SoftDevice may generate several events. The list of events provided 
+ *          below require the application to initiate a SoftDevice API call. The corresponding API call 
+ *          is referenced in the event documentation. 
+ *          If the application fails to do so, the BLE connection may timeout, or the SoftDevice may stop 
+ *          communicating with the peer device.
+ *          - @ref BLE_GAP_EVT_CONN_PARAM_UPDATE_REQUEST
+ *          - @ref BLE_GAP_EVT_DATA_LENGTH_UPDATE_REQUEST
+ *          - @ref BLE_GAP_EVT_PHY_UPDATE_REQUEST
+ *          - @ref BLE_GAP_EVT_SEC_PARAMS_REQUEST
+ *          - @ref BLE_GAP_EVT_SEC_INFO_REQUEST
+ *          - @ref BLE_GAP_EVT_SEC_REQUEST
+ *          - @ref BLE_GAP_EVT_AUTH_KEY_REQUEST
+ *          - @ref BLE_GATTS_EVT_EXCHANGE_MTU_REQUEST
+ *          - @ref BLE_EVT_USER_MEM_REQUEST
+ *          - @ref BLE_L2CAP_EVT_CH_SETUP_REQUEST
+ *
+ * @note The memory requirement for a specific configuration will not increase between SoftDevices
+ *       with the same major version number.
+ *
+ * @note At runtime the IC's RAM is split into 2 regions: The SoftDevice RAM region is located
+ *       between 0x20000000 and APP_RAM_BASE-1 and the application's RAM region is located between
+ *       APP_RAM_BASE and the start of the call stack.
+ *
+ * @details This call initializes the BLE stack, no BLE related function other than @ref
+ *          sd_ble_cfg_set can be called before this one.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_COMMON_ENABLE}
+ * @endmscs
+ *
+ * @retval ::NRF_SUCCESS              The BLE stack has been initialized successfully.
+ * @retval ::NRF_ERROR_INVALID_STATE  The BLE stack had already been initialized and cannot be reinitialized.
+ * @retval ::NRF_ERROR_INVALID_ADDR   Invalid or not sufficiently aligned pointer supplied.
+ * @retval ::NRF_ERROR_NO_MEM         One or more of the following is true:
+ *                                    - The amount of memory assigned to the SoftDevice by *p_app_ram_base is not
+ *                                      large enough to fit this configuration's memory requirement. Check *p_app_ram_base
+ *                                      and set the start address of the application RAM region accordingly.
+ *                                    - Dynamic part of the SoftDevice RAM region is larger then 64 kB which
+ *                                      is currently not supported.
+ * @retval ::NRF_ERROR_RESOURCES      The total number of L2CAP Channels configured using @ref sd_ble_cfg_set is too large.
+ */
+SVCALL(SD_BLE_ENABLE, uint32_t, sd_ble_enable(uint32_t * p_app_ram_base));
+
+/**@brief Add configurations for the BLE stack
+ *
+ * @param[in] cfg_id              Config ID, see @ref BLE_CONN_CFGS, @ref BLE_COMMON_CFGS, @ref
+ *                                BLE_GAP_CFGS or @ref BLE_GATTS_CFGS.
+ * @param[in] p_cfg               Pointer to a ble_cfg_t structure containing the configuration value.
+ * @param[in] app_ram_base        The start address of the application RAM region (APP_RAM_BASE).
+ *                                See @ref sd_ble_enable for details about APP_RAM_BASE.
+ *
+ * @note The memory requirement for a specific configuration will not increase between SoftDevices
+ *       with the same major version number.
+ *
+ * @note If a configuration is set more than once, the last one set is the one that takes effect on
+ *       @ref sd_ble_enable.
+ *
+ * @note Any part of the BLE stack that is NOT configured with @ref sd_ble_cfg_set will have default
+ *       configuration.
+ *
+ * @note @ref sd_ble_cfg_set may be called at any time when the SoftDevice is enabled (see @ref
+ *       sd_softdevice_enable) while the BLE part of the SoftDevice is not enabled (see @ref
+ *       sd_ble_enable).
+ *
+ * @note Error codes for the configurations are described in the configuration structs.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_COMMON_ENABLE}
+ * @endmscs
+ *
+ * @retval ::NRF_SUCCESS              The configuration has been added successfully.
+ * @retval ::NRF_ERROR_INVALID_STATE  The BLE stack had already been initialized.
+ * @retval ::NRF_ERROR_INVALID_ADDR   Invalid or not sufficiently aligned pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM  Invalid cfg_id supplied.
+ * @retval ::NRF_ERROR_NO_MEM         The amount of memory assigned to the SoftDevice by app_ram_base is not
+ *                                    large enough to fit this configuration's memory requirement.
+ */
+SVCALL(SD_BLE_CFG_SET, uint32_t, sd_ble_cfg_set(uint32_t cfg_id, ble_cfg_t const * p_cfg, uint32_t app_ram_base));
+
+/**@brief Get an event from the pending events queue.
+ *
+ * @param[out] p_dest Pointer to buffer to be filled in with an event, or NULL to retrieve the event length.
+ *                    This buffer <b>must be aligned to the extend defined by @ref BLE_EVT_PTR_ALIGNMENT</b>.
+ *                    The buffer should be interpreted as a @ref ble_evt_t struct.
+ * @param[in, out] p_len Pointer the length of the buffer, on return it is filled with the event length.
+ *
+ * @details This call allows the application to pull a BLE event from the BLE stack. The application is signaled that
+ * an event is available from the BLE stack by the triggering of the SD_EVT_IRQn interrupt.
+ * The application is free to choose whether to call this function from thread mode (main context) or directly from the
+ * Interrupt Service Routine that maps to SD_EVT_IRQn. In any case however, and because the BLE stack runs at a higher
+ * priority than the application, this function should be called in a loop (until @ref NRF_ERROR_NOT_FOUND is returned)
+ * every time SD_EVT_IRQn is raised to ensure that all available events are pulled from the BLE stack. Failure to do so
+ * could potentially leave events in the internal queue without the application being aware of this fact.
+ *
+ * Sizing the p_dest buffer is equally important, since the application needs to provide all the memory necessary for the event to
+ * be copied into application memory. If the buffer provided is not large enough to fit the entire contents of the event,
+ * @ref NRF_ERROR_DATA_SIZE will be returned and the application can then call again with a larger buffer size.
+ * The maximum possible event length is defined by @ref BLE_EVT_LEN_MAX. The application may also "peek" the event length
+ * by providing p_dest as a NULL pointer and inspecting the value of *p_len upon return:
+ *
+ *     \code
+ *     uint16_t len;
+ *     errcode = sd_ble_evt_get(NULL, &len);
+ *     \endcode
+ *
+ * @mscs
+ * @mmsc{@ref BLE_COMMON_IRQ_EVT_MSC}
+ * @mmsc{@ref BLE_COMMON_THREAD_EVT_MSC}
+ * @endmscs
+ *
+ * @retval ::NRF_SUCCESS Event pulled and stored into the supplied buffer.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid or not sufficiently aligned pointer supplied.
+ * @retval ::NRF_ERROR_NOT_FOUND No events ready to be pulled.
+ * @retval ::NRF_ERROR_DATA_SIZE Event ready but could not fit into the supplied buffer.
+ */
+SVCALL(SD_BLE_EVT_GET, uint32_t, sd_ble_evt_get(uint8_t *p_dest, uint16_t *p_len));
+
+
+/**@brief Add a Vendor Specific base UUID.
+ *
+ * @details This call enables the application to add a Vendor Specific base UUID to the BLE stack's table, for later
+ * use with all other modules and APIs. This then allows the application to use the shorter, 24-bit @ref ble_uuid_t
+ * format when dealing with both 16-bit and 128-bit UUIDs without having to check for lengths and having split code
+ * paths. This is accomplished by extending the grouping mechanism that the Bluetooth SIG standard base UUID uses
+ * for all other 128-bit UUIDs. The type field in the @ref ble_uuid_t structure is an index (relative to
+ * @ref BLE_UUID_TYPE_VENDOR_BEGIN) to the table populated by multiple calls to this function, and the UUID field
+ * in the same structure contains the 2 bytes at indexes 12 and 13. The number of possible 128-bit UUIDs available to
+ * the application is therefore the number of Vendor Specific UUIDs added with the help of this function times 65536,
+ * although restricted to modifying bytes 12 and 13 for each of the entries in the supplied array.
+ *
+ * @note Bytes 12 and 13 of the provided UUID will not be used internally, since those are always replaced by
+ * the 16-bit uuid field in @ref ble_uuid_t.
+ *
+ * @note If a UUID is already present in the BLE stack's internal table, the corresponding index will be returned in
+ * p_uuid_type along with an @ref NRF_SUCCESS error code.
+ *
+ * @param[in]  p_vs_uuid    Pointer to a 16-octet (128-bit) little endian Vendor Specific base UUID disregarding
+ *                          bytes 12 and 13.
+ * @param[out] p_uuid_type  Pointer to a uint8_t where the type field in @ref ble_uuid_t corresponding to this UUID will be stored.
+ *
+ * @retval ::NRF_SUCCESS Successfully added the Vendor Specific base UUID.
+ * @retval ::NRF_ERROR_INVALID_ADDR If p_vs_uuid or p_uuid_type is NULL or invalid.
+ * @retval ::NRF_ERROR_NO_MEM If there are no more free slots for VS UUIDs.
+ */
+SVCALL(SD_BLE_UUID_VS_ADD, uint32_t, sd_ble_uuid_vs_add(ble_uuid128_t const *p_vs_uuid, uint8_t *p_uuid_type));
+
+
+/**@brief Remove a Vendor Specific base UUID.
+ *
+ * @details This call removes a Vendor Specific base UUID. This function allows
+ * the application to reuse memory allocated for Vendor Specific base UUIDs.
+ *
+ * @note Currently this function can only be called with a p_uuid_type set to @ref BLE_UUID_TYPE_UNKNOWN or the last added UUID type.
+ *
+ * @param[inout] p_uuid_type Pointer to a uint8_t where its value matches the UUID type in @ref ble_uuid_t::type to be removed.
+ *                           If the type is set to @ref BLE_UUID_TYPE_UNKNOWN, or the pointer is NULL, the last Vendor Specific
+ *                           base UUID will be removed. If the function returns successfully, the UUID type that was removed will
+ *                           be written back to @p p_uuid_type. If function returns with a failure, it contains the last type that
+ *                           is in use by the ATT Server.
+ *
+ * @retval ::NRF_SUCCESS Successfully removed the Vendor Specific base UUID.
+ * @retval ::NRF_ERROR_INVALID_ADDR If p_uuid_type is invalid.
+ * @retval ::NRF_ERROR_INVALID_PARAM If p_uuid_type points to a non-valid UUID type.
+ * @retval ::NRF_ERROR_FORBIDDEN If the Vendor Specific base UUID is in use by the ATT Server.
+ */
+SVCALL(SD_BLE_UUID_VS_REMOVE, uint32_t, sd_ble_uuid_vs_remove(uint8_t *p_uuid_type));
+
+
+/** @brief Decode little endian raw UUID bytes (16-bit or 128-bit) into a 24 bit @ref ble_uuid_t structure.
+ *
+ * @details The raw UUID bytes excluding bytes 12 and 13 (i.e. bytes 0-11 and 14-15) of p_uuid_le are compared
+ * to the corresponding ones in each entry of the table of Vendor Specific base UUIDs
+ * to look for a match. If there is such a match, bytes 12 and 13 are returned as p_uuid->uuid and the index
+ * relative to @ref BLE_UUID_TYPE_VENDOR_BEGIN as p_uuid->type.
+ *
+ * @note If the UUID length supplied is 2, then the type set by this call will always be @ref BLE_UUID_TYPE_BLE.
+ *
+ * @param[in]   uuid_le_len Length in bytes of the buffer pointed to by p_uuid_le (must be 2 or 16 bytes).
+ * @param[in]   p_uuid_le   Pointer pointing to little endian raw UUID bytes.
+ * @param[out]  p_uuid      Pointer to a @ref ble_uuid_t structure to be filled in.
+ *
+ * @retval ::NRF_SUCCESS Successfully decoded into the @ref ble_uuid_t structure.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_LENGTH Invalid UUID length.
+ * @retval ::NRF_ERROR_NOT_FOUND For a 128-bit UUID, no match in the populated table of UUIDs.
+ */
+SVCALL(SD_BLE_UUID_DECODE, uint32_t, sd_ble_uuid_decode(uint8_t uuid_le_len, uint8_t const *p_uuid_le, ble_uuid_t *p_uuid));
+
+
+/** @brief Encode a @ref ble_uuid_t structure into little endian raw UUID bytes (16-bit or 128-bit).
+ *
+ * @note The pointer to the destination buffer p_uuid_le may be NULL, in which case only the validity and size of p_uuid is computed.
+ *
+ * @param[in]   p_uuid        Pointer to a @ref ble_uuid_t structure that will be encoded into bytes.
+ * @param[out]  p_uuid_le_len Pointer to a uint8_t that will be filled with the encoded length (2 or 16 bytes).
+ * @param[out]  p_uuid_le     Pointer to a buffer where the little endian raw UUID bytes (2 or 16) will be stored.
+ *
+ * @retval ::NRF_SUCCESS Successfully encoded into the buffer.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid UUID type.
+ */
+SVCALL(SD_BLE_UUID_ENCODE, uint32_t, sd_ble_uuid_encode(ble_uuid_t const *p_uuid, uint8_t *p_uuid_le_len, uint8_t *p_uuid_le));
+
+
+/**@brief Get Version Information.
+ *
+ * @details This call allows the application to get the BLE stack version information.
+ *
+ * @param[out] p_version Pointer to a ble_version_t structure to be filled in.
+ *
+ * @retval ::NRF_SUCCESS  Version information stored successfully.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_BUSY The BLE stack is busy (typically doing a locally-initiated disconnection procedure).
+ */
+SVCALL(SD_BLE_VERSION_GET, uint32_t, sd_ble_version_get(ble_version_t *p_version));
+
+
+/**@brief Provide a user memory block.
+ *
+ * @note This call can only be used as a response to a @ref BLE_EVT_USER_MEM_REQUEST event issued to the application.
+ *
+ * @param[in] conn_handle Connection handle.
+ * @param[in] p_block Pointer to a user memory block structure or NULL if memory is managed by the application.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTS_QUEUED_WRITE_PEER_CANCEL_MSC}
+ * @mmsc{@ref BLE_GATTS_QUEUED_WRITE_NOBUF_AUTH_MSC}
+ * @mmsc{@ref BLE_GATTS_QUEUED_WRITE_NOBUF_NOAUTH_MSC}
+ * @mmsc{@ref BLE_GATTS_QUEUED_WRITE_BUF_AUTH_MSC}
+ * @mmsc{@ref BLE_GATTS_QUEUED_WRITE_BUF_NOAUTH_MSC}
+ * @mmsc{@ref BLE_GATTS_QUEUED_WRITE_QUEUE_FULL_MSC}
+ * @endmscs
+ *
+ * @retval ::NRF_SUCCESS Successfully queued a response to the peer.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_BUSY The stack is busy, process pending events and retry.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_LENGTH Invalid user memory block length supplied.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid Connection state or no user memory request pending.
+ */
+SVCALL(SD_BLE_USER_MEM_REPLY, uint32_t, sd_ble_user_mem_reply(uint16_t conn_handle, ble_user_mem_block_t const *p_block));
+
+/**@brief Set a BLE option.
+ *
+ * @details This call allows the application to set the value of an option.
+ *
+ * @param[in] opt_id Option ID, see @ref BLE_COMMON_OPTS, @ref BLE_GAP_OPTS, and @ref BLE_GATTC_OPTS.
+ * @param[in] p_opt Pointer to a @ref ble_opt_t structure containing the option value.
+ *
+ * @retval ::NRF_SUCCESS  Option set successfully.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied, check parameter limits and constraints.
+ * @retval ::NRF_ERROR_INVALID_STATE Unable to set the parameter at this time.
+ * @retval ::NRF_ERROR_BUSY The BLE stack is busy or the previous procedure has not completed.
+ */
+SVCALL(SD_BLE_OPT_SET, uint32_t, sd_ble_opt_set(uint32_t opt_id, ble_opt_t const *p_opt));
+
+
+/**@brief Get a BLE option.
+ *
+ * @details This call allows the application to retrieve the value of an option.
+ *
+ * @param[in] opt_id Option ID, see @ref BLE_COMMON_OPTS and @ref BLE_GAP_OPTS.
+ * @param[out] p_opt Pointer to a ble_opt_t structure to be filled in.
+ *
+ * @retval ::NRF_SUCCESS  Option retrieved successfully.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied, check parameter limits and constraints.
+ * @retval ::NRF_ERROR_INVALID_STATE Unable to retrieve the parameter at this time.
+ * @retval ::NRF_ERROR_BUSY The BLE stack is busy or the previous procedure has not completed.
+ * @retval ::NRF_ERROR_NOT_SUPPORTED This option is not supported.
+ *
+ */
+SVCALL(SD_BLE_OPT_GET, uint32_t, sd_ble_opt_get(uint32_t opt_id, ble_opt_t *p_opt));
+
+/** @} */
+#ifdef __cplusplus
+}
+#endif
+#endif /* BLE_H__ */
+
+/**
+  @}
+  @}
+*/

--- a/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble_err.h
+++ b/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble_err.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+  @addtogroup BLE_COMMON
+  @{
+  @addtogroup  nrf_error
+  @{
+    @ingroup BLE_COMMON
+  @}
+
+  @defgroup ble_err General error codes
+  @{
+
+  @brief General error code definitions for the BLE API.
+
+  @ingroup BLE_COMMON
+*/
+#ifndef NRF_BLE_ERR_H__
+#define NRF_BLE_ERR_H__
+
+#include "nrf_error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* @defgroup BLE_ERRORS Error Codes
+ * @{ */
+#define BLE_ERROR_NOT_ENABLED            (NRF_ERROR_STK_BASE_NUM+0x001) /**< @ref sd_ble_enable has not been called. */
+#define BLE_ERROR_INVALID_CONN_HANDLE    (NRF_ERROR_STK_BASE_NUM+0x002) /**< Invalid connection handle. */
+#define BLE_ERROR_INVALID_ATTR_HANDLE    (NRF_ERROR_STK_BASE_NUM+0x003) /**< Invalid attribute handle. */
+#define BLE_ERROR_INVALID_ADV_HANDLE     (NRF_ERROR_STK_BASE_NUM+0x004) /**< Invalid advertising handle. */
+#define BLE_ERROR_INVALID_ROLE           (NRF_ERROR_STK_BASE_NUM+0x005) /**< Invalid role. */
+#define BLE_ERROR_BLOCKED_BY_OTHER_LINKS (NRF_ERROR_STK_BASE_NUM+0x006) /**< The attempt to change link settings failed due to the scheduling of other links. */
+/** @} */
+
+
+/** @defgroup BLE_ERROR_SUBRANGES Module specific error code subranges
+ *  @brief Assignment of subranges for module specific error codes.
+ *  @note For specific error codes, see ble_<module>.h or ble_error_<module>.h.
+ * @{ */
+#define NRF_L2CAP_ERR_BASE             (NRF_ERROR_STK_BASE_NUM+0x100) /**< L2CAP specific errors. */
+#define NRF_GAP_ERR_BASE               (NRF_ERROR_STK_BASE_NUM+0x200) /**< GAP specific errors. */
+#define NRF_GATTC_ERR_BASE             (NRF_ERROR_STK_BASE_NUM+0x300) /**< GATT client specific errors. */
+#define NRF_GATTS_ERR_BASE             (NRF_ERROR_STK_BASE_NUM+0x400) /**< GATT server specific errors. */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+
+
+/**
+  @}
+  @}
+*/

--- a/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble_gap.h
+++ b/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble_gap.h
@@ -1,0 +1,2867 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+  @addtogroup BLE_GAP Generic Access Profile (GAP)
+  @{
+  @brief Definitions and prototypes for the GAP interface.
+ */
+
+#ifndef BLE_GAP_H__
+#define BLE_GAP_H__
+
+#include <stdint.h>
+#include "nrf_svc.h"
+#include "nrf_error.h"
+#include "ble_hci.h"
+#include "ble_ranges.h"
+#include "ble_types.h"
+#include "ble_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**@addtogroup BLE_GAP_ENUMERATIONS Enumerations
+ * @{ */
+
+/**@brief GAP API SVC numbers.
+ */
+enum BLE_GAP_SVCS
+{
+  SD_BLE_GAP_ADDR_SET                   = BLE_GAP_SVC_BASE,       /**< Set own Bluetooth Address. */
+  SD_BLE_GAP_ADDR_GET                   = BLE_GAP_SVC_BASE + 1,   /**< Get own Bluetooth Address. */
+  SD_BLE_GAP_WHITELIST_SET              = BLE_GAP_SVC_BASE + 2,   /**< Set active whitelist. */
+  SD_BLE_GAP_DEVICE_IDENTITIES_SET      = BLE_GAP_SVC_BASE + 3,   /**< Set device identity list. */
+  SD_BLE_GAP_PRIVACY_SET                = BLE_GAP_SVC_BASE + 4,   /**< Set Privacy settings*/
+  SD_BLE_GAP_PRIVACY_GET                = BLE_GAP_SVC_BASE + 5,   /**< Get Privacy settings*/
+  SD_BLE_GAP_ADV_SET_CONFIGURE          = BLE_GAP_SVC_BASE + 6,   /**< Configure an advertising set. */
+  SD_BLE_GAP_ADV_START                  = BLE_GAP_SVC_BASE + 7,   /**< Start Advertising. */
+  SD_BLE_GAP_ADV_STOP                   = BLE_GAP_SVC_BASE + 8,   /**< Stop Advertising. */
+  SD_BLE_GAP_CONN_PARAM_UPDATE          = BLE_GAP_SVC_BASE + 9,   /**< Connection Parameter Update. */
+  SD_BLE_GAP_DISCONNECT                 = BLE_GAP_SVC_BASE + 10,  /**< Disconnect. */
+  SD_BLE_GAP_TX_POWER_SET               = BLE_GAP_SVC_BASE + 11,  /**< Set TX Power. */
+  SD_BLE_GAP_APPEARANCE_SET             = BLE_GAP_SVC_BASE + 12,  /**< Set Appearance. */
+  SD_BLE_GAP_APPEARANCE_GET             = BLE_GAP_SVC_BASE + 13,  /**< Get Appearance. */
+  SD_BLE_GAP_PPCP_SET                   = BLE_GAP_SVC_BASE + 14,  /**< Set PPCP. */
+  SD_BLE_GAP_PPCP_GET                   = BLE_GAP_SVC_BASE + 15,  /**< Get PPCP. */
+  SD_BLE_GAP_DEVICE_NAME_SET            = BLE_GAP_SVC_BASE + 16,  /**< Set Device Name. */
+  SD_BLE_GAP_DEVICE_NAME_GET            = BLE_GAP_SVC_BASE + 17,  /**< Get Device Name. */
+  SD_BLE_GAP_AUTHENTICATE               = BLE_GAP_SVC_BASE + 18,  /**< Initiate Pairing/Bonding. */
+  SD_BLE_GAP_SEC_PARAMS_REPLY           = BLE_GAP_SVC_BASE + 19,  /**< Reply with Security Parameters. */
+  SD_BLE_GAP_AUTH_KEY_REPLY             = BLE_GAP_SVC_BASE + 20,  /**< Reply with an authentication key. */
+  SD_BLE_GAP_LESC_DHKEY_REPLY           = BLE_GAP_SVC_BASE + 21,  /**< Reply with an LE Secure Connections DHKey. */
+  SD_BLE_GAP_KEYPRESS_NOTIFY            = BLE_GAP_SVC_BASE + 22,  /**< Notify of a keypress during an authentication procedure. */
+  SD_BLE_GAP_LESC_OOB_DATA_GET          = BLE_GAP_SVC_BASE + 23,  /**< Get the local LE Secure Connections OOB data. */
+  SD_BLE_GAP_LESC_OOB_DATA_SET          = BLE_GAP_SVC_BASE + 24,  /**< Set the remote LE Secure Connections OOB data. */
+  SD_BLE_GAP_ENCRYPT                    = BLE_GAP_SVC_BASE + 25,  /**< Initiate encryption procedure. */
+  SD_BLE_GAP_SEC_INFO_REPLY             = BLE_GAP_SVC_BASE + 26,  /**< Reply with Security Information. */
+  SD_BLE_GAP_CONN_SEC_GET               = BLE_GAP_SVC_BASE + 27,  /**< Obtain connection security level. */
+  SD_BLE_GAP_RSSI_START                 = BLE_GAP_SVC_BASE + 28,  /**< Start reporting of changes in RSSI. */
+  SD_BLE_GAP_RSSI_STOP                  = BLE_GAP_SVC_BASE + 29,  /**< Stop reporting of changes in RSSI. */
+  SD_BLE_GAP_SCAN_START                 = BLE_GAP_SVC_BASE + 30,  /**< Start Scanning. */
+  SD_BLE_GAP_SCAN_STOP                  = BLE_GAP_SVC_BASE + 31,  /**< Stop Scanning. */
+  SD_BLE_GAP_CONNECT                    = BLE_GAP_SVC_BASE + 32,  /**< Connect. */
+  SD_BLE_GAP_CONNECT_CANCEL             = BLE_GAP_SVC_BASE + 33,  /**< Cancel ongoing connection procedure. */
+  SD_BLE_GAP_RSSI_GET                   = BLE_GAP_SVC_BASE + 34,  /**< Get the last RSSI sample. */
+  SD_BLE_GAP_PHY_UPDATE                 = BLE_GAP_SVC_BASE + 35,  /**< Initiate or respond to a PHY Update Procedure. */
+  SD_BLE_GAP_DATA_LENGTH_UPDATE         = BLE_GAP_SVC_BASE + 36,  /**< Initiate or respond to a Data Length Update Procedure. */
+  SD_BLE_GAP_QOS_CHANNEL_SURVEY_START   = BLE_GAP_SVC_BASE + 37, /**< Start Quality of Service (QoS) channel survey module. */
+  SD_BLE_GAP_QOS_CHANNEL_SURVEY_STOP    = BLE_GAP_SVC_BASE + 38, /**< Stop Quality of Service (QoS) channel survey module. */
+  SD_BLE_GAP_ADV_ADDR_GET               = BLE_GAP_SVC_BASE + 39, /**< Get the Address used on air while Advertising. */
+  SD_BLE_GAP_NEXT_CONN_EVT_COUNTER_GET  = BLE_GAP_SVC_BASE + 40, /**< Get the next connection event counter. */
+  SD_BLE_GAP_CONN_EVT_TRIGGER_START     = BLE_GAP_SVC_BASE + 41, /** Start triggering a given task on connection event start. */
+  SD_BLE_GAP_CONN_EVT_TRIGGER_STOP      = BLE_GAP_SVC_BASE + 42, /** Stop triggering the task configured using @ref sd_ble_gap_conn_evt_trigger_start. */
+};
+
+/**@brief GAP Event IDs.
+ * IDs that uniquely identify an event coming from the stack to the application.
+ */
+enum BLE_GAP_EVTS
+{
+  BLE_GAP_EVT_CONNECTED                   = BLE_GAP_EVT_BASE,       /**< Connected to peer.                              \n See @ref ble_gap_evt_connected_t             */
+  BLE_GAP_EVT_DISCONNECTED                = BLE_GAP_EVT_BASE + 1,   /**< Disconnected from peer.                         \n See @ref ble_gap_evt_disconnected_t.         */
+  BLE_GAP_EVT_CONN_PARAM_UPDATE           = BLE_GAP_EVT_BASE + 2,   /**< Connection Parameters updated.                  \n See @ref ble_gap_evt_conn_param_update_t.    */
+  BLE_GAP_EVT_SEC_PARAMS_REQUEST          = BLE_GAP_EVT_BASE + 3,   /**< Request to provide security parameters.         \n Reply with @ref sd_ble_gap_sec_params_reply.  \n See @ref ble_gap_evt_sec_params_request_t. */
+  BLE_GAP_EVT_SEC_INFO_REQUEST            = BLE_GAP_EVT_BASE + 4,   /**< Request to provide security information.        \n Reply with @ref sd_ble_gap_sec_info_reply.    \n See @ref ble_gap_evt_sec_info_request_t.   */
+  BLE_GAP_EVT_PASSKEY_DISPLAY             = BLE_GAP_EVT_BASE + 5,   /**< Request to display a passkey to the user.       \n In LESC Numeric Comparison, reply with @ref sd_ble_gap_auth_key_reply. \n See @ref ble_gap_evt_passkey_display_t. */
+  BLE_GAP_EVT_KEY_PRESSED                 = BLE_GAP_EVT_BASE + 6,   /**< Notification of a keypress on the remote device.\n See @ref ble_gap_evt_key_pressed_t           */
+  BLE_GAP_EVT_AUTH_KEY_REQUEST            = BLE_GAP_EVT_BASE + 7,   /**< Request to provide an authentication key.       \n Reply with @ref sd_ble_gap_auth_key_reply.    \n See @ref ble_gap_evt_auth_key_request_t.   */
+  BLE_GAP_EVT_LESC_DHKEY_REQUEST          = BLE_GAP_EVT_BASE + 8,   /**< Request to calculate an LE Secure Connections DHKey. \n Reply with @ref sd_ble_gap_lesc_dhkey_reply.  \n See @ref ble_gap_evt_lesc_dhkey_request_t */
+  BLE_GAP_EVT_AUTH_STATUS                 = BLE_GAP_EVT_BASE + 9,   /**< Authentication procedure completed with status. \n See @ref ble_gap_evt_auth_status_t.          */
+  BLE_GAP_EVT_CONN_SEC_UPDATE             = BLE_GAP_EVT_BASE + 10,  /**< Connection security updated.                    \n See @ref ble_gap_evt_conn_sec_update_t.      */
+  BLE_GAP_EVT_TIMEOUT                     = BLE_GAP_EVT_BASE + 11,  /**< Timeout expired.                                \n See @ref ble_gap_evt_timeout_t.              */
+  BLE_GAP_EVT_RSSI_CHANGED                = BLE_GAP_EVT_BASE + 12,  /**< RSSI report.                                    \n See @ref ble_gap_evt_rssi_changed_t.         */
+  BLE_GAP_EVT_ADV_REPORT                  = BLE_GAP_EVT_BASE + 13,  /**< Advertising report.                             \n See @ref ble_gap_evt_adv_report_t.           */
+  BLE_GAP_EVT_SEC_REQUEST                 = BLE_GAP_EVT_BASE + 14,  /**< Security Request.                               \n Reply with @ref sd_ble_gap_authenticate
+  \n or with @ref sd_ble_gap_encrypt if required security information is available
+. \n See @ref ble_gap_evt_sec_request_t.          */
+  BLE_GAP_EVT_CONN_PARAM_UPDATE_REQUEST   = BLE_GAP_EVT_BASE + 15,  /**< Connection Parameter Update Request.            \n Reply with @ref sd_ble_gap_conn_param_update. \n See @ref ble_gap_evt_conn_param_update_request_t. */
+  BLE_GAP_EVT_SCAN_REQ_REPORT             = BLE_GAP_EVT_BASE + 16,  /**< Scan request report.                            \n See @ref ble_gap_evt_scan_req_report_t. */
+  BLE_GAP_EVT_PHY_UPDATE_REQUEST          = BLE_GAP_EVT_BASE + 17,  /**< PHY Update Request.                             \n Reply with @ref sd_ble_gap_phy_update. \n See @ref ble_gap_evt_phy_update_request_t. */
+  BLE_GAP_EVT_PHY_UPDATE                  = BLE_GAP_EVT_BASE + 18,  /**< PHY Update Procedure is complete.               \n See @ref ble_gap_evt_phy_update_t.           */
+  BLE_GAP_EVT_DATA_LENGTH_UPDATE_REQUEST = BLE_GAP_EVT_BASE + 19,   /**< Data Length Update Request.                     \n Reply with @ref sd_ble_gap_data_length_update. \n See @ref ble_gap_evt_data_length_update_request_t. */
+  BLE_GAP_EVT_DATA_LENGTH_UPDATE         = BLE_GAP_EVT_BASE + 20,   /**< LL Data Channel PDU payload length updated.     \n See @ref ble_gap_evt_data_length_update_t. */
+  BLE_GAP_EVT_QOS_CHANNEL_SURVEY_REPORT  = BLE_GAP_EVT_BASE + 21,   /**< Channel survey report.                          \n See @ref ble_gap_evt_qos_channel_survey_report_t. */
+  BLE_GAP_EVT_ADV_SET_TERMINATED         = BLE_GAP_EVT_BASE + 22,   /**< Advertising set terminated.                     \n See @ref ble_gap_evt_adv_set_terminated_t. */
+};
+
+/**@brief GAP Option IDs.
+ * IDs that uniquely identify a GAP option.
+ */
+enum BLE_GAP_OPTS
+{
+  BLE_GAP_OPT_CH_MAP                 = BLE_GAP_OPT_BASE,       /**< Channel Map. @ref ble_gap_opt_ch_map_t  */
+  BLE_GAP_OPT_LOCAL_CONN_LATENCY     = BLE_GAP_OPT_BASE + 1,   /**< Local connection latency. @ref ble_gap_opt_local_conn_latency_t */
+  BLE_GAP_OPT_PASSKEY                = BLE_GAP_OPT_BASE + 2,   /**< Set passkey. @ref ble_gap_opt_passkey_t */
+  BLE_GAP_OPT_COMPAT_MODE_1          = BLE_GAP_OPT_BASE + 3,   /**< Compatibility mode. @ref ble_gap_opt_compat_mode_1_t */
+  BLE_GAP_OPT_AUTH_PAYLOAD_TIMEOUT   = BLE_GAP_OPT_BASE + 4,   /**< Set Authenticated payload timeout. @ref ble_gap_opt_auth_payload_timeout_t */
+  BLE_GAP_OPT_SLAVE_LATENCY_DISABLE  = BLE_GAP_OPT_BASE + 5,   /**< Disable slave latency. @ref ble_gap_opt_slave_latency_disable_t */
+};
+
+/**@brief GAP Configuration IDs.
+ *
+ * IDs that uniquely identify a GAP configuration.
+ */
+enum BLE_GAP_CFGS
+{
+  BLE_GAP_CFG_ROLE_COUNT       = BLE_GAP_CFG_BASE,     /**< Role count configuration.  */
+  BLE_GAP_CFG_DEVICE_NAME      = BLE_GAP_CFG_BASE + 1, /**< Device name configuration. */
+  BLE_GAP_CFG_PPCP_INCL_CONFIG = BLE_GAP_CFG_BASE + 2, /**< Peripheral Preferred Connection Parameters characteristic
+                                                            inclusion configuration. */
+  BLE_GAP_CFG_CAR_INCL_CONFIG  = BLE_GAP_CFG_BASE + 3, /**< Central Address Resolution characteristic
+                                                            inclusion configuration. */
+};
+
+/**@brief GAP TX Power roles.
+ */
+enum BLE_GAP_TX_POWER_ROLES
+{
+  BLE_GAP_TX_POWER_ROLE_ADV       = 1,           /**< Advertiser role. */
+  BLE_GAP_TX_POWER_ROLE_SCAN_INIT = 2,           /**< Scanner and initiator role. */
+  BLE_GAP_TX_POWER_ROLE_CONN      = 3,           /**< Connection role. */
+};
+
+/** @} */
+
+/**@addtogroup BLE_GAP_DEFINES Defines
+ * @{ */
+
+/**@defgroup BLE_ERRORS_GAP SVC return values specific to GAP
+ * @{ */
+#define BLE_ERROR_GAP_UUID_LIST_MISMATCH            (NRF_GAP_ERR_BASE + 0x000)  /**< UUID list does not contain an integral number of UUIDs. */
+#define BLE_ERROR_GAP_DISCOVERABLE_WITH_WHITELIST   (NRF_GAP_ERR_BASE + 0x001)  /**< Use of Whitelist not permitted with discoverable advertising. */
+#define BLE_ERROR_GAP_INVALID_BLE_ADDR              (NRF_GAP_ERR_BASE + 0x002)  /**< The upper two bits of the address do not correspond to the specified address type. */
+#define BLE_ERROR_GAP_WHITELIST_IN_USE              (NRF_GAP_ERR_BASE + 0x003)  /**< Attempt to modify the whitelist while already in use by another operation. */
+#define BLE_ERROR_GAP_DEVICE_IDENTITIES_IN_USE      (NRF_GAP_ERR_BASE + 0x004)  /**< Attempt to modify the device identity list while already in use by another operation. */
+#define BLE_ERROR_GAP_DEVICE_IDENTITIES_DUPLICATE   (NRF_GAP_ERR_BASE + 0x005)  /**< The device identity list contains entries with duplicate identity addresses. */
+/**@} */
+
+
+/**@defgroup BLE_GAP_ROLES GAP Roles
+ * @{ */
+#define BLE_GAP_ROLE_INVALID     0x0            /**< Invalid Role. */
+#define BLE_GAP_ROLE_PERIPH      0x1            /**< Peripheral Role. */
+#define BLE_GAP_ROLE_CENTRAL     0x2            /**< Central Role. */
+/**@} */
+
+
+/**@defgroup BLE_GAP_TIMEOUT_SOURCES GAP Timeout sources
+ * @{ */
+#define BLE_GAP_TIMEOUT_SRC_SCAN                       0x01 /**< Scanning timeout. */
+#define BLE_GAP_TIMEOUT_SRC_CONN                       0x02 /**< Connection timeout. */
+#define BLE_GAP_TIMEOUT_SRC_AUTH_PAYLOAD               0x03 /**< Authenticated payload timeout. */
+/**@} */
+
+
+/**@defgroup BLE_GAP_ADDR_TYPES GAP Address types
+ * @{ */
+#define BLE_GAP_ADDR_TYPE_PUBLIC                        0x00 /**< Public (identity) address.*/
+#define BLE_GAP_ADDR_TYPE_RANDOM_STATIC                 0x01 /**< Random static (identity) address. */
+#define BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE     0x02 /**< Random private resolvable address. */
+#define BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_NON_RESOLVABLE 0x03 /**< Random private non-resolvable address. */
+#define BLE_GAP_ADDR_TYPE_ANONYMOUS                     0x7F /**< An advertiser may advertise without its address.
+                                                                  This type of advertising is called anonymous. */
+/**@} */
+
+
+/**@brief The default interval in seconds at which a private address is refreshed.  */
+#define BLE_GAP_DEFAULT_PRIVATE_ADDR_CYCLE_INTERVAL_S (900) /* 15 minutes. */
+/**@brief The maximum interval in seconds at which a private address can be refreshed.  */
+#define BLE_GAP_MAX_PRIVATE_ADDR_CYCLE_INTERVAL_S     (41400) /* 11 hours 30 minutes. */
+
+
+/** @brief BLE address length. */
+#define BLE_GAP_ADDR_LEN (6)
+
+/**@defgroup BLE_GAP_PRIVACY_MODES Privacy modes
+ * @{ */
+#define BLE_GAP_PRIVACY_MODE_OFF                       0x00 /**< Device will send and accept its identity address for its own address. */
+#define BLE_GAP_PRIVACY_MODE_DEVICE_PRIVACY            0x01 /**< Device will send and accept only private addresses for its own address. */
+#define BLE_GAP_PRIVACY_MODE_NETWORK_PRIVACY           0x02 /**< Device will send and accept only private addresses for its own address,
+                                                                 and will not accept a peer using identity address as sender address when
+                                                                 the peer IRK is exchanged, non-zero and added to the identity list. */
+/**@} */
+
+/** @brief Invalid power level. */
+#define BLE_GAP_POWER_LEVEL_INVALID     127
+
+/** @brief Advertising set handle not set. */
+#define BLE_GAP_ADV_SET_HANDLE_NOT_SET (0xFF)
+
+/** @brief The default number of advertising sets. */
+#define BLE_GAP_ADV_SET_COUNT_DEFAULT   (1)
+
+/** @brief The maximum number of advertising sets supported by this SoftDevice. */
+#define BLE_GAP_ADV_SET_COUNT_MAX       (1)
+
+/**@defgroup BLE_GAP_ADV_SET_DATA_SIZES Advertising data sizes.
+ * @{ */
+#define BLE_GAP_ADV_SET_DATA_SIZE_MAX                    (31)   /**< Maximum data length for an advertising set.
+                                                                     If more advertising data is required, use extended advertising instead. */
+#define BLE_GAP_ADV_SET_DATA_SIZE_EXTENDED_MAX_SUPPORTED (255)  /**< Maximum supported data length for an extended advertising set. */
+
+#define BLE_GAP_ADV_SET_DATA_SIZE_EXTENDED_CONNECTABLE_MAX_SUPPORTED (238) /**< Maximum supported data length for an extended connectable advertising set. */
+/**@}. */
+
+/** @brief Set ID not available in advertising report. */
+#define BLE_GAP_ADV_REPORT_SET_ID_NOT_AVAILABLE                    0xFF
+
+/**@defgroup BLE_GAP_EVT_ADV_SET_TERMINATED_REASON GAP Advertising Set Terminated reasons
+ * @{ */
+#define BLE_GAP_EVT_ADV_SET_TERMINATED_REASON_TIMEOUT              0x01  /**< Timeout value reached. */
+#define BLE_GAP_EVT_ADV_SET_TERMINATED_REASON_LIMIT_REACHED        0x02  /**< @ref ble_gap_adv_params_t::max_adv_evts was reached. */
+/**@} */
+
+/**@defgroup BLE_GAP_AD_TYPE_DEFINITIONS GAP Advertising and Scan Response Data format
+ * @note Found at https://www.bluetooth.org/Technical/AssignedNumbers/generic_access_profile.htm
+ * @{ */
+#define BLE_GAP_AD_TYPE_FLAGS                               0x01 /**< Flags for discoverability. */
+#define BLE_GAP_AD_TYPE_16BIT_SERVICE_UUID_MORE_AVAILABLE   0x02 /**< Partial list of 16 bit service UUIDs. */
+#define BLE_GAP_AD_TYPE_16BIT_SERVICE_UUID_COMPLETE         0x03 /**< Complete list of 16 bit service UUIDs. */
+#define BLE_GAP_AD_TYPE_32BIT_SERVICE_UUID_MORE_AVAILABLE   0x04 /**< Partial list of 32 bit service UUIDs. */
+#define BLE_GAP_AD_TYPE_32BIT_SERVICE_UUID_COMPLETE         0x05 /**< Complete list of 32 bit service UUIDs. */
+#define BLE_GAP_AD_TYPE_128BIT_SERVICE_UUID_MORE_AVAILABLE  0x06 /**< Partial list of 128 bit service UUIDs. */
+#define BLE_GAP_AD_TYPE_128BIT_SERVICE_UUID_COMPLETE        0x07 /**< Complete list of 128 bit service UUIDs. */
+#define BLE_GAP_AD_TYPE_SHORT_LOCAL_NAME                    0x08 /**< Short local device name. */
+#define BLE_GAP_AD_TYPE_COMPLETE_LOCAL_NAME                 0x09 /**< Complete local device name. */
+#define BLE_GAP_AD_TYPE_TX_POWER_LEVEL                      0x0A /**< Transmit power level. */
+#define BLE_GAP_AD_TYPE_CLASS_OF_DEVICE                     0x0D /**< Class of device. */
+#define BLE_GAP_AD_TYPE_SIMPLE_PAIRING_HASH_C               0x0E /**< Simple Pairing Hash C. */
+#define BLE_GAP_AD_TYPE_SIMPLE_PAIRING_RANDOMIZER_R         0x0F /**< Simple Pairing Randomizer R. */
+#define BLE_GAP_AD_TYPE_SECURITY_MANAGER_TK_VALUE           0x10 /**< Security Manager TK Value. */
+#define BLE_GAP_AD_TYPE_SECURITY_MANAGER_OOB_FLAGS          0x11 /**< Security Manager Out Of Band Flags. */
+#define BLE_GAP_AD_TYPE_SLAVE_CONNECTION_INTERVAL_RANGE     0x12 /**< Slave Connection Interval Range. */
+#define BLE_GAP_AD_TYPE_SOLICITED_SERVICE_UUIDS_16BIT       0x14 /**< List of 16-bit Service Solicitation UUIDs. */
+#define BLE_GAP_AD_TYPE_SOLICITED_SERVICE_UUIDS_128BIT      0x15 /**< List of 128-bit Service Solicitation UUIDs. */
+#define BLE_GAP_AD_TYPE_SERVICE_DATA                        0x16 /**< Service Data - 16-bit UUID. */
+#define BLE_GAP_AD_TYPE_PUBLIC_TARGET_ADDRESS               0x17 /**< Public Target Address. */
+#define BLE_GAP_AD_TYPE_RANDOM_TARGET_ADDRESS               0x18 /**< Random Target Address. */
+#define BLE_GAP_AD_TYPE_APPEARANCE                          0x19 /**< Appearance. */
+#define BLE_GAP_AD_TYPE_ADVERTISING_INTERVAL                0x1A /**< Advertising Interval. */
+#define BLE_GAP_AD_TYPE_LE_BLUETOOTH_DEVICE_ADDRESS         0x1B /**< LE Bluetooth Device Address. */
+#define BLE_GAP_AD_TYPE_LE_ROLE                             0x1C /**< LE Role. */
+#define BLE_GAP_AD_TYPE_SIMPLE_PAIRING_HASH_C256            0x1D /**< Simple Pairing Hash C-256. */
+#define BLE_GAP_AD_TYPE_SIMPLE_PAIRING_RANDOMIZER_R256      0x1E /**< Simple Pairing Randomizer R-256. */
+#define BLE_GAP_AD_TYPE_SERVICE_DATA_32BIT_UUID             0x20 /**< Service Data - 32-bit UUID. */
+#define BLE_GAP_AD_TYPE_SERVICE_DATA_128BIT_UUID            0x21 /**< Service Data - 128-bit UUID. */
+#define BLE_GAP_AD_TYPE_LESC_CONFIRMATION_VALUE             0x22 /**< LE Secure Connections Confirmation Value */
+#define BLE_GAP_AD_TYPE_LESC_RANDOM_VALUE                   0x23 /**< LE Secure Connections Random Value */
+#define BLE_GAP_AD_TYPE_URI                                 0x24 /**< URI */
+#define BLE_GAP_AD_TYPE_3D_INFORMATION_DATA                 0x3D /**< 3D Information Data. */
+#define BLE_GAP_AD_TYPE_MANUFACTURER_SPECIFIC_DATA          0xFF /**< Manufacturer Specific Data. */
+/**@} */
+
+
+/**@defgroup BLE_GAP_ADV_FLAGS GAP Advertisement Flags
+ * @{ */
+#define BLE_GAP_ADV_FLAG_LE_LIMITED_DISC_MODE         (0x01)   /**< LE Limited Discoverable Mode. */
+#define BLE_GAP_ADV_FLAG_LE_GENERAL_DISC_MODE         (0x02)   /**< LE General Discoverable Mode. */
+#define BLE_GAP_ADV_FLAG_BR_EDR_NOT_SUPPORTED         (0x04)   /**< BR/EDR not supported. */
+#define BLE_GAP_ADV_FLAG_LE_BR_EDR_CONTROLLER         (0x08)   /**< Simultaneous LE and BR/EDR, Controller. */
+#define BLE_GAP_ADV_FLAG_LE_BR_EDR_HOST               (0x10)   /**< Simultaneous LE and BR/EDR, Host. */
+#define BLE_GAP_ADV_FLAGS_LE_ONLY_LIMITED_DISC_MODE   (BLE_GAP_ADV_FLAG_LE_LIMITED_DISC_MODE | BLE_GAP_ADV_FLAG_BR_EDR_NOT_SUPPORTED)   /**< LE Limited Discoverable Mode, BR/EDR not supported. */
+#define BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE   (BLE_GAP_ADV_FLAG_LE_GENERAL_DISC_MODE | BLE_GAP_ADV_FLAG_BR_EDR_NOT_SUPPORTED)   /**< LE General Discoverable Mode, BR/EDR not supported. */
+/**@} */
+
+
+/**@defgroup BLE_GAP_ADV_INTERVALS GAP Advertising interval max and min
+ * @{ */
+#define BLE_GAP_ADV_INTERVAL_MIN        0x000020 /**< Minimum Advertising interval in 625 us units, i.e. 20 ms. */
+#define BLE_GAP_ADV_INTERVAL_MAX        0x004000 /**< Maximum Advertising interval in 625 us units, i.e. 10.24 s. */
+ /**@}  */
+
+
+/**@defgroup BLE_GAP_SCAN_INTERVALS GAP Scan interval max and min
+ * @{ */
+#define BLE_GAP_SCAN_INTERVAL_MIN       0x0004 /**< Minimum Scan interval in 625 us units, i.e. 2.5 ms. */
+#define BLE_GAP_SCAN_INTERVAL_MAX       0xFFFF /**< Maximum Scan interval in 625 us units, i.e. 40,959.375 s. */
+ /** @}  */
+
+
+/**@defgroup BLE_GAP_SCAN_WINDOW GAP Scan window max and min
+ * @{ */
+#define BLE_GAP_SCAN_WINDOW_MIN         0x0004 /**< Minimum Scan window in 625 us units, i.e. 2.5 ms. */
+#define BLE_GAP_SCAN_WINDOW_MAX         0xFFFF /**< Maximum Scan window in 625 us units, i.e. 40,959.375 s. */
+ /** @}  */
+
+
+/**@defgroup BLE_GAP_SCAN_TIMEOUT GAP Scan timeout max and min
+ * @{ */
+#define BLE_GAP_SCAN_TIMEOUT_MIN        0x0001 /**< Minimum Scan timeout in 10 ms units, i.e 10 ms. */
+#define BLE_GAP_SCAN_TIMEOUT_UNLIMITED  0x0000 /**< Continue to scan forever. */
+ /** @}  */
+
+/**@defgroup BLE_GAP_SCAN_BUFFER_SIZE GAP Minimum scanner buffer size
+ *
+ * Scan buffers are used for storing advertising data received from an advertiser.
+ * If ble_gap_scan_params_t::extended is set to 0, @ref BLE_GAP_SCAN_BUFFER_MIN is the minimum scan buffer length.
+ * else the minimum scan buffer size is @ref BLE_GAP_SCAN_BUFFER_EXTENDED_MIN.
+ * @{ */
+#define BLE_GAP_SCAN_BUFFER_MIN                    (31)                             /**< Minimum data length for an
+                                                                                         advertising set. */
+#define BLE_GAP_SCAN_BUFFER_MAX                    (31)                             /**< Maximum data length for an
+                                                                                         advertising set. */
+#define BLE_GAP_SCAN_BUFFER_EXTENDED_MIN           (255)                            /**< Minimum data length for an
+                                                                                         extended advertising set. */
+#define BLE_GAP_SCAN_BUFFER_EXTENDED_MAX           (1650)                           /**< Maximum data length for an
+                                                                                         extended advertising set. */
+#define BLE_GAP_SCAN_BUFFER_EXTENDED_MAX_SUPPORTED (255)                            /**< Maximum supported data length for
+                                                                                         an extended advertising set. */
+/** @}  */
+
+/**@defgroup BLE_GAP_ADV_TYPES GAP Advertising types
+ *
+ * Advertising types defined in Bluetooth Core Specification v5.0, Vol 6, Part B, Section 4.4.2.
+ *
+ * The maximum advertising data length is defined by @ref BLE_GAP_ADV_SET_DATA_SIZE_MAX.
+ * The maximum supported data length for an extended advertiser is defined by
+ * @ref BLE_GAP_ADV_SET_DATA_SIZE_EXTENDED_MAX_SUPPORTED
+ * Note that some of the advertising types do not support advertising data. Non-scannable types do not support
+ * scan response data.
+ *
+ * @{ */
+#define BLE_GAP_ADV_TYPE_CONNECTABLE_SCANNABLE_UNDIRECTED                   0x01   /**< Connectable and scannable undirected
+                                                                                        advertising events. */
+#define BLE_GAP_ADV_TYPE_CONNECTABLE_NONSCANNABLE_DIRECTED_HIGH_DUTY_CYCLE  0x02   /**< Connectable non-scannable directed advertising
+                                                                                        events. Advertising interval is less that 3.75 ms.
+                                                                                        Use this type for fast reconnections.
+                                                                                        @note Advertising data is not supported. */
+#define BLE_GAP_ADV_TYPE_CONNECTABLE_NONSCANNABLE_DIRECTED                  0x03   /**< Connectable non-scannable directed advertising
+                                                                                        events.
+                                                                                        @note Advertising data is not supported. */
+#define BLE_GAP_ADV_TYPE_NONCONNECTABLE_SCANNABLE_UNDIRECTED                0x04   /**< Non-connectable scannable undirected
+                                                                                        advertising events. */
+#define BLE_GAP_ADV_TYPE_NONCONNECTABLE_NONSCANNABLE_UNDIRECTED             0x05   /**< Non-connectable non-scannable undirected
+                                                                                        advertising events. */
+#define BLE_GAP_ADV_TYPE_EXTENDED_CONNECTABLE_NONSCANNABLE_UNDIRECTED       0x06   /**< Connectable non-scannable undirected advertising
+                                                                                        events using extended advertising PDUs. */
+#define BLE_GAP_ADV_TYPE_EXTENDED_CONNECTABLE_NONSCANNABLE_DIRECTED         0x07   /**< Connectable non-scannable directed advertising
+                                                                                        events using extended advertising PDUs. */
+#define BLE_GAP_ADV_TYPE_EXTENDED_NONCONNECTABLE_SCANNABLE_UNDIRECTED       0x08   /**< Non-connectable scannable undirected advertising
+                                                                                        events using extended advertising PDUs.
+                                                                                        @note Only scan response data is supported. */
+#define BLE_GAP_ADV_TYPE_EXTENDED_NONCONNECTABLE_SCANNABLE_DIRECTED         0x09   /**< Non-connectable scannable directed advertising
+                                                                                        events using extended advertising PDUs.
+                                                                                        @note Only scan response data is supported. */
+#define BLE_GAP_ADV_TYPE_EXTENDED_NONCONNECTABLE_NONSCANNABLE_UNDIRECTED    0x0A   /**< Non-connectable non-scannable undirected advertising
+                                                                                        events using extended advertising PDUs. */
+#define BLE_GAP_ADV_TYPE_EXTENDED_NONCONNECTABLE_NONSCANNABLE_DIRECTED      0x0B   /**< Non-connectable non-scannable directed advertising
+                                                                                        events using extended advertising PDUs. */
+/**@} */
+
+/**@defgroup BLE_GAP_ADV_FILTER_POLICIES GAP Advertising filter policies
+ * @{ */
+#define BLE_GAP_ADV_FP_ANY                0x00   /**< Allow scan requests and connect requests from any device. */
+#define BLE_GAP_ADV_FP_FILTER_SCANREQ     0x01   /**< Filter scan requests with whitelist. */
+#define BLE_GAP_ADV_FP_FILTER_CONNREQ     0x02   /**< Filter connect requests with whitelist. */
+#define BLE_GAP_ADV_FP_FILTER_BOTH        0x03   /**< Filter both scan and connect requests with whitelist. */
+/**@} */
+
+/**@defgroup BLE_GAP_ADV_DATA_STATUS GAP Advertising data status
+ * @{ */
+#define BLE_GAP_ADV_DATA_STATUS_COMPLETE             0x00 /**< All data in the advertising event have been received. */
+#define BLE_GAP_ADV_DATA_STATUS_INCOMPLETE_MORE_DATA 0x01 /**< More data to be received.
+                                                               @note This value will only be used if
+                                                               @ref ble_gap_scan_params_t::report_incomplete_evts and
+                                                               @ref ble_gap_adv_report_type_t::extended_pdu are set to true. */
+#define BLE_GAP_ADV_DATA_STATUS_INCOMPLETE_TRUNCATED 0x02 /**< Incomplete data. Buffer size insufficient to receive more.
+                                                               @note This value will only be used if
+                                                               @ref ble_gap_adv_report_type_t::extended_pdu is set to true. */
+#define BLE_GAP_ADV_DATA_STATUS_INCOMPLETE_MISSED    0x03 /**< Failed to receive the remaining data.
+                                                               @note This value will only be used if
+                                                               @ref ble_gap_adv_report_type_t::extended_pdu is set to true. */
+/**@} */
+
+/**@defgroup BLE_GAP_SCAN_FILTER_POLICIES GAP Scanner filter policies
+ * @{ */
+#define BLE_GAP_SCAN_FP_ACCEPT_ALL                      0x00  /**< Accept all advertising packets except directed advertising packets
+                                                                   not addressed to this device. */
+#define BLE_GAP_SCAN_FP_WHITELIST                       0x01  /**< Accept advertising packets from devices in the whitelist except directed
+                                                                   packets not addressed to this device. */
+#define BLE_GAP_SCAN_FP_ALL_NOT_RESOLVED_DIRECTED       0x02  /**< Accept all advertising packets specified in @ref BLE_GAP_SCAN_FP_ACCEPT_ALL.
+                                                                   In addition, accept directed advertising packets, where the advertiser's
+                                                                   address is a resolvable private address that cannot be resolved. */
+#define BLE_GAP_SCAN_FP_WHITELIST_NOT_RESOLVED_DIRECTED 0x03  /**< Accept all advertising packets specified in @ref BLE_GAP_SCAN_FP_WHITELIST.
+                                                                   In addition, accept directed advertising packets, where the advertiser's
+                                                                   address is a resolvable private address that cannot be resolved. */
+/**@} */
+
+/**@defgroup BLE_GAP_ADV_TIMEOUT_VALUES GAP Advertising timeout values in 10 ms units
+ * @{ */
+#define BLE_GAP_ADV_TIMEOUT_HIGH_DUTY_MAX     (128)   /**< Maximum high duty advertising time in 10 ms units. Corresponds to 1.28 s. */
+#define BLE_GAP_ADV_TIMEOUT_LIMITED_MAX       (18000) /**< Maximum advertising time in 10 ms units corresponding to TGAP(lim_adv_timeout) = 180 s in limited discoverable mode. */
+#define BLE_GAP_ADV_TIMEOUT_GENERAL_UNLIMITED (0)     /**< Unlimited advertising in general discoverable mode.
+                                                           For high duty cycle advertising, this corresponds to @ref BLE_GAP_ADV_TIMEOUT_HIGH_DUTY_MAX. */
+/**@} */
+
+
+/**@defgroup BLE_GAP_DISC_MODES GAP Discovery modes
+ * @{ */
+#define BLE_GAP_DISC_MODE_NOT_DISCOVERABLE  0x00   /**< Not discoverable discovery Mode. */
+#define BLE_GAP_DISC_MODE_LIMITED           0x01   /**< Limited Discovery Mode. */
+#define BLE_GAP_DISC_MODE_GENERAL           0x02   /**< General Discovery Mode. */
+/**@} */
+
+
+/**@defgroup BLE_GAP_IO_CAPS GAP IO Capabilities
+ * @{ */
+#define BLE_GAP_IO_CAPS_DISPLAY_ONLY      0x00   /**< Display Only. */
+#define BLE_GAP_IO_CAPS_DISPLAY_YESNO     0x01   /**< Display and Yes/No entry. */
+#define BLE_GAP_IO_CAPS_KEYBOARD_ONLY     0x02   /**< Keyboard Only. */
+#define BLE_GAP_IO_CAPS_NONE              0x03   /**< No I/O capabilities. */
+#define BLE_GAP_IO_CAPS_KEYBOARD_DISPLAY  0x04   /**< Keyboard and Display. */
+/**@} */
+
+
+/**@defgroup BLE_GAP_AUTH_KEY_TYPES GAP Authentication Key Types
+ * @{ */
+#define BLE_GAP_AUTH_KEY_TYPE_NONE        0x00   /**< No key (may be used to reject). */
+#define BLE_GAP_AUTH_KEY_TYPE_PASSKEY     0x01   /**< 6-digit Passkey. */
+#define BLE_GAP_AUTH_KEY_TYPE_OOB         0x02   /**< Out Of Band data. */
+/**@} */
+
+
+/**@defgroup BLE_GAP_KP_NOT_TYPES GAP Keypress Notification Types
+ * @{ */
+#define BLE_GAP_KP_NOT_TYPE_PASSKEY_START       0x00   /**< Passkey entry started. */
+#define BLE_GAP_KP_NOT_TYPE_PASSKEY_DIGIT_IN    0x01   /**< Passkey digit entered. */
+#define BLE_GAP_KP_NOT_TYPE_PASSKEY_DIGIT_OUT   0x02   /**< Passkey digit erased. */
+#define BLE_GAP_KP_NOT_TYPE_PASSKEY_CLEAR       0x03   /**< Passkey cleared. */
+#define BLE_GAP_KP_NOT_TYPE_PASSKEY_END         0x04   /**< Passkey entry completed. */
+/**@} */
+
+
+/**@defgroup BLE_GAP_SEC_STATUS GAP Security status
+ * @{ */
+#define BLE_GAP_SEC_STATUS_SUCCESS                0x00  /**< Procedure completed with success. */
+#define BLE_GAP_SEC_STATUS_TIMEOUT                0x01  /**< Procedure timed out. */
+#define BLE_GAP_SEC_STATUS_PDU_INVALID            0x02  /**< Invalid PDU received. */
+#define BLE_GAP_SEC_STATUS_RFU_RANGE1_BEGIN       0x03  /**< Reserved for Future Use range #1 begin. */
+#define BLE_GAP_SEC_STATUS_RFU_RANGE1_END         0x80  /**< Reserved for Future Use range #1 end. */
+#define BLE_GAP_SEC_STATUS_PASSKEY_ENTRY_FAILED   0x81  /**< Passkey entry failed (user canceled or other). */
+#define BLE_GAP_SEC_STATUS_OOB_NOT_AVAILABLE      0x82  /**< Out of Band Key not available. */
+#define BLE_GAP_SEC_STATUS_AUTH_REQ               0x83  /**< Authentication requirements not met. */
+#define BLE_GAP_SEC_STATUS_CONFIRM_VALUE          0x84  /**< Confirm value failed. */
+#define BLE_GAP_SEC_STATUS_PAIRING_NOT_SUPP       0x85  /**< Pairing not supported.  */
+#define BLE_GAP_SEC_STATUS_ENC_KEY_SIZE           0x86  /**< Encryption key size. */
+#define BLE_GAP_SEC_STATUS_SMP_CMD_UNSUPPORTED    0x87  /**< Unsupported SMP command. */
+#define BLE_GAP_SEC_STATUS_UNSPECIFIED            0x88  /**< Unspecified reason. */
+#define BLE_GAP_SEC_STATUS_REPEATED_ATTEMPTS      0x89  /**< Too little time elapsed since last attempt. */
+#define BLE_GAP_SEC_STATUS_INVALID_PARAMS         0x8A  /**< Invalid parameters. */
+#define BLE_GAP_SEC_STATUS_DHKEY_FAILURE          0x8B  /**< DHKey check failure. */
+#define BLE_GAP_SEC_STATUS_NUM_COMP_FAILURE       0x8C  /**< Numeric Comparison failure. */
+#define BLE_GAP_SEC_STATUS_BR_EDR_IN_PROG         0x8D  /**< BR/EDR pairing in progress. */
+#define BLE_GAP_SEC_STATUS_X_TRANS_KEY_DISALLOWED 0x8E  /**< BR/EDR Link Key cannot be used for LE keys. */
+#define BLE_GAP_SEC_STATUS_RFU_RANGE2_BEGIN       0x8F  /**< Reserved for Future Use range #2 begin. */
+#define BLE_GAP_SEC_STATUS_RFU_RANGE2_END         0xFF  /**< Reserved for Future Use range #2 end. */
+/**@} */
+
+
+/**@defgroup BLE_GAP_SEC_STATUS_SOURCES GAP Security status sources
+ * @{ */
+#define BLE_GAP_SEC_STATUS_SOURCE_LOCAL           0x00  /**< Local failure. */
+#define BLE_GAP_SEC_STATUS_SOURCE_REMOTE          0x01  /**< Remote failure. */
+/**@} */
+
+
+/**@defgroup BLE_GAP_CP_LIMITS GAP Connection Parameters Limits
+ * @{ */
+#define BLE_GAP_CP_MIN_CONN_INTVL_NONE           0xFFFF  /**< No new minimum connection interval specified in connect parameters. */
+#define BLE_GAP_CP_MIN_CONN_INTVL_MIN            0x0006  /**< Lowest minimum connection interval permitted, in units of 1.25 ms, i.e. 7.5 ms. */
+#define BLE_GAP_CP_MIN_CONN_INTVL_MAX            0x0C80  /**< Highest minimum connection interval permitted, in units of 1.25 ms, i.e. 4 s. */
+#define BLE_GAP_CP_MAX_CONN_INTVL_NONE           0xFFFF  /**< No new maximum connection interval specified in connect parameters. */
+#define BLE_GAP_CP_MAX_CONN_INTVL_MIN            0x0006  /**< Lowest maximum connection interval permitted, in units of 1.25 ms, i.e. 7.5 ms. */
+#define BLE_GAP_CP_MAX_CONN_INTVL_MAX            0x0C80  /**< Highest maximum connection interval permitted, in units of 1.25 ms, i.e. 4 s. */
+#define BLE_GAP_CP_SLAVE_LATENCY_MAX             0x01F3  /**< Highest slave latency permitted, in connection events. */
+#define BLE_GAP_CP_CONN_SUP_TIMEOUT_NONE         0xFFFF  /**< No new supervision timeout specified in connect parameters. */
+#define BLE_GAP_CP_CONN_SUP_TIMEOUT_MIN          0x000A  /**< Lowest supervision timeout permitted, in units of 10 ms, i.e. 100 ms. */
+#define BLE_GAP_CP_CONN_SUP_TIMEOUT_MAX          0x0C80  /**< Highest supervision timeout permitted, in units of 10 ms, i.e. 32 s. */
+/**@} */
+
+
+/**@defgroup BLE_GAP_DEVNAME GAP device name defines.
+ * @{ */
+#define BLE_GAP_DEVNAME_DEFAULT                  "nRF5x" /**< Default device name value. */
+#define BLE_GAP_DEVNAME_DEFAULT_LEN              31      /**< Default number of octets in device name. */
+#define BLE_GAP_DEVNAME_MAX_LEN                  248     /**< Maximum number of octets in device name. */
+/**@} */
+
+
+/**@brief Disable RSSI events for connections */
+#define BLE_GAP_RSSI_THRESHOLD_INVALID 0xFF
+
+/**@defgroup BLE_GAP_PHYS GAP PHYs
+ * @{ */
+#define BLE_GAP_PHY_AUTO                         0x00    /**< Automatic PHY selection. Refer @ref sd_ble_gap_phy_update for more information.*/
+#define BLE_GAP_PHY_1MBPS                        0x01    /**< 1 Mbps PHY. */
+#define BLE_GAP_PHY_2MBPS                        0x02    /**< 2 Mbps PHY. */
+#define BLE_GAP_PHY_CODED                        0x04    /**< Coded PHY. */
+#define BLE_GAP_PHY_NOT_SET                      0xFF    /**< PHY is not configured. */
+
+/**@brief Supported PHYs in connections, for scanning, and for advertising. */
+#define BLE_GAP_PHYS_SUPPORTED  (BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS | BLE_GAP_PHY_CODED) /**< All PHYs are supported. */
+
+/**@} */
+
+/**@defgroup BLE_GAP_CONN_SEC_MODE_SET_MACROS GAP attribute security requirement setters
+ *
+ * See @ref ble_gap_conn_sec_mode_t.
+ * @{ */
+/**@brief Set sec_mode pointed to by ptr to have no access rights.*/
+#define BLE_GAP_CONN_SEC_MODE_SET_NO_ACCESS(ptr)          do {(ptr)->sm = 0; (ptr)->lv = 0;} while(0)
+/**@brief Set sec_mode pointed to by ptr to require no protection, open link.*/
+#define BLE_GAP_CONN_SEC_MODE_SET_OPEN(ptr)               do {(ptr)->sm = 1; (ptr)->lv = 1;} while(0)
+/**@brief Set sec_mode pointed to by ptr to require encryption, but no MITM protection.*/
+#define BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM(ptr)        do {(ptr)->sm = 1; (ptr)->lv = 2;} while(0)
+/**@brief Set sec_mode pointed to by ptr to require encryption and MITM protection.*/
+#define BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM(ptr)      do {(ptr)->sm = 1; (ptr)->lv = 3;} while(0)
+/**@brief Set sec_mode pointed to by ptr to require LESC encryption and MITM protection.*/
+#define BLE_GAP_CONN_SEC_MODE_SET_LESC_ENC_WITH_MITM(ptr) do {(ptr)->sm = 1; (ptr)->lv = 4;} while(0)
+/**@brief Set sec_mode pointed to by ptr to require signing or encryption, no MITM protection needed.*/
+#define BLE_GAP_CONN_SEC_MODE_SET_SIGNED_NO_MITM(ptr)     do {(ptr)->sm = 2; (ptr)->lv = 1;} while(0)
+/**@brief Set sec_mode pointed to by ptr to require signing or encryption with MITM protection.*/
+#define BLE_GAP_CONN_SEC_MODE_SET_SIGNED_WITH_MITM(ptr)   do {(ptr)->sm = 2; (ptr)->lv = 2;} while(0)
+/**@} */
+
+
+/**@brief GAP Security Random Number Length. */
+#define BLE_GAP_SEC_RAND_LEN 8
+
+
+/**@brief GAP Security Key Length. */
+#define BLE_GAP_SEC_KEY_LEN 16
+
+
+/**@brief GAP LE Secure Connections Elliptic Curve Diffie-Hellman P-256 Public Key Length. */
+#define BLE_GAP_LESC_P256_PK_LEN 64
+
+
+/**@brief GAP LE Secure Connections Elliptic Curve Diffie-Hellman DHKey Length. */
+#define BLE_GAP_LESC_DHKEY_LEN   32
+
+
+/**@brief GAP Passkey Length. */
+#define BLE_GAP_PASSKEY_LEN 6
+
+
+/**@brief Maximum amount of addresses in the whitelist. */
+#define BLE_GAP_WHITELIST_ADDR_MAX_COUNT (8)
+
+
+/**@brief Maximum amount of identities in the device identities list. */
+#define BLE_GAP_DEVICE_IDENTITIES_MAX_COUNT (8)
+
+
+/**@brief Default connection count for a configuration. */
+#define BLE_GAP_CONN_COUNT_DEFAULT (1)
+
+
+/**@defgroup BLE_GAP_EVENT_LENGTH GAP event length defines.
+ * @{ */
+#define BLE_GAP_EVENT_LENGTH_MIN            (2)  /**< Minimum event length, in 1.25 ms units. */
+#define BLE_GAP_EVENT_LENGTH_CODED_PHY_MIN  (6)  /**< The shortest event length in 1.25 ms units supporting LE Coded PHY. */
+#define BLE_GAP_EVENT_LENGTH_DEFAULT        (3)  /**< Default event length, in 1.25 ms units. */
+/**@} */
+
+
+/**@defgroup BLE_GAP_ROLE_COUNT GAP concurrent connection count defines.
+ * @{ */
+#define BLE_GAP_ROLE_COUNT_PERIPH_DEFAULT      (1)   /**< Default maximum number of connections concurrently acting as peripherals. */
+#define BLE_GAP_ROLE_COUNT_CENTRAL_DEFAULT     (3)   /**< Default maximum number of connections concurrently acting as centrals. */
+#define BLE_GAP_ROLE_COUNT_CENTRAL_SEC_DEFAULT (1)   /**< Default number of SMP instances shared between all connections acting as centrals. */
+#define BLE_GAP_ROLE_COUNT_COMBINED_MAX        (20)  /**< Maximum supported number of concurrent connections in the peripheral and central roles combined. */
+
+/**@} */
+
+/**@brief Automatic data length parameter. */
+#define BLE_GAP_DATA_LENGTH_AUTO 0
+
+/**@defgroup BLE_GAP_AUTH_PAYLOAD_TIMEOUT Authenticated payload timeout defines.
+  * @{ */
+#define BLE_GAP_AUTH_PAYLOAD_TIMEOUT_MAX (48000) /**< Maximum authenticated payload timeout in 10 ms units, i.e. 8 minutes. */
+#define BLE_GAP_AUTH_PAYLOAD_TIMEOUT_MIN (1)     /**< Minimum authenticated payload timeout in 10 ms units, i.e. 10 ms. */
+/**@} */
+
+/**@defgroup GAP_SEC_MODES GAP Security Modes
+ * @{ */
+#define BLE_GAP_SEC_MODE 0x00 /**< No key (may be used to reject). */
+/**@} */
+
+/**@brief The total number of channels in Bluetooth Low Energy. */
+#define BLE_GAP_CHANNEL_COUNT      (40)
+
+/**@defgroup BLE_GAP_QOS_CHANNEL_SURVEY_INTERVALS Quality of Service (QoS) Channel survey interval defines
+ * @{ */
+#define BLE_GAP_QOS_CHANNEL_SURVEY_INTERVAL_CONTINUOUS  (0)       /**< Continuous channel survey. */
+#define BLE_GAP_QOS_CHANNEL_SURVEY_INTERVAL_MIN_US      (7500)    /**< Minimum channel survey interval in microseconds (7.5 ms). */
+#define BLE_GAP_QOS_CHANNEL_SURVEY_INTERVAL_MAX_US      (4000000) /**< Maximum channel survey interval in microseconds (4 s). */
+ /**@}  */
+
+/** @} */
+
+/** @defgroup BLE_GAP_CHAR_INCL_CONFIG GAP Characteristic inclusion configurations
+ * @{
+ */
+#define BLE_GAP_CHAR_INCL_CONFIG_INCLUDE               (0) /**< Include the characteristic in the Attribute Table */
+#define BLE_GAP_CHAR_INCL_CONFIG_EXCLUDE_WITH_SPACE    (1) /**< Do not include the characteristic in the Attribute table.
+                                                                The SoftDevice will reserve the attribute handles
+                                                                which are otherwise used for this characteristic.
+                                                                By reserving the attribute handles it will be possible
+                                                                to upgrade the SoftDevice without changing handle of the
+                                                                Service Changed characteristic. */
+#define BLE_GAP_CHAR_INCL_CONFIG_EXCLUDE_WITHOUT_SPACE (2) /**< Do not include the characteristic in the Attribute table.
+                                                                The SoftDevice will not reserve the attribute handles
+                                                                which are otherwise used for this characteristic. */
+/**@} */
+
+
+/** @defgroup BLE_GAP_CHAR_INCL_CONFIG_DEFAULTS Characteristic inclusion default values
+ * @{ */
+#define BLE_GAP_PPCP_INCL_CONFIG_DEFAULT     (BLE_GAP_CHAR_INCL_CONFIG_INCLUDE) /**< Included by default. */
+#define BLE_GAP_CAR_INCL_CONFIG_DEFAULT      (BLE_GAP_CHAR_INCL_CONFIG_INCLUDE) /**< Included by default. */
+/**@} */
+
+/** @defgroup BLE_GAP_SLAVE_LATENCY Slave latency configuration options
+ * @{ */
+#define BLE_GAP_SLAVE_LATENCY_ENABLE         (0) /**< Slave latency is enabled. When slave latency is enabled,
+                                                      the slave will wake up every time it has data to send,
+                                                      and/or every slave latency number of connection events. */
+#define BLE_GAP_SLAVE_LATENCY_DISABLE        (1) /**< Disable slave latency. The slave will wake up every connection event
+                                                      regardless of the requested slave latency.
+                                                      This option consumes the most power. */
+#define BLE_GAP_SLAVE_LATENCY_WAIT_FOR_ACK   (2) /**< The slave will wake up every connection event if it has not received
+                                                      an ACK from the master for at least slave latency events. This
+                                                      configuration may increase the power consumption in environments
+                                                      with a lot of radio activity. */
+/**@} */
+
+/**@addtogroup BLE_GAP_STRUCTURES Structures
+ * @{ */
+
+/**@brief Advertising event properties. */
+typedef struct
+{
+  uint8_t type;                 /**< Advertising type. See @ref BLE_GAP_ADV_TYPES. */
+  uint8_t anonymous        : 1; /**< Omit advertiser's address from all PDUs.
+                                     @note Anonymous advertising is only available for
+                                     @ref BLE_GAP_ADV_TYPE_EXTENDED_NONCONNECTABLE_NONSCANNABLE_UNDIRECTED and
+                                     @ref BLE_GAP_ADV_TYPE_EXTENDED_NONCONNECTABLE_NONSCANNABLE_DIRECTED. */
+  uint8_t include_tx_power : 1; /**< This feature is not supported on this SoftDevice. */
+} ble_gap_adv_properties_t;
+
+
+/**@brief Advertising report type. */
+typedef struct
+{
+  uint16_t connectable   : 1; /**< Connectable advertising event type. */
+  uint16_t scannable     : 1; /**< Scannable advertising event type. */
+  uint16_t directed      : 1; /**< Directed advertising event type. */
+  uint16_t scan_response : 1; /**< Received a scan response. */
+  uint16_t extended_pdu  : 1; /**< Received an extended advertising set. */
+  uint16_t status        : 2; /**< Data status. See @ref BLE_GAP_ADV_DATA_STATUS. */
+  uint16_t reserved      : 9; /**< Reserved for future use. */
+} ble_gap_adv_report_type_t;
+
+/**@brief Advertising Auxiliary Pointer. */
+typedef struct
+{
+  uint16_t  aux_offset;   /**< Time offset from the beginning of advertising packet to the auxiliary packet in 100 us units. */
+  uint8_t   aux_phy;      /**< Indicates the PHY on which the auxiliary advertising packet is sent. See @ref BLE_GAP_PHYS. */
+} ble_gap_aux_pointer_t;
+
+/**@brief Bluetooth Low Energy address. */
+typedef struct
+{
+  uint8_t addr_id_peer : 1;       /**< Only valid for peer addresses.
+                                       This bit is set by the SoftDevice to indicate whether the address has been resolved from
+                                       a Resolvable Private Address (when the peer is using privacy).
+                                       If set to 1, @ref addr and @ref addr_type refer to the identity address of the resolved address.
+
+                                       This bit is ignored when a variable of type @ref ble_gap_addr_t is used as input to API functions. */
+  uint8_t addr_type    : 7;       /**< See @ref BLE_GAP_ADDR_TYPES. */
+  uint8_t addr[BLE_GAP_ADDR_LEN]; /**< 48-bit address, LSB format.
+                                       @ref addr is not used if @ref addr_type is @ref BLE_GAP_ADDR_TYPE_ANONYMOUS. */
+} ble_gap_addr_t;
+
+
+/**@brief GAP connection parameters.
+ *
+ * @note  When ble_conn_params_t is received in an event, both min_conn_interval and
+ *        max_conn_interval will be equal to the connection interval set by the central.
+ *
+ * @note  If both conn_sup_timeout and max_conn_interval are specified, then the following constraint applies:
+ *        conn_sup_timeout * 4 > (1 + slave_latency) * max_conn_interval
+ *        that corresponds to the following Bluetooth Spec requirement:
+ *        The Supervision_Timeout in milliseconds shall be larger than
+ *        (1 + Conn_Latency) * Conn_Interval_Max * 2, where Conn_Interval_Max is given in milliseconds.
+ */
+typedef struct
+{
+  uint16_t min_conn_interval;         /**< Minimum Connection Interval in 1.25 ms units, see @ref BLE_GAP_CP_LIMITS.*/
+  uint16_t max_conn_interval;         /**< Maximum Connection Interval in 1.25 ms units, see @ref BLE_GAP_CP_LIMITS.*/
+  uint16_t slave_latency;             /**< Slave Latency in number of connection events, see @ref BLE_GAP_CP_LIMITS.*/
+  uint16_t conn_sup_timeout;          /**< Connection Supervision Timeout in 10 ms units, see @ref BLE_GAP_CP_LIMITS.*/
+} ble_gap_conn_params_t;
+
+
+/**@brief GAP connection security modes.
+ *
+ * Security Mode 0 Level 0: No access permissions at all (this level is not defined by the Bluetooth Core specification).\n
+ * Security Mode 1 Level 1: No security is needed (aka open link).\n
+ * Security Mode 1 Level 2: Encrypted link required, MITM protection not necessary.\n
+ * Security Mode 1 Level 3: MITM protected encrypted link required.\n
+ * Security Mode 1 Level 4: LESC MITM protected encrypted link using a 128-bit strength encryption key required.\n
+ * Security Mode 2 Level 1: Signing or encryption required, MITM protection not necessary.\n
+ * Security Mode 2 Level 2: MITM protected signing required, unless link is MITM protected encrypted.\n
+ */
+typedef struct
+{
+  uint8_t sm : 4;                     /**< Security Mode (1 or 2), 0 for no permissions at all. */
+  uint8_t lv : 4;                     /**< Level (1, 2, 3 or 4), 0 for no permissions at all. */
+
+} ble_gap_conn_sec_mode_t;
+
+
+/**@brief GAP connection security status.*/
+typedef struct
+{
+  ble_gap_conn_sec_mode_t sec_mode;           /**< Currently active security mode for this connection.*/
+  uint8_t                 encr_key_size;      /**< Length of currently active encryption key, 7 to 16 octets (only applicable for bonding procedures). */
+} ble_gap_conn_sec_t;
+
+/**@brief Identity Resolving Key. */
+typedef struct
+{
+  uint8_t irk[BLE_GAP_SEC_KEY_LEN];   /**< Array containing IRK. */
+} ble_gap_irk_t;
+
+
+/**@brief Channel mask (40 bits).
+ * Every channel is represented with a bit positioned as per channel index defined in Bluetooth Core Specification v5.0,
+ * Vol 6, Part B, Section 1.4.1. The LSB contained in array element 0 represents channel index 0, and bit 39 represents
+ * channel index 39. If a bit is set to 1, the channel is not used.
+ */
+typedef uint8_t ble_gap_ch_mask_t[5];
+
+
+/**@brief GAP advertising parameters. */
+typedef struct
+{
+  ble_gap_adv_properties_t properties;              /**< The properties of the advertising events. */
+  ble_gap_addr_t const    *p_peer_addr;             /**< Address of a known peer.
+                                                         @note ble_gap_addr_t::addr_type cannot be
+                                                               @ref BLE_GAP_ADDR_TYPE_ANONYMOUS.
+                                                         - When privacy is enabled and the local device uses
+                                                           @ref BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE addresses,
+                                                           the device identity list is searched for a matching entry. If
+                                                           the local IRK for that device identity is set, the local IRK
+                                                           for that device will be used to generate the advertiser address
+                                                           field in the advertising packet.
+                                                         - If @ref ble_gap_adv_properties_t::type is directed, this must be
+                                                           set to the targeted scanner or initiator. If the peer address is
+                                                           in the device identity list, the peer IRK for that device will be
+                                                           used to generate @ref BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE
+                                                           target addresses used in the advertising event PDUs. */
+  uint32_t                 interval;                /**< Advertising interval in 625 us units. @sa BLE_GAP_ADV_INTERVALS.
+                                                         @note If @ref ble_gap_adv_properties_t::type is set to
+                                                               @ref BLE_GAP_ADV_TYPE_CONNECTABLE_NONSCANNABLE_DIRECTED_HIGH_DUTY_CYCLE
+                                                               advertising, this parameter is ignored. */
+  uint16_t                 duration;                /**< Advertising duration in 10 ms units. When timeout is reached,
+                                                         an event of type @ref BLE_GAP_EVT_ADV_SET_TERMINATED is raised.
+                                                         @sa BLE_GAP_ADV_TIMEOUT_VALUES.
+                                                         @note The SoftDevice will always complete at least one advertising
+                                                               event even if the duration is set too low. */
+  uint8_t                  max_adv_evts;            /**< Maximum advertising events that shall be sent prior to disabling
+                                                         advertising. Setting the value to 0 disables the limitation. When
+                                                         the count of advertising events specified by this parameter
+                                                         (if not 0) is reached, advertising will be automatically stopped
+                                                         and an event of type @ref BLE_GAP_EVT_ADV_SET_TERMINATED is raised
+                                                         @note If @ref ble_gap_adv_properties_t::type is set to
+                                                               @ref BLE_GAP_ADV_TYPE_CONNECTABLE_NONSCANNABLE_DIRECTED_HIGH_DUTY_CYCLE,
+                                                               this parameter is ignored. */
+  ble_gap_ch_mask_t        channel_mask;            /**< Channel mask for primary and secondary advertising channels.
+                                                         At least one of the primary channels, that is channel index 37-39, must be used.
+                                                         Masking away secondary advertising channels is not supported. */
+  uint8_t                  filter_policy;           /**< Filter Policy. @sa BLE_GAP_ADV_FILTER_POLICIES. */
+  uint8_t                  primary_phy;             /**< Indicates the PHY on which the primary advertising channel packets
+                                                         are transmitted. If set to @ref BLE_GAP_PHY_AUTO, @ref BLE_GAP_PHY_1MBPS
+                                                         will be used.
+                                                         Valid values are @ref BLE_GAP_PHY_1MBPS and @ref BLE_GAP_PHY_CODED.
+                                                         @note The primary_phy shall indicate @ref BLE_GAP_PHY_1MBPS if
+                                                               @ref ble_gap_adv_properties_t::type is not an extended advertising type. */
+  uint8_t                  secondary_phy;           /**< Indicates the PHY on which the secondary advertising channel packets
+                                                         are transmitted.
+                                                         If set to @ref BLE_GAP_PHY_AUTO, @ref BLE_GAP_PHY_1MBPS will be used.
+                                                         Valid values are
+                                                         @ref BLE_GAP_PHY_1MBPS, @ref BLE_GAP_PHY_2MBPS, and @ref BLE_GAP_PHY_CODED.
+                                                         If @ref ble_gap_adv_properties_t::type is an extended advertising type
+                                                         and connectable, this is the PHY that will be used to establish a
+                                                         connection and send AUX_ADV_IND packets on.
+                                                         @note This parameter will be ignored when
+                                                               @ref ble_gap_adv_properties_t::type is not an extended advertising type. */
+  uint8_t                  set_id:4;                /**< The advertising set identifier distinguishes this advertising set from other
+                                                         advertising sets transmitted by this and other devices.
+                                                         @note This parameter will be ignored when
+                                                               @ref ble_gap_adv_properties_t::type is not an extended advertising type. */
+  uint8_t                  scan_req_notification:1; /**< Enable scan request notifications for this advertising set. When a
+                                                         scan request is received and the scanner address is allowed
+                                                         by the filter policy, @ref BLE_GAP_EVT_SCAN_REQ_REPORT is raised.
+                                                         @note This parameter will be ignored when
+                                                               @ref ble_gap_adv_properties_t::type is a non-scannable
+                                                               advertising type. */
+} ble_gap_adv_params_t;
+
+
+/**@brief GAP advertising data buffers.
+ *
+ * The application must provide the buffers for advertisement. The memory shall reside in application RAM, and
+ * shall never be modified while advertising. The data shall be kept alive until either:
+ *  - @ref BLE_GAP_EVT_ADV_SET_TERMINATED is raised.
+ *  - @ref BLE_GAP_EVT_CONNECTED is raised with @ref ble_gap_evt_connected_t::adv_handle set to the corresponding
+ *    advertising handle.
+ *  - Advertising is stopped.
+ *  - Advertising data is changed.
+ * To update advertising data while advertising, provide new buffers to @ref sd_ble_gap_adv_set_configure. */
+typedef struct
+{
+  ble_data_t       adv_data;                     /**< Advertising data.
+                                                      @note
+                                                      Advertising data can only be specified for a @ref ble_gap_adv_properties_t::type
+                                                      that is allowed to contain advertising data. */
+  ble_data_t       scan_rsp_data;                /**< Scan response data.
+                                                      @note
+                                                      Scan response data can only be specified for a @ref ble_gap_adv_properties_t::type
+                                                      that is scannable. */
+} ble_gap_adv_data_t;
+
+
+/**@brief GAP scanning parameters. */
+typedef struct
+{
+  uint8_t               extended               : 1; /**< If 1, the scanner will accept extended advertising packets.
+                                                         If set to 0, the scanner will not receive advertising packets
+                                                         on secondary advertising channels, and will not be able
+                                                         to receive long advertising PDUs. */
+  uint8_t               report_incomplete_evts : 1; /**< If 1, events of type @ref ble_gap_evt_adv_report_t may have
+                                                         @ref ble_gap_adv_report_type_t::status set to
+                                                         @ref BLE_GAP_ADV_DATA_STATUS_INCOMPLETE_MORE_DATA.
+                                                         This parameter is ignored when used with @ref sd_ble_gap_connect
+                                                         @note This may be used to abort receiving more packets from an extended
+                                                               advertising event, and is only available for extended
+                                                               scanning, see @ref sd_ble_gap_scan_start.
+                                                         @note This feature is not supported by this SoftDevice. */
+  uint8_t               active                 : 1; /**< If 1, perform active scanning by sending scan requests.
+                                                         This parameter is ignored when used with @ref sd_ble_gap_connect. */
+  uint8_t               filter_policy          : 2; /**< Scanning filter policy. @sa BLE_GAP_SCAN_FILTER_POLICIES.
+                                                         @note Only @ref BLE_GAP_SCAN_FP_ACCEPT_ALL and
+                                                               @ref BLE_GAP_SCAN_FP_WHITELIST are valid when used with
+                                                               @ref sd_ble_gap_connect */
+  uint8_t               scan_phys;                  /**< Bitfield of PHYs to scan on. If set to @ref BLE_GAP_PHY_AUTO,
+                                                         scan_phys will default to @ref BLE_GAP_PHY_1MBPS.
+                                                         - If @ref ble_gap_scan_params_t::extended is set to 0, the only
+                                                           supported PHY is @ref BLE_GAP_PHY_1MBPS.
+                                                         - When used with @ref sd_ble_gap_scan_start,
+                                                           the bitfield indicates the PHYs the scanner will use for scanning
+                                                           on primary advertising channels. The scanner will accept
+                                                           @ref BLE_GAP_PHYS_SUPPORTED as secondary advertising channel PHYs.
+                                                         - When used with @ref sd_ble_gap_connect, the bitfield indicates
+                                                           the PHYs the initiator will use for scanning on primary advertising
+                                                           channels. The initiator will accept connections initiated on either
+                                                           of the @ref BLE_GAP_PHYS_SUPPORTED PHYs.
+                                                           If scan_phys contains @ref BLE_GAP_PHY_1MBPS and/or @ref BLE_GAP_PHY_2MBPS,
+                                                           the primary scan PHY is @ref BLE_GAP_PHY_1MBPS.
+                                                           If scan_phys also contains @ref BLE_GAP_PHY_CODED, the primary scan
+                                                           PHY will also contain @ref BLE_GAP_PHY_CODED. If the only scan PHY is
+                                                           @ref BLE_GAP_PHY_CODED, the primary scan PHY is
+                                                           @ref BLE_GAP_PHY_CODED only. */
+  uint16_t              interval;                   /**< Scan interval in 625 us units. @sa BLE_GAP_SCAN_INTERVALS. */
+  uint16_t              window;                     /**< Scan window in 625 us units. @sa BLE_GAP_SCAN_WINDOW.
+                                                         If scan_phys contains both @ref BLE_GAP_PHY_1MBPS and
+                                                         @ref BLE_GAP_PHY_CODED interval shall be larger than or
+                                                         equal to twice the scan window. */
+  uint16_t              timeout;                    /**< Scan timeout in 10 ms units. @sa BLE_GAP_SCAN_TIMEOUT. */
+  ble_gap_ch_mask_t     channel_mask;               /**< Channel mask for primary and secondary advertising channels.
+                                                         At least one of the primary channels, that is channel index 37-39, must be
+                                                         set to 0.
+                                                         Masking away secondary channels is not supported. */
+} ble_gap_scan_params_t;
+
+
+/**@brief Privacy.
+ *
+ *        The privacy feature provides a way for the device to avoid being tracked over a period of time.
+ *        The privacy feature, when enabled, hides the local device identity and replaces it with a private address
+ *        that is automatically refreshed at a specified interval.
+ *
+ *        If a device still wants to be recognized by other peers, it needs to share it's Identity Resolving Key (IRK).
+ *        With this key, a device can generate a random private address that can only be recognized by peers in possession of that key,
+ *        and devices can establish connections without revealing their real identities.
+ *
+ *        Both network privacy (@ref BLE_GAP_PRIVACY_MODE_NETWORK_PRIVACY) and device privacy (@ref BLE_GAP_PRIVACY_MODE_DEVICE_PRIVACY)
+ *        are supported.
+ *
+ * @note  If the device IRK is updated, the new IRK becomes the one to be distributed in all
+ *        bonding procedures performed after @ref sd_ble_gap_privacy_set returns.
+ *        The IRK distributed during bonding procedure is the device IRK that is active when @ref sd_ble_gap_sec_params_reply is called.
+ */
+typedef struct
+{
+  uint8_t        privacy_mode;         /**< Privacy mode, see @ref BLE_GAP_PRIVACY_MODES. Default is @ref BLE_GAP_PRIVACY_MODE_OFF. */
+  uint8_t        private_addr_type;    /**< The private address type must be either @ref BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE or @ref BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_NON_RESOLVABLE. */
+  uint16_t       private_addr_cycle_s; /**< Private address cycle interval in seconds. Providing an address cycle value of 0 will use the default value defined by @ref BLE_GAP_DEFAULT_PRIVATE_ADDR_CYCLE_INTERVAL_S. */
+  ble_gap_irk_t *p_device_irk;         /**< When used as input, pointer to IRK structure that will be used as the default IRK. If NULL, the device default IRK will be used.
+                                            When used as output, pointer to IRK structure where the current default IRK will be written to. If NULL, this argument is ignored.
+                                            By default, the default IRK is used to generate random private resolvable addresses for the local device unless instructed otherwise. */
+} ble_gap_privacy_params_t;
+
+
+/**@brief PHY preferences for TX and RX
+ * @note  tx_phys and rx_phys are bit fields. Multiple bits can be set in them to indicate multiple preferred PHYs for each direction.
+ * @code
+ * p_gap_phys->tx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS;
+ * p_gap_phys->rx_phys = BLE_GAP_PHY_1MBPS | BLE_GAP_PHY_2MBPS;
+ * @endcode
+ *
+ */
+typedef struct
+{
+  uint8_t tx_phys;     /**< Preferred transmit PHYs, see @ref BLE_GAP_PHYS. */
+  uint8_t rx_phys;     /**< Preferred receive PHYs, see @ref BLE_GAP_PHYS. */
+} ble_gap_phys_t;
+
+/** @brief Keys that can be exchanged during a bonding procedure. */
+typedef struct
+{
+  uint8_t enc     : 1;                        /**< Long Term Key and Master Identification. */
+  uint8_t id      : 1;                        /**< Identity Resolving Key and Identity Address Information. */
+  uint8_t sign    : 1;                        /**< Connection Signature Resolving Key. */
+  uint8_t link    : 1;                        /**< Derive the Link Key from the LTK. */
+} ble_gap_sec_kdist_t;
+
+
+/**@brief GAP security parameters. */
+typedef struct
+{
+  uint8_t               bond      : 1;             /**< Perform bonding. */
+  uint8_t               mitm      : 1;             /**< Enable Man In The Middle protection. */
+  uint8_t               lesc      : 1;             /**< Enable LE Secure Connection pairing. */
+  uint8_t               keypress  : 1;             /**< Enable generation of keypress notifications. */
+  uint8_t               io_caps   : 3;             /**< IO capabilities, see @ref BLE_GAP_IO_CAPS. */
+  uint8_t               oob       : 1;             /**< The OOB data flag.
+                                                        - In LE legacy pairing, this flag is set if a device has out of band authentication data.
+                                                          The OOB method is used if both of the devices have out of band authentication data.
+                                                        - In LE Secure Connections pairing, this flag is set if a device has the peer device's out of band authentication data.
+                                                          The OOB method is used if at least one device has the peer device's OOB data available. */
+  uint8_t               min_key_size;              /**< Minimum encryption key size in octets between 7 and 16. If 0 then not applicable in this instance. */
+  uint8_t               max_key_size;              /**< Maximum encryption key size in octets between min_key_size and 16. */
+  ble_gap_sec_kdist_t   kdist_own;                 /**< Key distribution bitmap: keys that the local device will distribute. */
+  ble_gap_sec_kdist_t   kdist_peer;                /**< Key distribution bitmap: keys that the remote device will distribute. */
+} ble_gap_sec_params_t;
+
+
+/**@brief GAP Encryption Information. */
+typedef struct
+{
+  uint8_t   ltk[BLE_GAP_SEC_KEY_LEN];   /**< Long Term Key. */
+  uint8_t   lesc : 1;                   /**< Key generated using LE Secure Connections. */
+  uint8_t   auth : 1;                   /**< Authenticated Key. */
+  uint8_t   ltk_len : 6;                /**< LTK length in octets. */
+} ble_gap_enc_info_t;
+
+
+/**@brief GAP Master Identification. */
+typedef struct
+{
+  uint16_t  ediv;                       /**< Encrypted Diversifier. */
+  uint8_t   rand[BLE_GAP_SEC_RAND_LEN]; /**< Random Number. */
+} ble_gap_master_id_t;
+
+
+/**@brief GAP Signing Information. */
+typedef struct
+{
+  uint8_t   csrk[BLE_GAP_SEC_KEY_LEN];        /**< Connection Signature Resolving Key. */
+} ble_gap_sign_info_t;
+
+
+/**@brief GAP LE Secure Connections P-256 Public Key. */
+typedef struct
+{
+  uint8_t   pk[BLE_GAP_LESC_P256_PK_LEN];        /**< LE Secure Connections Elliptic Curve Diffie-Hellman P-256 Public Key. Stored in the standard SMP protocol format: {X,Y} both in little-endian. */
+} ble_gap_lesc_p256_pk_t;
+
+
+/**@brief GAP LE Secure Connections DHKey. */
+typedef struct
+{
+  uint8_t   key[BLE_GAP_LESC_DHKEY_LEN];        /**< LE Secure Connections Elliptic Curve Diffie-Hellman Key. Stored in little-endian. */
+} ble_gap_lesc_dhkey_t;
+
+
+/**@brief GAP LE Secure Connections OOB data. */
+typedef struct
+{
+  ble_gap_addr_t  addr;                          /**< Bluetooth address of the device. */
+  uint8_t         r[BLE_GAP_SEC_KEY_LEN];        /**< Random Number. */
+  uint8_t         c[BLE_GAP_SEC_KEY_LEN];        /**< Confirm Value. */
+} ble_gap_lesc_oob_data_t;
+
+
+/**@brief Event structure for @ref BLE_GAP_EVT_CONNECTED. */
+typedef struct
+{
+  ble_gap_addr_t        peer_addr;              /**< Bluetooth address of the peer device. If the peer_addr resolved: @ref ble_gap_addr_t::addr_id_peer is set to 1
+                                                     and the address is the device's identity address. */
+  uint8_t               role;                   /**< BLE role for this connection, see @ref BLE_GAP_ROLES */
+  ble_gap_conn_params_t conn_params;            /**< GAP Connection Parameters. */
+  uint8_t               adv_handle;             /**< Advertising handle in which advertising has ended.
+                                                     This variable is only set if role is set to @ref BLE_GAP_ROLE_PERIPH. */
+  ble_gap_adv_data_t    adv_data;               /**< Advertising buffers corresponding to the terminated
+                                                     advertising set. The advertising buffers provided in
+                                                     @ref sd_ble_gap_adv_set_configure are now released.
+                                                     This variable is only set if role is set to @ref BLE_GAP_ROLE_PERIPH. */
+} ble_gap_evt_connected_t;
+
+
+/**@brief Event structure for @ref BLE_GAP_EVT_DISCONNECTED. */
+typedef struct
+{
+  uint8_t reason;                               /**< HCI error code, see @ref BLE_HCI_STATUS_CODES. */
+} ble_gap_evt_disconnected_t;
+
+
+/**@brief Event structure for @ref BLE_GAP_EVT_CONN_PARAM_UPDATE. */
+typedef struct
+{
+  ble_gap_conn_params_t conn_params;            /**<  GAP Connection Parameters. */
+} ble_gap_evt_conn_param_update_t;
+
+/**@brief Event structure for @ref BLE_GAP_EVT_PHY_UPDATE_REQUEST. */
+typedef struct
+{
+  ble_gap_phys_t peer_preferred_phys;            /**< The PHYs the peer prefers to use. */
+} ble_gap_evt_phy_update_request_t;
+
+/**@brief Event Structure for @ref BLE_GAP_EVT_PHY_UPDATE. */
+typedef struct
+{
+  uint8_t status;                               /**< Status of the procedure, see @ref BLE_HCI_STATUS_CODES.*/
+  uint8_t tx_phy;                               /**< TX PHY for this connection, see @ref BLE_GAP_PHYS. */
+  uint8_t rx_phy;                               /**< RX PHY for this connection, see @ref BLE_GAP_PHYS. */
+} ble_gap_evt_phy_update_t;
+
+/**@brief Event structure for @ref BLE_GAP_EVT_SEC_PARAMS_REQUEST. */
+typedef struct
+{
+  ble_gap_sec_params_t peer_params;             /**< Initiator Security Parameters. */
+} ble_gap_evt_sec_params_request_t;
+
+
+/**@brief Event structure for @ref BLE_GAP_EVT_SEC_INFO_REQUEST. */
+typedef struct
+{
+  ble_gap_addr_t      peer_addr;                     /**< Bluetooth address of the peer device. */
+  ble_gap_master_id_t master_id;                     /**< Master Identification for LTK lookup. */
+  uint8_t             enc_info  : 1;                 /**< If 1, Encryption Information required. */
+  uint8_t             id_info   : 1;                 /**< If 1, Identity Information required. */
+  uint8_t             sign_info : 1;                 /**< If 1, Signing Information required. */
+} ble_gap_evt_sec_info_request_t;
+
+
+/**@brief Event structure for @ref BLE_GAP_EVT_PASSKEY_DISPLAY. */
+typedef struct
+{
+  uint8_t passkey[BLE_GAP_PASSKEY_LEN];         /**< 6-digit passkey in ASCII ('0'-'9' digits only). */
+  uint8_t match_request : 1;                    /**< If 1 requires the application to report the match using @ref sd_ble_gap_auth_key_reply
+                                                     with either @ref BLE_GAP_AUTH_KEY_TYPE_NONE if there is no match or
+                                                     @ref BLE_GAP_AUTH_KEY_TYPE_PASSKEY if there is a match. */
+} ble_gap_evt_passkey_display_t;
+
+/**@brief Event structure for @ref BLE_GAP_EVT_KEY_PRESSED. */
+typedef struct
+{
+  uint8_t kp_not;         /**< Keypress notification type, see @ref BLE_GAP_KP_NOT_TYPES. */
+} ble_gap_evt_key_pressed_t;
+
+
+/**@brief Event structure for @ref BLE_GAP_EVT_AUTH_KEY_REQUEST. */
+typedef struct
+{
+  uint8_t key_type;                             /**< See @ref BLE_GAP_AUTH_KEY_TYPES. */
+} ble_gap_evt_auth_key_request_t;
+
+/**@brief Event structure for @ref BLE_GAP_EVT_LESC_DHKEY_REQUEST. */
+typedef struct
+{
+  ble_gap_lesc_p256_pk_t *p_pk_peer;  /**< LE Secure Connections remote P-256 Public Key. This will point to the application-supplied memory
+                                           inside the keyset during the call to @ref sd_ble_gap_sec_params_reply. */
+  uint8_t oobd_req       :1;          /**< LESC OOB data required. A call to @ref sd_ble_gap_lesc_oob_data_set is required to complete the procedure. */
+} ble_gap_evt_lesc_dhkey_request_t;
+
+
+/**@brief Security levels supported.
+ * @note  See Bluetooth Specification Version 4.2 Volume 3, Part C, Chapter 10, Section 10.2.1.
+*/
+typedef struct
+{
+  uint8_t lv1 : 1;                              /**< If 1: Level 1 is supported. */
+  uint8_t lv2 : 1;                              /**< If 1: Level 2 is supported. */
+  uint8_t lv3 : 1;                              /**< If 1: Level 3 is supported. */
+  uint8_t lv4 : 1;                              /**< If 1: Level 4 is supported. */
+} ble_gap_sec_levels_t;
+
+
+/**@brief Encryption Key. */
+typedef struct
+{
+  ble_gap_enc_info_t    enc_info;             /**< Encryption Information. */
+  ble_gap_master_id_t   master_id;            /**< Master Identification. */
+} ble_gap_enc_key_t;
+
+
+/**@brief Identity Key. */
+typedef struct
+{
+  ble_gap_irk_t         id_info;              /**< Identity Resolving Key. */
+  ble_gap_addr_t        id_addr_info;         /**< Identity Address. */
+} ble_gap_id_key_t;
+
+
+/**@brief Security Keys. */
+typedef struct
+{
+  ble_gap_enc_key_t      *p_enc_key;           /**< Encryption Key, or NULL. */
+  ble_gap_id_key_t       *p_id_key;            /**< Identity Key, or NULL. */
+  ble_gap_sign_info_t    *p_sign_key;          /**< Signing Key, or NULL. */
+  ble_gap_lesc_p256_pk_t *p_pk;                /**< LE Secure Connections P-256 Public Key. When in debug mode the application must use the value defined
+                                                    in the Core Bluetooth Specification v4.2 Vol.3, Part H, Section 2.3.5.6.1 */
+} ble_gap_sec_keys_t;
+
+
+/**@brief Security key set for both local and peer keys. */
+typedef struct
+{
+  ble_gap_sec_keys_t            keys_own;     /**< Keys distributed by the local device. For LE Secure Connections the encryption key will be generated locally and will always be stored if bonding. */
+  ble_gap_sec_keys_t            keys_peer;    /**< Keys distributed by the remote device. For LE Secure Connections, p_enc_key must always be NULL. */
+} ble_gap_sec_keyset_t;
+
+
+/**@brief Data Length Update Procedure parameters. */
+typedef struct
+{
+  uint16_t max_tx_octets;   /**< Maximum number of payload octets that a Controller supports for transmission of a single Link Layer Data Channel PDU. */
+  uint16_t max_rx_octets;   /**< Maximum number of payload octets that a Controller supports for reception of a single Link Layer Data Channel PDU. */
+  uint16_t max_tx_time_us;  /**< Maximum time, in microseconds, that a Controller supports for transmission of a single Link Layer Data Channel PDU. */
+  uint16_t max_rx_time_us;  /**< Maximum time, in microseconds, that a Controller supports for reception of a single Link Layer Data Channel PDU. */
+} ble_gap_data_length_params_t;
+
+
+/**@brief Data Length Update Procedure local limitation. */
+typedef struct
+{
+  uint16_t tx_payload_limited_octets; /**< If > 0, the requested TX packet length is too long by this many octets. */
+  uint16_t rx_payload_limited_octets; /**< If > 0, the requested RX packet length is too long by this many octets. */
+  uint16_t tx_rx_time_limited_us;     /**< If > 0, the requested combination of TX and RX packet lengths is too long by this many microseconds. */
+} ble_gap_data_length_limitation_t;
+
+
+/**@brief Event structure for @ref BLE_GAP_EVT_AUTH_STATUS. */
+typedef struct
+{
+  uint8_t               auth_status;            /**< Authentication status, see @ref BLE_GAP_SEC_STATUS. */
+  uint8_t               error_src : 2;          /**< On error, source that caused the failure, see @ref BLE_GAP_SEC_STATUS_SOURCES. */
+  uint8_t               bonded : 1;             /**< Procedure resulted in a bond. */
+  uint8_t               lesc : 1;               /**< Procedure resulted in a LE Secure Connection. */
+  ble_gap_sec_levels_t  sm1_levels;             /**< Levels supported in Security Mode 1. */
+  ble_gap_sec_levels_t  sm2_levels;             /**< Levels supported in Security Mode 2. */
+  ble_gap_sec_kdist_t   kdist_own;              /**< Bitmap stating which keys were exchanged (distributed) by the local device. If bonding with LE Secure Connections, the enc bit will be always set. */
+  ble_gap_sec_kdist_t   kdist_peer;             /**< Bitmap stating which keys were exchanged (distributed) by the remote device. If bonding with LE Secure Connections, the enc bit will never be set. */
+} ble_gap_evt_auth_status_t;
+
+
+/**@brief Event structure for @ref BLE_GAP_EVT_CONN_SEC_UPDATE. */
+typedef struct
+{
+  ble_gap_conn_sec_t conn_sec;                  /**< Connection security level. */
+} ble_gap_evt_conn_sec_update_t;
+
+
+/**@brief Event structure for @ref BLE_GAP_EVT_TIMEOUT. */
+typedef struct
+{
+  uint8_t src;                                  /**< Source of timeout event, see @ref BLE_GAP_TIMEOUT_SOURCES. */
+  union
+  {
+    ble_data_t adv_report_buffer;               /**< If source is set to @ref BLE_GAP_TIMEOUT_SRC_SCAN, the released
+                                                     scan buffer is contained in this field. */
+  } params;                                     /**< Event Parameters. */
+} ble_gap_evt_timeout_t;
+
+
+/**@brief Event structure for @ref BLE_GAP_EVT_RSSI_CHANGED. */
+typedef struct
+{
+  int8_t  rssi;                                 /**< Received Signal Strength Indication in dBm.
+                                                     @note ERRATA-153 and ERRATA-225 require the rssi sample to be compensated based on a temperature measurement. */
+  uint8_t ch_index;                             /**< Data Channel Index on which the Signal Strength is measured (0-36). */
+} ble_gap_evt_rssi_changed_t;
+
+/**@brief Event structure for @ref BLE_GAP_EVT_ADV_SET_TERMINATED */
+typedef struct
+{
+  uint8_t             reason;                         /**< Reason for why the advertising set terminated. See
+                                                           @ref BLE_GAP_EVT_ADV_SET_TERMINATED_REASON. */
+  uint8_t             adv_handle;                     /**< Advertising handle in which advertising has ended. */
+  uint8_t             num_completed_adv_events;       /**< If @ref ble_gap_adv_params_t::max_adv_evts was not set to 0,
+                                                           this field indicates the number of completed advertising events. */
+  ble_gap_adv_data_t  adv_data;                       /**< Advertising buffers corresponding to the terminated
+                                                           advertising set. The advertising buffers provided in
+                                                           @ref sd_ble_gap_adv_set_configure are now released. */
+} ble_gap_evt_adv_set_terminated_t;
+
+/**@brief Event structure for @ref BLE_GAP_EVT_ADV_REPORT.
+ *
+ * @note If @ref ble_gap_adv_report_type_t::status is set to @ref BLE_GAP_ADV_DATA_STATUS_INCOMPLETE_MORE_DATA,
+ *       not all fields in the advertising report may be available.
+ *
+ * @note When ble_gap_adv_report_type_t::status is not set to @ref BLE_GAP_ADV_DATA_STATUS_INCOMPLETE_MORE_DATA,
+ *       scanning will be paused. To continue scanning, call @ref sd_ble_gap_scan_start.
+ */
+typedef struct
+{
+  ble_gap_adv_report_type_t type;                  /**< Advertising report type. See @ref ble_gap_adv_report_type_t. */
+  ble_gap_addr_t            peer_addr;             /**< Bluetooth address of the peer device. If the peer_addr is resolved:
+                                                        @ref ble_gap_addr_t::addr_id_peer is set to 1 and the address is the
+                                                        peer's identity address. */
+  ble_gap_addr_t            direct_addr;           /**< Contains the target address of the advertising event if
+                                                        @ref ble_gap_adv_report_type_t::directed is set to 1. If the
+                                                        SoftDevice was able to resolve the address,
+                                                        @ref ble_gap_addr_t::addr_id_peer is set to 1 and the direct_addr
+                                                        contains the local identity address. If the target address of the
+                                                        advertising event is @ref BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE,
+                                                        and the SoftDevice was unable to resolve it, the application may try
+                                                        to resolve this address to find out if the advertising event was
+                                                        directed to us. */
+  uint8_t                   primary_phy;           /**< Indicates the PHY on which the primary advertising packet was received.
+                                                        See @ref BLE_GAP_PHYS. */
+  uint8_t                   secondary_phy;         /**< Indicates the PHY on which the secondary advertising packet was received.
+                                                        See @ref BLE_GAP_PHYS. This field is set to @ref BLE_GAP_PHY_NOT_SET if no packets
+                                                        were received on a secondary advertising channel. */
+  int8_t                    tx_power;              /**< TX Power reported by the advertiser in the last packet header received.
+                                                        This field is set to @ref BLE_GAP_POWER_LEVEL_INVALID if the
+                                                        last received packet did not contain the Tx Power field.
+                                                        @note TX Power is only included in extended advertising packets. */
+  int8_t                    rssi;                  /**< Received Signal Strength Indication in dBm of the last packet received.
+                                                        @note ERRATA-153 and ERRATA-225 require the rssi sample to be compensated based on a temperature measurement. */
+  uint8_t                   ch_index;              /**< Channel Index on which the last advertising packet is received (0-39). */
+  uint8_t                   set_id;                /**< Set ID of the received advertising data. Set ID is not present
+                                                        if set to @ref BLE_GAP_ADV_REPORT_SET_ID_NOT_AVAILABLE. */
+  uint16_t                  data_id:12;            /**< The advertising data ID of the received advertising data. Data ID
+                                                        is not present if @ref ble_gap_evt_adv_report_t::set_id is set to
+                                                        @ref BLE_GAP_ADV_REPORT_SET_ID_NOT_AVAILABLE. */
+  ble_data_t                data;                  /**< Received advertising or scan response data. If
+                                                        @ref ble_gap_adv_report_type_t::status is not set to
+                                                        @ref BLE_GAP_ADV_DATA_STATUS_INCOMPLETE_MORE_DATA, the data buffer provided
+                                                        in @ref sd_ble_gap_scan_start is now released. */
+  ble_gap_aux_pointer_t     aux_pointer;           /**< The offset and PHY of the next advertising packet in this extended advertising
+                                                        event. @note This field is only set if @ref ble_gap_adv_report_type_t::status
+                                                        is set to @ref BLE_GAP_ADV_DATA_STATUS_INCOMPLETE_MORE_DATA. */
+} ble_gap_evt_adv_report_t;
+
+
+/**@brief Event structure for @ref BLE_GAP_EVT_SEC_REQUEST. */
+typedef struct
+{
+  uint8_t    bond       : 1;                       /**< Perform bonding. */
+  uint8_t    mitm       : 1;                       /**< Man In The Middle protection requested. */
+  uint8_t    lesc       : 1;                       /**< LE Secure Connections requested. */
+  uint8_t    keypress   : 1;                       /**< Generation of keypress notifications requested. */
+} ble_gap_evt_sec_request_t;
+
+
+/**@brief Event structure for @ref BLE_GAP_EVT_CONN_PARAM_UPDATE_REQUEST. */
+typedef struct
+{
+  ble_gap_conn_params_t conn_params;            /**<  GAP Connection Parameters. */
+} ble_gap_evt_conn_param_update_request_t;
+
+
+/**@brief Event structure for @ref BLE_GAP_EVT_SCAN_REQ_REPORT. */
+typedef struct
+{
+  uint8_t                 adv_handle;        /**< Advertising handle for the advertising set which received the Scan Request */
+  int8_t                  rssi;              /**< Received Signal Strength Indication in dBm.
+                                                  @note ERRATA-153 and ERRATA-225 require the rssi sample to be compensated based on a temperature measurement. */
+  ble_gap_addr_t          peer_addr;         /**< Bluetooth address of the peer device. If the peer_addr resolved: @ref ble_gap_addr_t::addr_id_peer is set to 1
+                                                  and the address is the device's identity address. */
+} ble_gap_evt_scan_req_report_t;
+
+
+/**@brief Event structure for @ref BLE_GAP_EVT_DATA_LENGTH_UPDATE_REQUEST. */
+typedef struct
+{
+  ble_gap_data_length_params_t peer_params; /**< Peer data length parameters. */
+} ble_gap_evt_data_length_update_request_t;
+
+/**@brief Event structure for @ref BLE_GAP_EVT_DATA_LENGTH_UPDATE.
+ *
+ * @note This event may also be raised after a PHY Update procedure.
+ */
+typedef struct
+{
+  ble_gap_data_length_params_t effective_params;  /**< The effective data length parameters. */
+} ble_gap_evt_data_length_update_t;
+
+
+/**@brief Event structure for @ref BLE_GAP_EVT_QOS_CHANNEL_SURVEY_REPORT. */
+typedef struct
+{
+  int8_t channel_energy[BLE_GAP_CHANNEL_COUNT]; /**< The measured energy on the Bluetooth Low Energy
+                                                     channels, in dBm, indexed by Channel Index.
+                                                     If no measurement is available for the given channel, channel_energy is set to
+                                                     @ref BLE_GAP_POWER_LEVEL_INVALID. */
+} ble_gap_evt_qos_channel_survey_report_t;
+
+/**@brief GAP event structure. */
+typedef struct
+{
+  uint16_t conn_handle;                                     /**< Connection Handle on which event occurred. */
+  union                                                     /**< union alternative identified by evt_id in enclosing struct. */
+  {
+    ble_gap_evt_connected_t                   connected;                    /**< Connected Event Parameters. */
+    ble_gap_evt_disconnected_t                disconnected;                 /**< Disconnected Event Parameters. */
+    ble_gap_evt_conn_param_update_t           conn_param_update;            /**< Connection Parameter Update Parameters. */
+    ble_gap_evt_sec_params_request_t          sec_params_request;           /**< Security Parameters Request Event Parameters. */
+    ble_gap_evt_sec_info_request_t            sec_info_request;             /**< Security Information Request Event Parameters. */
+    ble_gap_evt_passkey_display_t             passkey_display;              /**< Passkey Display Event Parameters. */
+    ble_gap_evt_key_pressed_t                 key_pressed;                  /**< Key Pressed Event Parameters. */
+    ble_gap_evt_auth_key_request_t            auth_key_request;             /**< Authentication Key Request Event Parameters. */
+    ble_gap_evt_lesc_dhkey_request_t          lesc_dhkey_request;           /**< LE Secure Connections DHKey calculation request. */
+    ble_gap_evt_auth_status_t                 auth_status;                  /**< Authentication Status Event Parameters. */
+    ble_gap_evt_conn_sec_update_t             conn_sec_update;              /**< Connection Security Update Event Parameters. */
+    ble_gap_evt_timeout_t                     timeout;                      /**< Timeout Event Parameters. */
+    ble_gap_evt_rssi_changed_t                rssi_changed;                 /**< RSSI Event Parameters. */
+    ble_gap_evt_adv_report_t                  adv_report;                   /**< Advertising Report Event Parameters. */
+    ble_gap_evt_adv_set_terminated_t          adv_set_terminated;           /**< Advertising Set Terminated Event Parameters. */
+    ble_gap_evt_sec_request_t                 sec_request;                  /**< Security Request Event Parameters. */
+    ble_gap_evt_conn_param_update_request_t   conn_param_update_request;    /**< Connection Parameter Update Parameters. */
+    ble_gap_evt_scan_req_report_t             scan_req_report;              /**< Scan Request Report Parameters. */
+    ble_gap_evt_phy_update_request_t          phy_update_request;           /**< PHY Update Request Event Parameters. */
+    ble_gap_evt_phy_update_t                  phy_update;                   /**< PHY Update Parameters. */
+    ble_gap_evt_data_length_update_request_t  data_length_update_request;   /**< Data Length Update Request Event Parameters. */
+    ble_gap_evt_data_length_update_t          data_length_update;           /**< Data Length Update Event Parameters. */
+    ble_gap_evt_qos_channel_survey_report_t   qos_channel_survey_report;    /**< Quality of Service (QoS) Channel Survey Report Parameters. */
+  } params;                                                                 /**< Event Parameters. */
+} ble_gap_evt_t;
+
+
+/**
+ * @brief BLE GAP connection configuration parameters, set with @ref sd_ble_cfg_set.
+ *
+ * @retval ::NRF_ERROR_CONN_COUNT     The connection count for the connection configurations is zero.
+ * @retval ::NRF_ERROR_INVALID_PARAM  One or more of the following is true:
+ *                                    - The sum of conn_count for all connection configurations combined exceeds UINT8_MAX.
+ *                                    - The event length is smaller than @ref BLE_GAP_EVENT_LENGTH_MIN.
+ */
+typedef struct
+{
+  uint8_t  conn_count;     /**< The number of concurrent connections the application can create with this configuration.
+                                The default and minimum value is @ref BLE_GAP_CONN_COUNT_DEFAULT. */
+  uint16_t event_length;   /**< The time set aside for this connection on every connection interval in 1.25 ms units.
+                                The default value is @ref BLE_GAP_EVENT_LENGTH_DEFAULT, the minimum value is @ref BLE_GAP_EVENT_LENGTH_MIN.
+                                The event length and the connection interval are the primary parameters
+                                for setting the throughput of a connection.
+                                See the SoftDevice Specification for details on throughput. */
+} ble_gap_conn_cfg_t;
+
+
+/**
+ * @brief Configuration of maximum concurrent connections in the different connected roles, set with
+ * @ref sd_ble_cfg_set.
+ *
+ * @retval ::NRF_ERROR_CONN_COUNT     The sum of periph_role_count and central_role_count is too
+ *                                    large. The maximum supported sum of concurrent connections is
+ *                                    @ref BLE_GAP_ROLE_COUNT_COMBINED_MAX.
+ * @retval ::NRF_ERROR_INVALID_PARAM  central_sec_count is larger than central_role_count.
+ * @retval ::NRF_ERROR_RESOURCES      The adv_set_count is too large. The maximum
+ *                                    supported advertising handles is
+ *                                    @ref BLE_GAP_ADV_SET_COUNT_MAX.
+ */
+typedef struct
+{
+  uint8_t adv_set_count;      /**< Maximum number of advertising sets. Default value is @ref BLE_GAP_ADV_SET_COUNT_DEFAULT. */
+  uint8_t periph_role_count;  /**< Maximum number of connections concurrently acting as a peripheral. Default value is @ref BLE_GAP_ROLE_COUNT_PERIPH_DEFAULT. */
+  uint8_t central_role_count; /**< Maximum number of connections concurrently acting as a central. Default value is @ref BLE_GAP_ROLE_COUNT_CENTRAL_DEFAULT. */
+  uint8_t central_sec_count;  /**< Number of SMP instances shared between all connections acting as a central. Default value is @ref BLE_GAP_ROLE_COUNT_CENTRAL_SEC_DEFAULT. */
+  uint8_t qos_channel_survey_role_available:1; /**< If set, the Quality of Service (QoS) channel survey module is available to the
+                                                    application using @ref sd_ble_gap_qos_channel_survey_start. */
+} ble_gap_cfg_role_count_t;
+
+
+/**
+ * @brief Device name and its properties, set with @ref sd_ble_cfg_set.
+ *
+ * @note  If the device name is not configured, the default device name will be
+ *        @ref BLE_GAP_DEVNAME_DEFAULT, the maximum device name length will be
+ *        @ref BLE_GAP_DEVNAME_DEFAULT_LEN, vloc will be set to @ref BLE_GATTS_VLOC_STACK and the device name
+ *        will have no write access.
+ *
+ * @note  If @ref max_len is more than @ref BLE_GAP_DEVNAME_DEFAULT_LEN and vloc is set to @ref BLE_GATTS_VLOC_STACK,
+ *        the attribute table size must be increased to have room for the longer device name (see
+ *        @ref sd_ble_cfg_set and @ref ble_gatts_cfg_attr_tab_size_t).
+ *
+ * @note  If vloc is @ref BLE_GATTS_VLOC_STACK :
+ *        - p_value must point to non-volatile memory (flash) or be NULL.
+ *        - If p_value is NULL, the device name will initially be empty.
+ *
+ * @note  If vloc is @ref BLE_GATTS_VLOC_USER :
+ *        - p_value cannot be NULL.
+ *        - If the device name is writable, p_value must point to volatile memory (RAM).
+ *
+ * @retval ::NRF_ERROR_INVALID_PARAM  One or more of the following is true:
+ *                                    - Invalid device name location (vloc).
+ *                                    - Invalid device name security mode.
+ * @retval ::NRF_ERROR_INVALID_LENGTH One or more of the following is true:
+ *                                    - The device name length is invalid (must be between 0 and @ref BLE_GAP_DEVNAME_MAX_LEN).
+ *                                    - The device name length is too long for the given Attribute Table.
+ * @retval ::NRF_ERROR_NOT_SUPPORTED  Device name security mode is not supported.
+ */
+typedef struct
+{
+  ble_gap_conn_sec_mode_t  write_perm;   /**< Write permissions. */
+  uint8_t                  vloc:2;       /**< Value location, see @ref BLE_GATTS_VLOCS.*/
+  uint8_t                 *p_value;      /**< Pointer to where the value (device name) is stored or will be stored. */
+  uint16_t                 current_len;  /**< Current length in bytes of the memory pointed to by p_value.*/
+  uint16_t                 max_len;      /**< Maximum length in bytes of the memory pointed to by p_value.*/
+} ble_gap_cfg_device_name_t;
+
+
+/**@brief Peripheral Preferred Connection Parameters include configuration parameters, set with @ref sd_ble_cfg_set. */
+typedef struct
+{
+  uint8_t include_cfg;     /**< Inclusion configuration of the Peripheral Preferred Connection Parameters characteristic.
+                                See @ref BLE_GAP_CHAR_INCL_CONFIG. Default is @ref BLE_GAP_PPCP_INCL_CONFIG_DEFAULT. */
+} ble_gap_cfg_ppcp_incl_cfg_t;
+
+
+/**@brief Central Address Resolution include configuration parameters, set with @ref sd_ble_cfg_set. */
+typedef struct
+{
+  uint8_t include_cfg;     /**< Inclusion configuration of the Central Address Resolution characteristic.
+                                See @ref BLE_GAP_CHAR_INCL_CONFIG. Default is @ref BLE_GAP_CAR_INCL_CONFIG_DEFAULT. */
+} ble_gap_cfg_car_incl_cfg_t;
+
+
+/**@brief Configuration structure for GAP configurations. */
+typedef union
+{
+  ble_gap_cfg_role_count_t      role_count_cfg;   /**< Role count configuration, cfg_id is @ref BLE_GAP_CFG_ROLE_COUNT. */
+  ble_gap_cfg_device_name_t     device_name_cfg;  /**< Device name configuration, cfg_id is @ref BLE_GAP_CFG_DEVICE_NAME. */
+  ble_gap_cfg_ppcp_incl_cfg_t   ppcp_include_cfg; /**< Peripheral Preferred Connection Parameters characteristic include
+                                                       configuration, cfg_id is @ref BLE_GAP_CFG_PPCP_INCL_CONFIG. */
+  ble_gap_cfg_car_incl_cfg_t    car_include_cfg;  /**< Central Address Resolution characteristic include configuration,
+                                                       cfg_id is @ref BLE_GAP_CFG_CAR_INCL_CONFIG. */
+} ble_gap_cfg_t;
+
+
+/**@brief Channel Map option.
+ *
+ * @details Used with @ref sd_ble_opt_get to get the current channel map
+ *          or @ref sd_ble_opt_set to set a new channel map. When setting the
+ *          channel map, it applies to all current and future connections. When getting the
+ *          current channel map, it applies to a single connection and the connection handle
+ *          must be supplied.
+ *
+ * @note Setting the channel map may take some time, depending on connection parameters.
+ *       The time taken may be different for each connection and the get operation will
+ *       return the previous channel map until the new one has taken effect.
+ *
+ * @note After setting the channel map, by spec it can not be set again until at least 1 s has passed.
+ *       See Bluetooth Specification Version 4.1 Volume 2, Part E, Section 7.3.46.
+ *
+ * @retval ::NRF_SUCCESS Get or set successful.
+ * @retval ::NRF_ERROR_INVALID_PARAM One or more of the following is true:
+ *                                   - Less then two bits in @ref ch_map are set.
+ *                                   - Bits for primary advertising channels (37-39) are set.
+ * @retval ::NRF_ERROR_BUSY Channel map was set again before enough time had passed.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied for get.
+ *
+ */
+typedef struct
+{
+  uint16_t conn_handle;                   /**< Connection Handle (only applicable for get) */
+  uint8_t ch_map[5];                      /**< Channel Map (37-bit). */
+} ble_gap_opt_ch_map_t;
+
+
+/**@brief Local connection latency option.
+ *
+ * @details Local connection latency is a feature which enables the slave to improve
+ *          current consumption by ignoring the slave latency set by the peer. The
+ *          local connection latency can only be set to a multiple of the slave latency,
+ *          and cannot be longer than half of the supervision timeout.
+ *
+ * @details Used with @ref sd_ble_opt_set to set the local connection latency. The
+ *          @ref sd_ble_opt_get is not supported for this option, but the actual
+ *          local connection latency (unless set to NULL) is set as a return parameter
+ *          when setting the option.
+ *
+ * @note The latency set will be truncated down to the closest slave latency event
+ *       multiple, or the nearest multiple before half of the supervision timeout.
+ *
+ * @note The local connection latency is disabled by default, and needs to be enabled for new
+ *       connections and whenever the connection is updated.
+ *
+ * @retval ::NRF_SUCCESS Set successfully.
+ * @retval ::NRF_ERROR_NOT_SUPPORTED Get is not supported.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle parameter.
+ */
+typedef struct
+{
+  uint16_t   conn_handle;                       /**< Connection Handle */
+  uint16_t   requested_latency;                 /**< Requested local connection latency. */
+  uint16_t * p_actual_latency;                  /**< Pointer to storage for the actual local connection latency (can be set to NULL to skip return value). */
+} ble_gap_opt_local_conn_latency_t;
+
+/**@brief Disable slave latency
+ *
+ * @details Used with @ref sd_ble_opt_set to temporarily disable slave latency of a peripheral connection
+ *          (see @ref ble_gap_conn_params_t::slave_latency). And to re-enable it again. When disabled, the
+ *          peripheral will ignore the slave_latency set by the central.
+ *
+ * @note  Shall only be called on peripheral links.
+ *
+ * @retval ::NRF_SUCCESS Set successfully.
+ * @retval ::NRF_ERROR_NOT_SUPPORTED Get is not supported.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle parameter.
+ */
+typedef struct
+{
+  uint16_t   conn_handle;    /**< Connection Handle */
+  uint8_t    disable;        /**< For allowed values see @ref BLE_GAP_SLAVE_LATENCY */
+} ble_gap_opt_slave_latency_disable_t;
+
+/**@brief Passkey Option.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_PERIPH_BONDING_STATIC_PK_MSC}
+ * @endmscs
+ *
+ * @details Structure containing the passkey to be used during pairing. This can be used with @ref
+ *          sd_ble_opt_set to make the SoftDevice use a preprogrammed passkey for authentication
+ *          instead of generating a random one.
+ *
+ * @note Repeated pairing attempts using the same preprogrammed passkey makes pairing vulnerable to MITM attacks.
+ *
+ * @note @ref sd_ble_opt_get is not supported for this option.
+ *
+ */
+typedef struct
+{
+  uint8_t const * p_passkey;                    /**< Pointer to 6-digit ASCII string (digit 0..9 only, no NULL termination) passkey to be used during pairing. If this is NULL, the SoftDevice will generate a random passkey if required.*/
+} ble_gap_opt_passkey_t;
+
+
+/**@brief Compatibility mode 1 option.
+ *
+ * @details This can be used with @ref sd_ble_opt_set to enable and disable
+ *          compatibility mode 1. Compatibility mode 1 is disabled by default.
+ *
+ * @note Compatibility mode 1 enables interoperability with devices that do not support a value of
+ *       0 for the WinOffset parameter in the Link Layer CONNECT_IND packet. This applies to a
+ *       limited set of legacy peripheral devices from another vendor. Enabling this compatibility
+ *       mode will only have an effect if the local device will act as a central device and
+ *       initiate a connection to a peripheral device. In that case it may lead to the connection
+ *       creation taking up to one connection interval longer to complete for all connections.
+ *
+ *  @retval ::NRF_SUCCESS Set successfully.
+ *  @retval ::NRF_ERROR_INVALID_STATE When connection creation is ongoing while mode 1 is set.
+ */
+typedef struct
+{
+   uint8_t enable : 1;                           /**< Enable compatibility mode 1.*/
+} ble_gap_opt_compat_mode_1_t;
+
+
+/**@brief Authenticated payload timeout option.
+ *
+ * @details This can be used with @ref sd_ble_opt_set to change the Authenticated payload timeout to a value other
+ *          than the default of @ref BLE_GAP_AUTH_PAYLOAD_TIMEOUT_MAX.
+ *
+ * @note The authenticated payload timeout event ::BLE_GAP_TIMEOUT_SRC_AUTH_PAYLOAD will be generated
+ *       if auth_payload_timeout time has elapsed without receiving a packet with a valid MIC on an encrypted
+ *       link.
+ *
+ * @note The LE ping procedure will be initiated before the timer expires to give the peer a chance
+ *       to reset the timer. In addition the stack will try to prioritize running of LE ping over other
+ *       activities to increase chances of finishing LE ping before timer expires. To avoid side-effects
+ *       on other activities, it is recommended to use high timeout values.
+ *       Recommended timeout > 2*(connInterval * (6 + connSlaveLatency)).
+ *
+ * @retval ::NRF_SUCCESS Set successfully.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied. auth_payload_timeout was outside of allowed range.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle parameter.
+ */
+typedef struct
+{
+  uint16_t   conn_handle;                       /**< Connection Handle */
+  uint16_t   auth_payload_timeout;              /**< Requested timeout in 10 ms unit, see @ref BLE_GAP_AUTH_PAYLOAD_TIMEOUT. */
+} ble_gap_opt_auth_payload_timeout_t;
+
+/**@brief Option structure for GAP options. */
+typedef union
+{
+  ble_gap_opt_ch_map_t                  ch_map;                    /**< Parameters for the Channel Map option. */
+  ble_gap_opt_local_conn_latency_t      local_conn_latency;        /**< Parameters for the Local connection latency option */
+  ble_gap_opt_passkey_t                 passkey;                   /**< Parameters for the Passkey option.*/
+  ble_gap_opt_compat_mode_1_t           compat_mode_1;             /**< Parameters for the compatibility mode 1 option.*/
+  ble_gap_opt_auth_payload_timeout_t    auth_payload_timeout;      /**< Parameters for the authenticated payload timeout option.*/
+  ble_gap_opt_slave_latency_disable_t   slave_latency_disable;     /**< Parameters for the Disable slave latency option */
+} ble_gap_opt_t;
+
+/**@brief  Connection event triggering parameters. */
+typedef struct
+{
+  uint8_t  ppi_ch_id;                /**< PPI channel to use. This channel should be regarded as reserved until
+                                          connection event PPI task triggering is stopped.
+                                          The PPI channel ID can not be one of the PPI channels reserved by
+                                          the SoftDevice. See @ref NRF_SOC_SD_PPI_CHANNELS_SD_ENABLED_MSK. */
+  uint32_t task_endpoint;            /**< Task Endpoint to trigger. */
+  uint16_t conn_evt_counter_start;   /**< The connection event on which the task triggering should start. */
+  uint16_t period_in_events;         /**< Trigger period. Valid range is [1, 32767].
+                                          If the device is in slave role and slave latency is enabled,
+                                          this parameter should be set to a multiple of (slave latency + 1)
+                                          to ensure low power operation. */
+} ble_gap_conn_event_trigger_t;
+/**@} */
+
+/**@addtogroup BLE_GAP_FUNCTIONS Functions
+ * @{ */
+
+/**@brief Set the local Bluetooth identity address.
+ *
+ *        The local Bluetooth identity address is the address that identifies this device to other peers.
+ *        The address type must be either @ref BLE_GAP_ADDR_TYPE_PUBLIC or @ref BLE_GAP_ADDR_TYPE_RANDOM_STATIC.
+ *
+ * @note  The identity address cannot be changed while advertising, scanning or creating a connection.
+ *
+ * @note  This address will be distributed to the peer during bonding.
+ *        If the address changes, the address stored in the peer device will not be valid and the ability to
+ *        reconnect using the old address will be lost.
+ *
+ * @note  By default the SoftDevice will set an address of type @ref BLE_GAP_ADDR_TYPE_RANDOM_STATIC upon being
+ *        enabled. The address is a random number populated during the IC manufacturing process and remains unchanged
+ *        for the lifetime of each IC.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_ADV_MSC}
+ * @endmscs
+ *
+ * @param[in] p_addr Pointer to address structure.
+ *
+ * @retval ::NRF_SUCCESS Address successfully set.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::BLE_ERROR_GAP_INVALID_BLE_ADDR Invalid address.
+ * @retval ::NRF_ERROR_BUSY The stack is busy, process pending events and retry.
+ * @retval ::NRF_ERROR_INVALID_STATE The identity address cannot be changed while advertising,
+ *                                   scanning or creating a connection.
+ */
+SVCALL(SD_BLE_GAP_ADDR_SET, uint32_t, sd_ble_gap_addr_set(ble_gap_addr_t const *p_addr));
+
+
+/**@brief Get local Bluetooth identity address.
+ *
+ * @note  This will always return the identity address irrespective of the privacy settings,
+ *        i.e. the address type will always be either @ref BLE_GAP_ADDR_TYPE_PUBLIC or @ref BLE_GAP_ADDR_TYPE_RANDOM_STATIC.
+ *
+ * @param[out] p_addr Pointer to address structure to be filled in.
+ *
+ * @retval ::NRF_SUCCESS Address successfully retrieved.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid or NULL pointer supplied.
+ */
+SVCALL(SD_BLE_GAP_ADDR_GET, uint32_t, sd_ble_gap_addr_get(ble_gap_addr_t *p_addr));
+
+
+/**@brief Get the Bluetooth device address used by the advertiser.
+ *
+ * @note  This function will return the local Bluetooth address used in advertising PDUs. When
+ *        using privacy, the SoftDevice will generate a new private address every
+ *        @ref ble_gap_privacy_params_t::private_addr_cycle_s configured using
+ *        @ref sd_ble_gap_privacy_set. Hence depending on when the application calls this API, the
+ *        address returned may not be the latest address that is used in the advertising PDUs.
+ *
+ * @param[in]  adv_handle The advertising handle to get the address from.
+ * @param[out] p_addr     Pointer to address structure to be filled in.
+ *
+ * @retval ::NRF_SUCCESS                  Address successfully retrieved.
+ * @retval ::NRF_ERROR_INVALID_ADDR       Invalid or NULL pointer supplied.
+ * @retval ::BLE_ERROR_INVALID_ADV_HANDLE The provided advertising handle was not found.
+ * @retval ::NRF_ERROR_INVALID_STATE      The advertising set is currently not advertising.
+ */
+SVCALL(SD_BLE_GAP_ADV_ADDR_GET, uint32_t, sd_ble_gap_adv_addr_get(uint8_t adv_handle, ble_gap_addr_t *p_addr));
+
+
+/**@brief Set the active whitelist in the SoftDevice.
+ *
+ * @note  Only one whitelist can be used at a time and the whitelist is shared between the BLE roles.
+ *        The whitelist cannot be set if a BLE role is using the whitelist.
+ *
+ * @note  If an address is resolved using the information in the device identity list, then the whitelist
+ *        filter policy applies to the peer identity address and not the resolvable address sent on air.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_WL_SHARE_MSC}
+ * @mmsc{@ref BLE_GAP_PRIVACY_SCAN_PRIVATE_SCAN_MSC}
+ * @endmscs
+ *
+ * @param[in] pp_wl_addrs Pointer to a whitelist of peer addresses, if NULL the whitelist will be cleared.
+ * @param[in] len         Length of the whitelist, maximum @ref BLE_GAP_WHITELIST_ADDR_MAX_COUNT.
+ *
+ * @retval ::NRF_SUCCESS The whitelist is successfully set/cleared.
+ * @retval ::NRF_ERROR_INVALID_ADDR The whitelist (or one of its entries) provided is invalid.
+ * @retval ::BLE_ERROR_GAP_WHITELIST_IN_USE The whitelist is in use by a BLE role and cannot be set or cleared.
+ * @retval ::BLE_ERROR_GAP_INVALID_BLE_ADDR Invalid address type is supplied.
+ * @retval ::NRF_ERROR_DATA_SIZE The given whitelist size is invalid (zero or too large); this can only return when
+ *                               pp_wl_addrs is not NULL.
+ */
+SVCALL(SD_BLE_GAP_WHITELIST_SET, uint32_t, sd_ble_gap_whitelist_set(ble_gap_addr_t const * const * pp_wl_addrs, uint8_t len));
+
+
+/**@brief Set device identity list.
+ *
+ * @note  Only one device identity list can be used at a time and the list is shared between the BLE roles.
+ *        The device identity list cannot be set if a BLE role is using the list.
+ *
+ * @param[in] pp_id_keys     Pointer to an array of peer identity addresses and peer IRKs, if NULL the device identity list will be cleared.
+ * @param[in] pp_local_irks  Pointer to an array of local IRKs. Each entry in the array maps to the entry in pp_id_keys at the same index.
+ *                           To fill in the list with the currently set device IRK for all peers, set to NULL.
+ * @param[in] len            Length of the device identity list, maximum @ref BLE_GAP_DEVICE_IDENTITIES_MAX_COUNT.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_PRIVACY_ADV_MSC}
+ * @mmsc{@ref BLE_GAP_PRIVACY_SCAN_MSC}
+ * @mmsc{@ref BLE_GAP_PRIVACY_SCAN_PRIVATE_SCAN_MSC}
+ * @mmsc{@ref BLE_GAP_PRIVACY_ADV_DIR_PRIV_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_CONN_PRIV_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_CONN_PRIV_MSC}
+ * @endmscs
+ *
+ * @retval ::NRF_SUCCESS The device identity list successfully set/cleared.
+ * @retval ::NRF_ERROR_INVALID_ADDR The device identity list (or one of its entries) provided is invalid.
+ *                                  This code may be returned if the local IRK list also has an invalid entry.
+ * @retval ::BLE_ERROR_GAP_DEVICE_IDENTITIES_IN_USE The device identity list is in use and cannot be set or cleared.
+ * @retval ::BLE_ERROR_GAP_DEVICE_IDENTITIES_DUPLICATE The device identity list contains multiple entries with the same identity address.
+ * @retval ::BLE_ERROR_GAP_INVALID_BLE_ADDR Invalid address type is supplied.
+ * @retval ::NRF_ERROR_DATA_SIZE The given device identity list size invalid (zero or too large); this can
+ *                               only return when pp_id_keys is not NULL.
+ */
+SVCALL(SD_BLE_GAP_DEVICE_IDENTITIES_SET, uint32_t, sd_ble_gap_device_identities_set(ble_gap_id_key_t const * const * pp_id_keys, ble_gap_irk_t const * const * pp_local_irks, uint8_t len));
+
+
+/**@brief Set privacy settings.
+ *
+ * @note  Privacy settings cannot be changed while advertising, scanning or creating a connection.
+ *
+ * @param[in] p_privacy_params Privacy settings.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_PRIVACY_ADV_MSC}
+ * @mmsc{@ref BLE_GAP_PRIVACY_SCAN_MSC}
+ * @mmsc{@ref BLE_GAP_PRIVACY_ADV_DIR_PRIV_MSC}
+ * @endmscs
+ *
+ * @retval ::NRF_SUCCESS Set successfully.
+ * @retval ::NRF_ERROR_BUSY The stack is busy, process pending events and retry.
+ * @retval ::BLE_ERROR_GAP_INVALID_BLE_ADDR Invalid address type is supplied.
+ * @retval ::NRF_ERROR_INVALID_ADDR The pointer to privacy settings is NULL or invalid.
+ *                                  Otherwise, the p_device_irk pointer in privacy parameter is an invalid pointer.
+ * @retval ::NRF_ERROR_INVALID_PARAM Out of range parameters are provided.
+ * @retval ::NRF_ERROR_NOT_SUPPORTED The SoftDevice does not support privacy if the Central Address Resolution
+                                     characteristic is not configured to be included and the SoftDevice is configured
+                                     to support central roles.
+                                     See @ref ble_gap_cfg_car_incl_cfg_t and @ref ble_gap_cfg_role_count_t.
+ * @retval ::NRF_ERROR_INVALID_STATE Privacy settings cannot be changed while advertising, scanning
+ *                                   or creating a connection.
+ */
+SVCALL(SD_BLE_GAP_PRIVACY_SET, uint32_t, sd_ble_gap_privacy_set(ble_gap_privacy_params_t const *p_privacy_params));
+
+
+/**@brief Get privacy settings.
+ *
+ * @note ::ble_gap_privacy_params_t::p_device_irk must be initialized to NULL or a valid address before this function is called.
+ *       If it is initialized to a valid address, the address pointed to will contain the current device IRK on return.
+ *
+ * @param[in,out] p_privacy_params Privacy settings.
+ *
+ * @retval ::NRF_SUCCESS            Privacy settings read.
+ * @retval ::NRF_ERROR_INVALID_ADDR The pointer given for returning the privacy settings may be NULL or invalid.
+ *                                  Otherwise, the p_device_irk pointer in privacy parameter is an invalid pointer.
+ */
+SVCALL(SD_BLE_GAP_PRIVACY_GET, uint32_t, sd_ble_gap_privacy_get(ble_gap_privacy_params_t *p_privacy_params));
+
+
+/**@brief Configure an advertising set. Set, clear or update advertising and scan response data.
+ *
+ * @note  The format of the advertising data will be checked by this call to ensure interoperability.
+ *        Limitations imposed by this API call to the data provided include having a flags data type in the scan response data and
+ *        duplicating the local name in the advertising data and scan response data.
+ *
+ * @note In order to update advertising data while advertising, new advertising buffers must be provided.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_ADV_MSC}
+ * @mmsc{@ref BLE_GAP_WL_SHARE_MSC}
+ * @endmscs
+ *
+ * @param[in,out] p_adv_handle                         Provide a pointer to a handle containing @ref BLE_GAP_ADV_SET_HANDLE_NOT_SET to configure
+ *                                                     a new advertising set. On success, a new handle is then returned through the pointer.
+ *                                                     Provide a pointer to an existing advertising handle to configure an existing advertising set.
+ * @param[in]     p_adv_data                           Advertising data. If set to NULL, no advertising data will be used. See @ref ble_gap_adv_data_t.
+ * @param[in]     p_adv_params                         Advertising parameters. When this function is used to update advertising data while advertising,
+ *                                                     this parameter must be NULL. See @ref ble_gap_adv_params_t.
+ *
+ * @retval ::NRF_SUCCESS                               Advertising set successfully configured.
+ * @retval ::NRF_ERROR_INVALID_PARAM                   Invalid parameter(s) supplied:
+ *                                                      - Invalid advertising data configuration specified. See @ref ble_gap_adv_data_t.
+ *                                                      - Invalid configuration of p_adv_params. See @ref ble_gap_adv_params_t.
+ *                                                      - Use of whitelist requested but whitelist has not been set,
+ *                                                        see @ref sd_ble_gap_whitelist_set.
+ * @retval ::BLE_ERROR_GAP_INVALID_BLE_ADDR            ble_gap_adv_params_t::p_peer_addr is invalid.
+ * @retval ::NRF_ERROR_INVALID_STATE                   Invalid state to perform operation. Either:
+ *                                                     - It is invalid to provide non-NULL advertising set parameters while advertising.
+ *                                                     - It is invalid to provide the same data buffers while advertising. To update
+ *                                                       advertising data, provide new advertising buffers.
+ * @retval ::BLE_ERROR_GAP_DISCOVERABLE_WITH_WHITELIST Discoverable mode and whitelist incompatible.
+ * @retval ::BLE_ERROR_INVALID_ADV_HANDLE              The provided advertising handle was not found. Use @ref BLE_GAP_ADV_SET_HANDLE_NOT_SET to
+ *                                                     configure a new advertising handle.
+ * @retval ::NRF_ERROR_INVALID_ADDR                    Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_FLAGS                   Invalid combination of advertising flags supplied.
+ * @retval ::NRF_ERROR_INVALID_DATA                    Invalid data type(s) supplied. Check the advertising data format specification
+ *                                                     given in Bluetooth Specification Version 5.0, Volume 3, Part C, Chapter 11.
+ * @retval ::NRF_ERROR_INVALID_LENGTH                  Invalid data length(s) supplied.
+ * @retval ::NRF_ERROR_NOT_SUPPORTED                   Unsupported data length or advertising parameter configuration.
+ * @retval ::NRF_ERROR_NO_MEM                          Not enough memory to configure a new advertising handle. Update an
+ *                                                     existing advertising handle instead.
+ * @retval ::BLE_ERROR_GAP_UUID_LIST_MISMATCH Invalid UUID list supplied.
+ */
+SVCALL(SD_BLE_GAP_ADV_SET_CONFIGURE, uint32_t, sd_ble_gap_adv_set_configure(uint8_t *p_adv_handle, ble_gap_adv_data_t const *p_adv_data, ble_gap_adv_params_t const *p_adv_params));
+
+
+/**@brief Start advertising (GAP Discoverable, Connectable modes, Broadcast Procedure).
+ *
+ * @note Only one advertiser may be active at any time.
+ *
+ * @note If privacy is enabled, the advertiser's private address will be refreshed when this function is called.
+ *       See @ref sd_ble_gap_privacy_set().
+ *
+ * @events
+ * @event{@ref BLE_GAP_EVT_CONNECTED, Generated after connection has been established through connectable advertising.}
+ * @event{@ref BLE_GAP_EVT_ADV_SET_TERMINATED, Advertising set has terminated.}
+ * @event{@ref BLE_GAP_EVT_SCAN_REQ_REPORT, A scan request was received.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_ADV_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_CONN_PRIV_MSC}
+ * @mmsc{@ref BLE_GAP_PRIVACY_ADV_DIR_PRIV_MSC}
+ * @mmsc{@ref BLE_GAP_WL_SHARE_MSC}
+ * @endmscs
+ *
+ * @param[in] adv_handle   Advertising handle to advertise on, received from @ref sd_ble_gap_adv_set_configure.
+ * @param[in] conn_cfg_tag Tag identifying a configuration set by @ref sd_ble_cfg_set or
+ *                         @ref BLE_CONN_CFG_TAG_DEFAULT to use the default connection configuration. For non-connectable
+ *                         advertising, this is ignored.
+ *
+ * @retval ::NRF_SUCCESS                  The BLE stack has started advertising.
+ * @retval ::NRF_ERROR_INVALID_STATE      adv_handle is not configured or already advertising.
+ * @retval ::NRF_ERROR_CONN_COUNT         The limit of available connections for this connection configuration
+ *                                        tag has been reached; connectable advertiser cannot be started.
+ *                                        To increase the number of available connections,
+ *                                        use @ref sd_ble_cfg_set with @ref BLE_GAP_CFG_ROLE_COUNT or @ref BLE_CONN_CFG_GAP.
+ * @retval ::BLE_ERROR_INVALID_ADV_HANDLE Advertising handle not found. Configure a new adveriting handle with @ref sd_ble_gap_adv_set_configure.
+ * @retval ::NRF_ERROR_NOT_FOUND          conn_cfg_tag not found.
+ * @retval ::NRF_ERROR_INVALID_PARAM      Invalid parameter(s) supplied:
+ *                                        - Invalid configuration of p_adv_params. See @ref ble_gap_adv_params_t.
+ *                                        - Use of whitelist requested but whitelist has not been set, see @ref sd_ble_gap_whitelist_set.
+ * @retval ::NRF_ERROR_RESOURCES          Either:
+ *                                        - adv_handle is configured with connectable advertising, but the event_length parameter
+ *                                          associated with conn_cfg_tag is too small to be able to establish a connection on
+ *                                          the selected advertising phys. Use @ref sd_ble_cfg_set to increase the event length.
+ *                                        - Not enough BLE role slots available.
+                                            Stop one or more currently active roles (Central, Peripheral, Broadcaster or Observer) and try again.
+ *                                        - p_adv_params is configured with connectable advertising, but the event_length parameter
+ *                                          associated with conn_cfg_tag is too small to be able to establish a connection on
+ *                                          the selected advertising phys. Use @ref sd_ble_cfg_set to increase the event length.
+ */
+SVCALL(SD_BLE_GAP_ADV_START, uint32_t, sd_ble_gap_adv_start(uint8_t adv_handle, uint8_t conn_cfg_tag));
+
+
+/**@brief Stop advertising (GAP Discoverable, Connectable modes, Broadcast Procedure).
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_ADV_MSC}
+ * @mmsc{@ref BLE_GAP_WL_SHARE_MSC}
+ * @endmscs
+ *
+ * @param[in] adv_handle The advertising handle that should stop advertising.
+ *
+ * @retval ::NRF_SUCCESS The BLE stack has stopped advertising.
+ * @retval ::BLE_ERROR_INVALID_ADV_HANDLE Invalid advertising handle.
+ * @retval ::NRF_ERROR_INVALID_STATE The advertising handle is not advertising.
+ */
+SVCALL(SD_BLE_GAP_ADV_STOP, uint32_t, sd_ble_gap_adv_stop(uint8_t adv_handle));
+
+
+
+/**@brief Update connection parameters.
+ *
+ * @details In the central role this will initiate a Link Layer connection parameter update procedure,
+ *          otherwise in the peripheral role, this will send the corresponding L2CAP request and wait for
+ *          the central to perform the procedure. In both cases, and regardless of success or failure, the application
+ *          will be informed of the result with a @ref BLE_GAP_EVT_CONN_PARAM_UPDATE event.
+ *
+ * @details This function can be used as a central both to reply to a @ref BLE_GAP_EVT_CONN_PARAM_UPDATE_REQUEST or to start the procedure unrequested.
+ *
+ * @events
+ * @event{@ref BLE_GAP_EVT_CONN_PARAM_UPDATE, Result of the connection parameter update procedure.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_CPU_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_ENC_AUTH_MUTEX_MSC}
+ * @mmsc{@ref BLE_GAP_MULTILINK_CPU_MSC}
+ * @mmsc{@ref BLE_GAP_MULTILINK_CTRL_PROC_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_CPU_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle Connection handle.
+ * @param[in] p_conn_params  Pointer to desired connection parameters. If NULL is provided on a peripheral role,
+ *                           the parameters in the PPCP characteristic of the GAP service will be used instead.
+ *                           If NULL is provided on a central role and in response to a @ref BLE_GAP_EVT_CONN_PARAM_UPDATE_REQUEST, the peripheral request will be rejected
+ *
+ * @retval ::NRF_SUCCESS The Connection Update procedure has been started successfully.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied, check parameter limits and constraints.
+ * @retval ::NRF_ERROR_INVALID_STATE Disconnection in progress or link has not been established.
+ * @retval ::NRF_ERROR_BUSY Procedure already in progress, wait for pending procedures to complete and retry.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ * @retval ::NRF_ERROR_NO_MEM Not enough memory to complete operation.
+ */
+SVCALL(SD_BLE_GAP_CONN_PARAM_UPDATE, uint32_t, sd_ble_gap_conn_param_update(uint16_t conn_handle, ble_gap_conn_params_t const *p_conn_params));
+
+
+/**@brief Disconnect (GAP Link Termination).
+ *
+ * @details This call initiates the disconnection procedure, and its completion will be communicated to the application
+ *          with a @ref BLE_GAP_EVT_DISCONNECTED event.
+ *
+ * @events
+ * @event{@ref BLE_GAP_EVT_DISCONNECTED, Generated when disconnection procedure is complete.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_CONN_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle Connection handle.
+ * @param[in] hci_status_code HCI status code, see @ref BLE_HCI_STATUS_CODES (accepted values are @ref BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION and @ref BLE_HCI_CONN_INTERVAL_UNACCEPTABLE).
+ *
+ * @retval ::NRF_SUCCESS The disconnection procedure has been started successfully.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ * @retval ::NRF_ERROR_INVALID_STATE Disconnection in progress or link has not been established.
+ */
+SVCALL(SD_BLE_GAP_DISCONNECT, uint32_t, sd_ble_gap_disconnect(uint16_t conn_handle, uint8_t hci_status_code));
+
+
+/**@brief Set the radio's transmit power.
+ *
+ * @param[in] role The role to set the transmit power for, see @ref BLE_GAP_TX_POWER_ROLES for
+ *                 possible roles.
+ * @param[in] handle   The handle parameter is interpreted depending on role:
+ *                     - If role is @ref BLE_GAP_TX_POWER_ROLE_CONN, this value is the specific connection handle.
+ *                     - If role is @ref BLE_GAP_TX_POWER_ROLE_ADV, the advertising set identified with the advertising handle,
+ *                       will use the specified transmit power, and include it in the advertising packet headers if
+ *                       @ref ble_gap_adv_properties_t::include_tx_power set.
+ *                     - For all other roles handle is ignored.
+ * @param[in] tx_power Radio transmit power in dBm (see note for accepted values).
+ *
+ * @note Supported tx_power values: -40dBm, -20dBm, -16dBm, -12dBm, -8dBm, -4dBm, 0dBm, +3dBm and +4dBm.
+  *       In addition, on some chips following values are supported: +2dBm, +5dBm, +6dBm, +7dBm and +8dBm.
+ *       Setting these values on a chip that does not support them will result in undefined behaviour.
+  * @note The initiator will have the same transmit power as the scanner.
+ * @note When a connection is created it will inherit the transmit power from the initiator or
+ *       advertiser leading to the connection.
+ *
+ * @retval ::NRF_SUCCESS Successfully changed the transmit power.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ * @retval ::BLE_ERROR_INVALID_ADV_HANDLE Advertising handle not found.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ */
+SVCALL(SD_BLE_GAP_TX_POWER_SET, uint32_t, sd_ble_gap_tx_power_set(uint8_t role, uint16_t handle, int8_t tx_power));
+
+
+/**@brief Set GAP Appearance value.
+ *
+ * @param[in] appearance Appearance (16-bit), see @ref BLE_APPEARANCES.
+ *
+ * @retval ::NRF_SUCCESS  Appearance value set successfully.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ */
+SVCALL(SD_BLE_GAP_APPEARANCE_SET, uint32_t, sd_ble_gap_appearance_set(uint16_t appearance));
+
+
+/**@brief Get GAP Appearance value.
+ *
+ * @param[out] p_appearance Pointer to appearance (16-bit) to be filled in, see @ref BLE_APPEARANCES.
+ *
+ * @retval ::NRF_SUCCESS Appearance value retrieved successfully.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ */
+SVCALL(SD_BLE_GAP_APPEARANCE_GET, uint32_t, sd_ble_gap_appearance_get(uint16_t *p_appearance));
+
+
+/**@brief Set GAP Peripheral Preferred Connection Parameters.
+ *
+ * @param[in] p_conn_params Pointer to a @ref ble_gap_conn_params_t structure with the desired parameters.
+ *
+ * @retval ::NRF_SUCCESS Peripheral Preferred Connection Parameters set successfully.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ * @retval ::NRF_ERROR_NOT_SUPPORTED The characteristic is not included in the Attribute Table,
+                                     see @ref ble_gap_cfg_ppcp_incl_cfg_t.
+ */
+SVCALL(SD_BLE_GAP_PPCP_SET, uint32_t, sd_ble_gap_ppcp_set(ble_gap_conn_params_t const *p_conn_params));
+
+
+/**@brief Get GAP Peripheral Preferred Connection Parameters.
+ *
+ * @param[out] p_conn_params Pointer to a @ref ble_gap_conn_params_t structure where the parameters will be stored.
+ *
+ * @retval ::NRF_SUCCESS Peripheral Preferred Connection Parameters retrieved successfully.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_NOT_SUPPORTED The characteristic is not included in the Attribute Table,
+                                     see @ref ble_gap_cfg_ppcp_incl_cfg_t.
+ */
+SVCALL(SD_BLE_GAP_PPCP_GET, uint32_t, sd_ble_gap_ppcp_get(ble_gap_conn_params_t *p_conn_params));
+
+
+/**@brief Set GAP device name.
+ *
+ * @note  If the device name is located in application flash memory (see @ref ble_gap_cfg_device_name_t),
+ *        it cannot be changed. Then @ref NRF_ERROR_FORBIDDEN will be returned.
+ *
+ * @param[in] p_write_perm Write permissions for the Device Name characteristic, see @ref ble_gap_conn_sec_mode_t.
+ * @param[in] p_dev_name Pointer to a UTF-8 encoded, <b>non NULL-terminated</b> string.
+ * @param[in] len Length of the UTF-8, <b>non NULL-terminated</b> string pointed to by p_dev_name in octets (must be smaller or equal than @ref BLE_GAP_DEVNAME_MAX_LEN).
+ *
+ * @retval ::NRF_SUCCESS GAP device name and permissions set successfully.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ * @retval ::NRF_ERROR_DATA_SIZE Invalid data size(s) supplied.
+ * @retval ::NRF_ERROR_FORBIDDEN Device name is not writable.
+ */
+SVCALL(SD_BLE_GAP_DEVICE_NAME_SET, uint32_t, sd_ble_gap_device_name_set(ble_gap_conn_sec_mode_t const *p_write_perm, uint8_t const *p_dev_name, uint16_t len));
+
+
+/**@brief Get GAP device name.
+ *
+ * @note  If the device name is longer than the size of the supplied buffer,
+ *        p_len will return the complete device name length,
+ *        and not the number of bytes actually returned in p_dev_name.
+ *        The application may use this information to allocate a suitable buffer size.
+ *
+ * @param[out]    p_dev_name Pointer to an empty buffer where the UTF-8 <b>non NULL-terminated</b> string will be placed. Set to NULL to obtain the complete device name length.
+ * @param[in,out] p_len      Length of the buffer pointed by p_dev_name, complete device name length on output.
+ *
+ * @retval ::NRF_SUCCESS GAP device name retrieved successfully.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_DATA_SIZE Invalid data size(s) supplied.
+ */
+SVCALL(SD_BLE_GAP_DEVICE_NAME_GET, uint32_t, sd_ble_gap_device_name_get(uint8_t *p_dev_name, uint16_t *p_len));
+
+
+/**@brief Initiate the GAP Authentication procedure.
+ *
+ * @details In the central role, this function will send an SMP Pairing Request (or an SMP Pairing Failed if rejected),
+ *          otherwise in the peripheral role, an SMP Security Request will be sent.
+ *
+ * @events
+ * @event{Depending on the security parameters set and the packet exchanges with the peer\, the following events may be generated:}
+ * @event{@ref BLE_GAP_EVT_SEC_PARAMS_REQUEST}
+ * @event{@ref BLE_GAP_EVT_SEC_INFO_REQUEST}
+ * @event{@ref BLE_GAP_EVT_PASSKEY_DISPLAY}
+ * @event{@ref BLE_GAP_EVT_KEY_PRESSED}
+ * @event{@ref BLE_GAP_EVT_AUTH_KEY_REQUEST}
+ * @event{@ref BLE_GAP_EVT_LESC_DHKEY_REQUEST}
+ * @event{@ref BLE_GAP_EVT_CONN_SEC_UPDATE}
+ * @event{@ref BLE_GAP_EVT_AUTH_STATUS}
+ * @event{@ref BLE_GAP_EVT_TIMEOUT}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_PERIPH_SEC_REQ_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_SEC_REQ_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_ENC_AUTH_MUTEX_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_PAIRING_JW_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_BONDING_JW_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_BONDING_PK_PERIPH_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_BONDING_PK_PERIPH_OOB_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_PAIRING_JW_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_BONDING_NC_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_BONDING_PKE_PD_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_BONDING_PKE_CD_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_BONDING_OOB_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle Connection handle.
+ * @param[in] p_sec_params Pointer to the @ref ble_gap_sec_params_t structure with the security parameters to be used during the pairing or bonding procedure.
+ *                         In the peripheral role, only the bond, mitm, lesc and keypress fields of this structure are used.
+ *                         In the central role, this pointer may be NULL to reject a Security Request.
+ *
+ * @retval ::NRF_SUCCESS Successfully initiated authentication procedure.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid state to perform operation. Either:
+ *                                   - No link has been established.
+ *                                   - An encryption is already executing or queued.
+ * @retval ::NRF_ERROR_NO_MEM The maximum number of authentication procedures that can run in parallel for the given role is reached.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ * @retval ::NRF_ERROR_NOT_SUPPORTED Setting of sign or link fields in @ref ble_gap_sec_kdist_t not supported.
+ *                                   Distribution of own Identity Information is only supported if the Central
+ *                                   Address Resolution characteristic is configured to be included or
+ *                                   the Softdevice is configured to support peripheral roles only.
+ *                                   See @ref ble_gap_cfg_car_incl_cfg_t and @ref ble_gap_cfg_role_count_t.
+ * @retval ::NRF_ERROR_TIMEOUT A SMP timeout has occurred, and further SMP operations on this link is prohibited.
+ */
+SVCALL(SD_BLE_GAP_AUTHENTICATE, uint32_t, sd_ble_gap_authenticate(uint16_t conn_handle, ble_gap_sec_params_t const *p_sec_params));
+
+
+/**@brief Reply with GAP security parameters.
+ *
+ * @details This function is only used to reply to a @ref BLE_GAP_EVT_SEC_PARAMS_REQUEST, calling it at other times will result in an @ref NRF_ERROR_INVALID_STATE.
+ * @note    If the call returns an error code, the request is still pending, and the reply call may be repeated with corrected parameters.
+ *
+ * @events
+ * @event{This function is used during authentication procedures, see the list of events in the documentation of @ref sd_ble_gap_authenticate.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_PERIPH_PAIRING_JW_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_BONDING_JW_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_BONDING_PK_PERIPH_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_BONDING_PK_CENTRAL_OOB_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_BONDING_STATIC_PK_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_PAIRING_CONFIRM_FAIL_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_LESC_PAIRING_JW_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_LESC_BONDING_NC_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_LESC_BONDING_PKE_PD_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_LESC_BONDING_PKE_CD_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_LESC_BONDING_OOB_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_PAIRING_KS_TOO_SMALL_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_PAIRING_APP_ERROR_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_PAIRING_REMOTE_PAIRING_FAIL_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_PAIRING_TIMEOUT_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_PAIRING_JW_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_BONDING_JW_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_BONDING_PK_PERIPH_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_BONDING_PK_PERIPH_OOB_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_PAIRING_JW_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_BONDING_NC_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_BONDING_PKE_PD_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_BONDING_PKE_CD_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_BONDING_OOB_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle Connection handle.
+ * @param[in] sec_status Security status, see @ref BLE_GAP_SEC_STATUS.
+ * @param[in] p_sec_params Pointer to a @ref ble_gap_sec_params_t security parameters structure. In the central role this must be set to NULL, as the parameters have
+ *                         already been provided during a previous call to @ref sd_ble_gap_authenticate.
+ * @param[in,out] p_sec_keyset Pointer to a @ref ble_gap_sec_keyset_t security keyset structure. Any keys generated and/or distributed as a result of the ongoing security procedure
+ *                         will be stored into the memory referenced by the pointers inside this structure. The keys will be stored and available to the application
+ *                         upon reception of a @ref BLE_GAP_EVT_AUTH_STATUS event.
+ *                         Note that the SoftDevice expects the application to provide memory for storing the
+ *                         peer's keys. So it must be ensured that the relevant pointers inside this structure are not NULL. The pointers to the local key
+ *                         can, however, be NULL, in which case, the local key data will not be available to the application upon reception of the
+ *                         @ref BLE_GAP_EVT_AUTH_STATUS event.
+ *
+ * @retval ::NRF_SUCCESS Successfully accepted security parameter from the application.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_BUSY The stack is busy, process pending events and retry.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ * @retval ::NRF_ERROR_INVALID_STATE Security parameters has not been requested.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ * @retval ::NRF_ERROR_NOT_SUPPORTED Setting of sign or link fields in @ref ble_gap_sec_kdist_t not supported.
+ *                                   Distribution of own Identity Information is only supported if the Central
+ *                                   Address Resolution characteristic is configured to be included or
+ *                                   the Softdevice is configured to support peripheral roles only.
+ *                                   See @ref ble_gap_cfg_car_incl_cfg_t and @ref ble_gap_cfg_role_count_t.
+ */
+SVCALL(SD_BLE_GAP_SEC_PARAMS_REPLY, uint32_t, sd_ble_gap_sec_params_reply(uint16_t conn_handle, uint8_t sec_status, ble_gap_sec_params_t const *p_sec_params, ble_gap_sec_keyset_t const *p_sec_keyset));
+
+
+/**@brief Reply with an authentication key.
+ *
+ * @details This function is only used to reply to a @ref BLE_GAP_EVT_AUTH_KEY_REQUEST or a @ref BLE_GAP_EVT_PASSKEY_DISPLAY, calling it at other times will result in an @ref NRF_ERROR_INVALID_STATE.
+ * @note    If the call returns an error code, the request is still pending, and the reply call may be repeated with corrected parameters.
+ *
+ * @events
+ * @event{This function is used during authentication procedures\, see the list of events in the documentation of @ref sd_ble_gap_authenticate.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_PERIPH_BONDING_PK_CENTRAL_OOB_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_LESC_BONDING_NC_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_LESC_BONDING_PKE_CD_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_BONDING_PK_PERIPH_OOB_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_BONDING_NC_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_BONDING_PKE_CD_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle Connection handle.
+ * @param[in] key_type See @ref BLE_GAP_AUTH_KEY_TYPES.
+ * @param[in] p_key If key type is @ref BLE_GAP_AUTH_KEY_TYPE_NONE, then NULL.
+ *                  If key type is @ref BLE_GAP_AUTH_KEY_TYPE_PASSKEY, then a 6-byte ASCII string (digit 0..9 only, no NULL termination)
+ *                     or NULL when confirming LE Secure Connections Numeric Comparison.
+ *                  If key type is @ref BLE_GAP_AUTH_KEY_TYPE_OOB, then a 16-byte OOB key value in little-endian format.
+ *
+ * @retval ::NRF_SUCCESS Authentication key successfully set.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ * @retval ::NRF_ERROR_INVALID_STATE Authentication key has not been requested.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ */
+SVCALL(SD_BLE_GAP_AUTH_KEY_REPLY, uint32_t, sd_ble_gap_auth_key_reply(uint16_t conn_handle, uint8_t key_type, uint8_t const *p_key));
+
+
+/**@brief Reply with an LE Secure connections DHKey.
+ *
+ * @details This function is only used to reply to a @ref BLE_GAP_EVT_LESC_DHKEY_REQUEST, calling it at other times will result in an @ref NRF_ERROR_INVALID_STATE.
+ * @note    If the call returns an error code, the request is still pending, and the reply call may be repeated with corrected parameters.
+ *
+ * @events
+ * @event{This function is used during authentication procedures\, see the list of events in the documentation of @ref sd_ble_gap_authenticate.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_PERIPH_LESC_PAIRING_JW_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_LESC_BONDING_NC_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_LESC_BONDING_PKE_PD_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_LESC_BONDING_PKE_CD_MSC}
+ * @mmsc{@ref BLE_GAP_PERIPH_LESC_BONDING_OOB_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_PAIRING_JW_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_BONDING_NC_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_BONDING_PKE_PD_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_BONDING_PKE_CD_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_BONDING_OOB_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle Connection handle.
+ * @param[in] p_dhkey LE Secure Connections DHKey.
+ *
+ * @retval ::NRF_SUCCESS DHKey successfully set.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid state to perform operation. Either:
+ *                                   - The peer is not authenticated.
+ *                                   - The application has not pulled a @ref BLE_GAP_EVT_LESC_DHKEY_REQUEST event.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ */
+SVCALL(SD_BLE_GAP_LESC_DHKEY_REPLY, uint32_t, sd_ble_gap_lesc_dhkey_reply(uint16_t conn_handle, ble_gap_lesc_dhkey_t const *p_dhkey));
+
+
+/**@brief Notify the peer of a local keypress.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_PERIPH_LESC_BONDING_PKE_CD_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_BONDING_PKE_CD_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle Connection handle.
+ * @param[in] kp_not See @ref BLE_GAP_KP_NOT_TYPES.
+ *
+ * @retval ::NRF_SUCCESS Keypress notification successfully queued for transmission.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid state to perform operation. Either:
+ *                                   - Authentication key not requested.
+ *                                   - Passkey has not been entered.
+ *                                   - Keypresses have not been enabled by both peers.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ * @retval ::NRF_ERROR_BUSY The BLE stack is busy. Retry at later time.
+ */
+SVCALL(SD_BLE_GAP_KEYPRESS_NOTIFY, uint32_t, sd_ble_gap_keypress_notify(uint16_t conn_handle, uint8_t kp_not));
+
+
+/**@brief Generate a set of OOB data to send to a peer out of band.
+ *
+ * @note  The @ref ble_gap_addr_t included in the OOB data returned will be the currently active one (or, if a connection has already been established,
+ *        the one used during connection setup). The application may manually overwrite it with an updated value.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_PERIPH_LESC_BONDING_OOB_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_BONDING_OOB_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle Connection handle. Can be @ref BLE_CONN_HANDLE_INVALID if a BLE connection has not been established yet.
+ * @param[in] p_pk_own LE Secure Connections local P-256 Public Key.
+ * @param[out] p_oobd_own The OOB data to be sent out of band to a peer.
+ *
+ * @retval ::NRF_SUCCESS OOB data successfully generated.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ */
+SVCALL(SD_BLE_GAP_LESC_OOB_DATA_GET, uint32_t, sd_ble_gap_lesc_oob_data_get(uint16_t conn_handle, ble_gap_lesc_p256_pk_t const *p_pk_own, ble_gap_lesc_oob_data_t *p_oobd_own));
+
+/**@brief Provide the OOB data sent/received out of band.
+ *
+ * @note  An authentication procedure with OOB selected as an algorithm must be in progress when calling this function.
+ * @note  A @ref BLE_GAP_EVT_LESC_DHKEY_REQUEST event with the oobd_req set to 1 must have been received prior to calling this function.
+ *
+ * @events
+ * @event{This function is used during authentication procedures\, see the list of events in the documentation of @ref sd_ble_gap_authenticate.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_PERIPH_LESC_BONDING_OOB_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_LESC_BONDING_OOB_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle Connection handle.
+ * @param[in] p_oobd_own The OOB data sent out of band to a peer or NULL if the peer has not received OOB data.
+ *                       Must correspond to @ref ble_gap_sec_params_t::oob flag in @ref BLE_GAP_EVT_SEC_PARAMS_REQUEST.
+ * @param[in] p_oobd_peer The OOB data received out of band from a peer or NULL if none received.
+ *                        Must correspond to @ref ble_gap_sec_params_t::oob flag
+ *                        in @ref sd_ble_gap_authenticate in the central role or
+ *                        in @ref sd_ble_gap_sec_params_reply in the peripheral role.
+ *
+ * @retval ::NRF_SUCCESS OOB data accepted.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid state to perform operation. Either:
+ *                                   - Authentication key not requested
+ *                                   - Not expecting LESC OOB data
+ *                                   - Have not actually exchanged passkeys.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ */
+SVCALL(SD_BLE_GAP_LESC_OOB_DATA_SET, uint32_t, sd_ble_gap_lesc_oob_data_set(uint16_t conn_handle, ble_gap_lesc_oob_data_t const *p_oobd_own, ble_gap_lesc_oob_data_t const *p_oobd_peer));
+
+
+/**@brief Initiate GAP Encryption procedure.
+ *
+ * @details In the central role, this function will initiate the encryption procedure using the encryption information provided.
+ *
+ * @events
+ * @event{@ref BLE_GAP_EVT_CONN_SEC_UPDATE, The connection security has been updated.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_CENTRAL_ENC_AUTH_MUTEX_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_ENC_MSC}
+ * @mmsc{@ref BLE_GAP_MULTILINK_CTRL_PROC_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_SEC_REQ_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle Connection handle.
+ * @param[in] p_master_id Pointer to a @ref ble_gap_master_id_t master identification structure.
+ * @param[in] p_enc_info  Pointer to a @ref ble_gap_enc_info_t encryption information structure.
+ *
+ * @retval ::NRF_SUCCESS Successfully initiated authentication procedure.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_STATE No link has been established.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ * @retval ::BLE_ERROR_INVALID_ROLE Operation is not supported in the Peripheral role.
+ * @retval ::NRF_ERROR_BUSY Procedure already in progress or not allowed at this time, wait for pending procedures to complete and retry.
+ */
+SVCALL(SD_BLE_GAP_ENCRYPT, uint32_t, sd_ble_gap_encrypt(uint16_t conn_handle, ble_gap_master_id_t const *p_master_id, ble_gap_enc_info_t const *p_enc_info));
+
+
+/**@brief Reply with GAP security information.
+ *
+ * @details This function is only used to reply to a @ref BLE_GAP_EVT_SEC_INFO_REQUEST, calling it at other times will result in @ref NRF_ERROR_INVALID_STATE.
+ * @note    If the call returns an error code, the request is still pending, and the reply call may be repeated with corrected parameters.
+ * @note    Data signing is not yet supported, and p_sign_info must therefore be NULL.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_PERIPH_ENC_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle Connection handle.
+ * @param[in] p_enc_info Pointer to a @ref ble_gap_enc_info_t encryption information structure. May be NULL to signal none is available.
+ * @param[in] p_id_info Pointer to a @ref ble_gap_irk_t identity information structure. May be NULL to signal none is available.
+ * @param[in] p_sign_info Pointer to a @ref ble_gap_sign_info_t signing information structure. May be NULL to signal none is available.
+ *
+ * @retval ::NRF_SUCCESS Successfully accepted security information.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid state to perform operation. Either:
+ *                                   - No link has been established.
+ *                                   - No @ref BLE_GAP_EVT_SEC_INFO_REQUEST pending.
+ *                                   - Encryption information provided by the app without being requested. See @ref ble_gap_evt_sec_info_request_t::enc_info.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ */
+SVCALL(SD_BLE_GAP_SEC_INFO_REPLY, uint32_t, sd_ble_gap_sec_info_reply(uint16_t conn_handle, ble_gap_enc_info_t const *p_enc_info, ble_gap_irk_t const *p_id_info, ble_gap_sign_info_t const *p_sign_info));
+
+
+/**@brief Get the current connection security.
+ *
+ * @param[in]  conn_handle Connection handle.
+ * @param[out] p_conn_sec  Pointer to a @ref ble_gap_conn_sec_t structure to be filled in.
+ *
+ * @retval ::NRF_SUCCESS Current connection security successfully retrieved.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ */
+SVCALL(SD_BLE_GAP_CONN_SEC_GET, uint32_t, sd_ble_gap_conn_sec_get(uint16_t conn_handle, ble_gap_conn_sec_t *p_conn_sec));
+
+
+/**@brief Start reporting the received signal strength to the application.
+ *
+ *        A new event is reported whenever the RSSI value changes, until @ref sd_ble_gap_rssi_stop is called.
+ *
+ * @events
+ * @event{@ref BLE_GAP_EVT_RSSI_CHANGED, New RSSI data available. How often the event is generated is
+ *                                       dependent on the settings of the <code>threshold_dbm</code>
+ *                                       and <code>skip_count</code> input parameters.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_CENTRAL_RSSI_READ_MSC}
+ * @mmsc{@ref BLE_GAP_RSSI_FILT_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle        Connection handle.
+ * @param[in] threshold_dbm      Minimum change in dBm before triggering the @ref BLE_GAP_EVT_RSSI_CHANGED event. Events are disabled if threshold_dbm equals @ref BLE_GAP_RSSI_THRESHOLD_INVALID.
+ * @param[in] skip_count         Number of RSSI samples with a change of threshold_dbm or more before sending a new @ref BLE_GAP_EVT_RSSI_CHANGED event.
+ *
+ * @retval ::NRF_SUCCESS                   Successfully activated RSSI reporting.
+ * @retval ::NRF_ERROR_INVALID_STATE       RSSI reporting is already ongoing.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ */
+SVCALL(SD_BLE_GAP_RSSI_START, uint32_t, sd_ble_gap_rssi_start(uint16_t conn_handle, uint8_t threshold_dbm, uint8_t skip_count));
+
+
+/**@brief Stop reporting the received signal strength.
+ *
+ * @note  An RSSI change detected before the call but not yet received by the application
+ *        may be reported after @ref sd_ble_gap_rssi_stop has been called.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_CENTRAL_RSSI_READ_MSC}
+ * @mmsc{@ref BLE_GAP_RSSI_FILT_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle Connection handle.
+ *
+ * @retval ::NRF_SUCCESS                   Successfully deactivated RSSI reporting.
+ * @retval ::NRF_ERROR_INVALID_STATE       RSSI reporting is not ongoing.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ */
+SVCALL(SD_BLE_GAP_RSSI_STOP, uint32_t, sd_ble_gap_rssi_stop(uint16_t conn_handle));
+
+
+/**@brief Get the received signal strength for the last connection event.
+ *
+ *        @ref sd_ble_gap_rssi_start must be called to start reporting RSSI before using this function. @ref NRF_ERROR_NOT_FOUND
+ *        will be returned until RSSI was sampled for the first time after calling @ref sd_ble_gap_rssi_start.
+ * @note ERRATA-153 and ERRATA-225 require the rssi sample to be compensated based on a temperature measurement.
+ * @mscs
+ * @mmsc{@ref BLE_GAP_CENTRAL_RSSI_READ_MSC}
+ * @endmscs
+ *
+ * @param[in]  conn_handle Connection handle.
+ * @param[out] p_rssi      Pointer to the location where the RSSI measurement shall be stored.
+ * @param[out] p_ch_index  Pointer to the location where Channel Index for the RSSI measurement shall be stored.
+ *
+ * @retval ::NRF_SUCCESS                   Successfully read the RSSI.
+ * @retval ::NRF_ERROR_NOT_FOUND           No sample is available.
+ * @retval ::NRF_ERROR_INVALID_ADDR        Invalid pointer supplied.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ * @retval ::NRF_ERROR_INVALID_STATE       RSSI reporting is not ongoing.
+ */
+SVCALL(SD_BLE_GAP_RSSI_GET, uint32_t, sd_ble_gap_rssi_get(uint16_t conn_handle, int8_t *p_rssi, uint8_t *p_ch_index));
+
+
+/**@brief Start or continue scanning (GAP Discovery procedure, Observer Procedure).
+ *
+ * @note    A call to this function will require the application to keep the memory pointed by
+ *          p_adv_report_buffer alive until the buffer is released. The buffer is released when the scanner is stopped
+ *          or when this function is called with another buffer.
+ *
+ * @note    The scanner will automatically stop in the following cases:
+ *           - @ref sd_ble_gap_scan_stop is called.
+ *           - @ref sd_ble_gap_connect is called.
+ *           - A @ref BLE_GAP_EVT_TIMEOUT with source set to @ref BLE_GAP_TIMEOUT_SRC_SCAN is received.
+ *           - When a @ref BLE_GAP_EVT_ADV_REPORT event is received and @ref ble_gap_adv_report_type_t::status is not set to
+ *             @ref BLE_GAP_ADV_DATA_STATUS_INCOMPLETE_MORE_DATA. In this case scanning is only paused to let the application
+ *             access received data. The application must call this function to continue scanning, or call @ref sd_ble_gap_scan_stop
+ *             to stop scanning.
+ *
+ * @note    If a @ref BLE_GAP_EVT_ADV_REPORT event is received with @ref ble_gap_adv_report_type_t::status set to
+ *          @ref BLE_GAP_ADV_DATA_STATUS_INCOMPLETE_MORE_DATA, the scanner will continue scanning, and the application will
+ *          receive more reports from this advertising event. The following reports will include the old and new received data.
+ *
+ * @events
+ * @event{@ref BLE_GAP_EVT_ADV_REPORT, An advertising or scan response packet has been received.}
+ * @event{@ref BLE_GAP_EVT_TIMEOUT, Scanner has timed out.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_SCAN_MSC}
+ * @mmsc{@ref BLE_GAP_WL_SHARE_MSC}
+ * @endmscs
+ *
+ * @param[in] p_scan_params       Pointer to scan parameters structure. When this function is used to continue
+ *                                scanning, this parameter must be NULL.
+ * @param[in] p_adv_report_buffer Pointer to buffer used to store incoming advertising data.
+ *                                The memory pointed to should be kept alive until the scanning is stopped.
+ *                                See @ref BLE_GAP_SCAN_BUFFER_SIZE for minimum and maximum buffer size.
+ *                                If the scanner receives advertising data larger than can be stored in the buffer,
+ *                                a @ref BLE_GAP_EVT_ADV_REPORT will be raised with @ref ble_gap_adv_report_type_t::status
+ *                                set to @ref BLE_GAP_ADV_DATA_STATUS_INCOMPLETE_TRUNCATED.
+ *
+ * @retval ::NRF_SUCCESS Successfully initiated scanning procedure.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid state to perform operation. Either:
+ *                                   - Scanning is already ongoing and p_scan_params was not NULL
+ *                                   - Scanning is not running and p_scan_params was NULL.
+ *                                   - The scanner has timed out when this function is called to continue scanning.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied. See @ref ble_gap_scan_params_t.
+ * @retval ::NRF_ERROR_NOT_SUPPORTED Unsupported parameters supplied. See @ref ble_gap_scan_params_t.
+ * @retval ::NRF_ERROR_INVALID_LENGTH The provided buffer length is invalid. See @ref BLE_GAP_SCAN_BUFFER_MIN.
+ * @retval ::NRF_ERROR_RESOURCES Not enough BLE role slots available.
+ *                               Stop one or more currently active roles (Central, Peripheral or Broadcaster) and try again
+ */
+SVCALL(SD_BLE_GAP_SCAN_START, uint32_t, sd_ble_gap_scan_start(ble_gap_scan_params_t const *p_scan_params, ble_data_t const * p_adv_report_buffer));
+
+
+/**@brief Stop scanning (GAP Discovery procedure, Observer Procedure).
+ *
+ * @note The buffer provided in @ref sd_ble_gap_scan_start is released.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_SCAN_MSC}
+ * @mmsc{@ref BLE_GAP_WL_SHARE_MSC}
+ * @endmscs
+ *
+ * @retval ::NRF_SUCCESS Successfully stopped scanning procedure.
+ * @retval ::NRF_ERROR_INVALID_STATE Not in the scanning state.
+ */
+SVCALL(SD_BLE_GAP_SCAN_STOP, uint32_t, sd_ble_gap_scan_stop(void));
+
+
+/**@brief Create a connection (GAP Link Establishment).
+ *
+ * @note If a scanning procedure is currently in progress it will be automatically stopped when calling this function.
+ *       The scanning procedure will be stopped even if the function returns an error.
+ *
+ * @events
+ * @event{@ref BLE_GAP_EVT_CONNECTED, A connection was established.}
+ * @event{@ref BLE_GAP_EVT_TIMEOUT, Failed to establish a connection.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_WL_SHARE_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_CONN_PRIV_MSC}
+ * @mmsc{@ref BLE_GAP_CENTRAL_CONN_MSC}
+ * @endmscs
+ *
+ * @param[in] p_peer_addr   Pointer to peer identity address. If @ref ble_gap_scan_params_t::filter_policy is set to use
+ *                          whitelist, then p_peer_addr is ignored.
+ * @param[in] p_scan_params Pointer to scan parameters structure.
+ * @param[in] p_conn_params Pointer to desired connection parameters.
+ * @param[in] conn_cfg_tag  Tag identifying a configuration set by @ref sd_ble_cfg_set or
+ *                          @ref BLE_CONN_CFG_TAG_DEFAULT to use the default connection configuration.
+ *
+ * @retval ::NRF_SUCCESS Successfully initiated connection procedure.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid parameter(s) pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ *                                   - Invalid parameter(s) in p_scan_params or p_conn_params.
+ *                                   - Use of whitelist requested but whitelist has not been set, see @ref sd_ble_gap_whitelist_set.
+ *                                   - Peer address was not present in the device identity list, see @ref sd_ble_gap_device_identities_set.
+ * @retval ::NRF_ERROR_NOT_FOUND conn_cfg_tag not found.
+ * @retval ::NRF_ERROR_INVALID_STATE The SoftDevice is in an invalid state to perform this operation. This may be due to an
+ *                                   existing locally initiated connect procedure, which must complete before initiating again.
+ * @retval ::BLE_ERROR_GAP_INVALID_BLE_ADDR Invalid Peer address.
+ * @retval ::NRF_ERROR_CONN_COUNT The limit of available connections for this connection configuration tag has been reached.
+ *                                To increase the number of available connections,
+ *                                use @ref sd_ble_cfg_set with @ref BLE_GAP_CFG_ROLE_COUNT or @ref BLE_CONN_CFG_GAP.
+ * @retval ::NRF_ERROR_RESOURCES Either:
+ *                                 - Not enough BLE role slots available.
+ *                                   Stop one or more currently active roles (Central, Peripheral or Observer) and try again.
+ *                                 - The event_length parameter associated with conn_cfg_tag is too small to be able to
+ *                                   establish a connection on the selected @ref ble_gap_scan_params_t::scan_phys.
+ *                                   Use @ref sd_ble_cfg_set to increase the event length.
+ */
+SVCALL(SD_BLE_GAP_CONNECT, uint32_t, sd_ble_gap_connect(ble_gap_addr_t const *p_peer_addr, ble_gap_scan_params_t const *p_scan_params, ble_gap_conn_params_t const *p_conn_params, uint8_t conn_cfg_tag));
+
+
+/**@brief Cancel a connection establishment.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_CENTRAL_CONN_MSC}
+ * @endmscs
+ *
+ * @retval ::NRF_SUCCESS Successfully canceled an ongoing connection procedure.
+ * @retval ::NRF_ERROR_INVALID_STATE No locally initiated connect procedure started or connection
+ *                                   completed occurred.
+ */
+SVCALL(SD_BLE_GAP_CONNECT_CANCEL, uint32_t, sd_ble_gap_connect_cancel(void));
+
+
+/**@brief Initiate or respond to a PHY Update Procedure
+ *
+ * @details   This function is used to initiate or respond to a PHY Update Procedure. It will always
+ *            generate a @ref BLE_GAP_EVT_PHY_UPDATE event if successfully executed.
+ *            If this function is used to initiate a PHY Update procedure and the only option
+ *            provided in @ref ble_gap_phys_t::tx_phys and @ref ble_gap_phys_t::rx_phys is the
+ *            currently active PHYs in the respective directions, the SoftDevice will generate a
+ *            @ref BLE_GAP_EVT_PHY_UPDATE with the current PHYs set and will not initiate the
+ *            procedure in the Link Layer.
+ *
+ *            If @ref ble_gap_phys_t::tx_phys or @ref ble_gap_phys_t::rx_phys is @ref BLE_GAP_PHY_AUTO,
+ *            then the stack will select PHYs based on the peer's PHY preferences and the local link
+ *            configuration. The PHY Update procedure will for this case result in a PHY combination
+ *            that respects the time constraints configured with @ref sd_ble_cfg_set and the current
+ *            link layer data length.
+ *
+ *            When acting as a central, the SoftDevice will select the fastest common PHY in each direction.
+ *
+ *            If the peer does not support the PHY Update Procedure, then the resulting
+ *            @ref BLE_GAP_EVT_PHY_UPDATE event will have a status set to
+ *            @ref BLE_HCI_UNSUPPORTED_REMOTE_FEATURE.
+ *
+ *            If the PHY Update procedure was rejected by the peer due to a procedure collision, the status
+ *            will be @ref BLE_HCI_STATUS_CODE_LMP_ERROR_TRANSACTION_COLLISION or
+ *            @ref BLE_HCI_DIFFERENT_TRANSACTION_COLLISION.
+ *            If the peer responds to the PHY Update procedure with invalid parameters, the status
+ *            will be @ref BLE_HCI_STATUS_CODE_INVALID_LMP_PARAMETERS.
+ *            If the PHY Update procedure was rejected by the peer for a different reason, the status will
+ *            contain the reason as specified by the peer.
+ *
+ * @events
+ * @event{@ref BLE_GAP_EVT_PHY_UPDATE, Result of the PHY Update Procedure.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_CENTRAL_PHY_UPDATE}
+ * @mmsc{@ref BLE_GAP_PERIPHERAL_PHY_UPDATE}
+ * @endmscs
+ *
+ * @param[in] conn_handle   Connection handle to indicate the connection for which the PHY Update is requested.
+ * @param[in] p_gap_phys    Pointer to PHY structure.
+ *
+ * @retval ::NRF_SUCCESS Successfully requested a PHY Update.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ * @retval ::NRF_ERROR_INVALID_STATE No link has been established.
+ * @retval ::NRF_ERROR_RESOURCES The connection event length configured for this link is not sufficient for the combination of
+ *                               @ref ble_gap_phys_t::tx_phys, @ref ble_gap_phys_t::rx_phys, and @ref ble_gap_data_length_params_t.
+ *                               The connection event length is configured with @ref BLE_CONN_CFG_GAP using @ref sd_ble_cfg_set.
+ * @retval ::NRF_ERROR_BUSY Procedure is already in progress or not allowed at this time. Process pending events and wait for the pending procedure to complete and retry.
+ *
+ */
+SVCALL(SD_BLE_GAP_PHY_UPDATE, uint32_t, sd_ble_gap_phy_update(uint16_t conn_handle, ble_gap_phys_t const *p_gap_phys));
+
+
+/**@brief Initiate or respond to a Data Length Update Procedure.
+ *
+ * @note If the application uses @ref BLE_GAP_DATA_LENGTH_AUTO for one or more members of
+ *       p_dl_params, the SoftDevice will choose the highest value supported in current
+ *       configuration and connection parameters.
+ * @note  If the link PHY is Coded, the SoftDevice will ensure that the MaxTxTime and/or MaxRxTime
+ *        used in the Data Length Update procedure is at least 2704 us. Otherwise, MaxTxTime and
+ *        MaxRxTime will be limited to maximum 2120 us.
+ *
+ * @param[in]   conn_handle       Connection handle.
+ * @param[in]   p_dl_params       Pointer to local parameters to be used in Data Length Update
+ *                                Procedure. Set any member to @ref BLE_GAP_DATA_LENGTH_AUTO to let
+ *                                the SoftDevice automatically decide the value for that member.
+ *                                Set to NULL to use automatic values for all members.
+ * @param[out]  p_dl_limitation   Pointer to limitation to be written when local device does not
+ *                                have enough resources or does not support the requested Data Length
+ *                                Update parameters. Ignored if NULL.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GAP_DATA_LENGTH_UPDATE_PROCEDURE_MSC}
+ * @endmscs
+ *
+ * @retval ::NRF_SUCCESS Successfully set Data Length Extension initiation/response parameters.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle parameter supplied.
+ * @retval ::NRF_ERROR_INVALID_STATE No link has been established.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameters supplied.
+ * @retval ::NRF_ERROR_NOT_SUPPORTED The requested parameters are not supported by the SoftDevice. Inspect
+ *                                   p_dl_limitation to see which parameter is not supported.
+ * @retval ::NRF_ERROR_RESOURCES The connection event length configured for this link is not sufficient for the requested parameters.
+ *                               Use @ref sd_ble_cfg_set with @ref BLE_CONN_CFG_GAP to increase the connection event length.
+ *                               Inspect p_dl_limitation to see where the limitation is.
+ * @retval ::NRF_ERROR_BUSY Peer has already initiated a Data Length Update Procedure. Process the
+ *                          pending @ref BLE_GAP_EVT_DATA_LENGTH_UPDATE_REQUEST event to respond.
+ */
+SVCALL(SD_BLE_GAP_DATA_LENGTH_UPDATE, uint32_t, sd_ble_gap_data_length_update(uint16_t conn_handle, ble_gap_data_length_params_t const *p_dl_params, ble_gap_data_length_limitation_t *p_dl_limitation));
+
+/**@brief   Start the Quality of Service (QoS) channel survey module.
+ *
+ * @details The channel survey module provides measurements of the energy levels on
+ *          the Bluetooth Low Energy channels. When the module is enabled, @ref BLE_GAP_EVT_QOS_CHANNEL_SURVEY_REPORT
+ *          events will periodically report the measured energy levels for each channel.
+ *
+ * @note    The measurements are scheduled with lower priority than other Bluetooth Low Energy roles,
+ *          Radio Timeslot API events and Flash API events.
+ *
+ * @note    The channel survey module will attempt to do measurements so that the average interval
+ *          between measurements will be interval_us. However due to the channel survey module
+ *          having the lowest priority of all roles and modules, this may not be possible. In that
+ *          case fewer than expected channel survey reports may be given.
+ *
+ * @note    In order to use the channel survey module, @ref ble_gap_cfg_role_count_t::qos_channel_survey_role_available
+ *          must be set. This is done using @ref sd_ble_cfg_set.
+ *
+ * @param[in]   interval_us      Requested average interval for the measurements and reports. See
+ *                               @ref BLE_GAP_QOS_CHANNEL_SURVEY_INTERVALS for valid ranges. If set
+ *                               to @ref BLE_GAP_QOS_CHANNEL_SURVEY_INTERVAL_CONTINUOUS, the channel
+ *                               survey role will be scheduled at every available opportunity.
+ *
+ * @retval ::NRF_SUCCESS             The module is successfully started.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter supplied. interval_us is out of the
+ *                                   allowed range.
+ * @retval ::NRF_ERROR_INVALID_STATE Trying to start the module when already running.
+ * @retval ::NRF_ERROR_RESOURCES     The channel survey module is not available to the application.
+ *                                   Set @ref ble_gap_cfg_role_count_t::qos_channel_survey_role_available using
+ *                                   @ref sd_ble_cfg_set.
+ */
+SVCALL(SD_BLE_GAP_QOS_CHANNEL_SURVEY_START, uint32_t, sd_ble_gap_qos_channel_survey_start(uint32_t interval_us));
+
+/**@brief   Stop the Quality of Service (QoS) channel survey module.
+ *
+ * @note    The SoftDevice may generate one @ref BLE_GAP_EVT_QOS_CHANNEL_SURVEY_REPORT event after this
+ *          function is called.
+ *
+ * @retval ::NRF_SUCCESS             The module is successfully stopped.
+ * @retval ::NRF_ERROR_INVALID_STATE Trying to stop the module when it is not running.
+ */
+SVCALL(SD_BLE_GAP_QOS_CHANNEL_SURVEY_STOP, uint32_t, sd_ble_gap_qos_channel_survey_stop(void));
+
+
+/**@brief   Obtain the next connection event counter value.
+ *
+ * @details The connection event counter is initialized to zero on the first connection event. The value is incremented
+ *          by one for each connection event. For more information see Bluetooth Core Specification v5.0, Vol 6, Part B,
+ *          Section 4.5.1.
+ *
+ * @note    The connection event counter obtained through this API will be outdated if this API is called
+ *          at the same time as the connection event counter is incremented.
+ *
+ * @note    This API will always return the last connection event counter + 1.
+ *          The actual connection event may be multiple connection events later if:
+ *           - Slave latency is enabled and there is no data to transmit or receive.
+ *           - Another role is scheduled with a higher priority at the same time as the next connection event.
+ *
+ * @param[in]   conn_handle       Connection handle.
+ * @param[out]  p_counter         Pointer to the variable where the next connection event counter will be written.
+ *
+ * @retval ::NRF_SUCCESS                   The connection event counter was successfully retrieved.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle parameter supplied.
+ * @retval ::NRF_ERROR_INVALID_ADDR        Invalid pointer supplied.
+ */
+SVCALL(SD_BLE_GAP_NEXT_CONN_EVT_COUNTER_GET, uint32_t, sd_ble_gap_next_conn_evt_counter_get(uint16_t conn_handle, uint16_t * p_counter));
+
+
+/**@brief   Start triggering a given task on connection event start.
+ *
+ * @details When enabled, this feature will trigger a PPI task at the start of connection events.
+ *          The application can configure the SoftDevice to trigger every N connection events starting from
+ *          a given connection event counter. See also @ref ble_gap_conn_event_trigger_t.
+ *
+ * @param[in]   conn_handle   Connection handle.
+ * @param[in]   p_params      Connection event trigger parameters.
+ *
+ * @retval ::NRF_SUCCESS                   Success.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ * @retval ::NRF_ERROR_INVALID_ADDR        Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM       Invalid parameter supplied. See @ref ble_gap_conn_event_trigger_t.
+ * @retval ::NRF_ERROR_INVALID_STATE       Either:
+ *                                         - Trying to start connection event triggering when it is already ongoing.
+ *                                         - @ref ble_gap_conn_event_trigger_t::conn_evt_counter_start is in the past.
+ *                                           Use @ref sd_ble_gap_next_conn_evt_counter_get to find a new value
+                                             to be used as ble_gap_conn_event_trigger_t::conn_evt_counter_start.
+ */
+SVCALL(SD_BLE_GAP_CONN_EVT_TRIGGER_START, uint32_t, sd_ble_gap_conn_evt_trigger_start(uint16_t conn_handle, ble_gap_conn_event_trigger_t const * p_params));
+
+
+/**@brief   Stop triggering the task configured using @ref sd_ble_gap_conn_evt_trigger_start.
+ *
+ * @param[in]   conn_handle   Connection handle.
+ *
+ * @retval ::NRF_SUCCESS                   Success.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied.
+ * @retval ::NRF_ERROR_INVALID_STATE       Trying to stop connection event triggering when it is not enabled.
+ */
+SVCALL(SD_BLE_GAP_CONN_EVT_TRIGGER_STOP, uint32_t, sd_ble_gap_conn_evt_trigger_stop(uint16_t conn_handle));
+
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+#endif // BLE_GAP_H__
+
+/**
+  @}
+*/

--- a/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble_gatt.h
+++ b/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble_gatt.h
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+  @addtogroup BLE_GATT Generic Attribute Profile (GATT) Common
+  @{
+  @brief  Common definitions and prototypes for the GATT interfaces.
+ */
+
+#ifndef BLE_GATT_H__
+#define BLE_GATT_H__
+
+#include <stdint.h>
+#include "nrf_svc.h"
+#include "nrf_error.h"
+#include "ble_hci.h"
+#include "ble_ranges.h"
+#include "ble_types.h"
+#include "ble_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @addtogroup BLE_GATT_DEFINES Defines
+ * @{ */
+
+/** @brief Default ATT MTU, in bytes. */
+#define BLE_GATT_ATT_MTU_DEFAULT          23
+
+/**@brief Invalid Attribute Handle. */
+#define BLE_GATT_HANDLE_INVALID            0x0000
+
+/**@brief First Attribute Handle. */
+#define BLE_GATT_HANDLE_START              0x0001
+
+/**@brief Last Attribute Handle. */
+#define BLE_GATT_HANDLE_END                0xFFFF
+
+/** @defgroup BLE_GATT_TIMEOUT_SOURCES GATT Timeout sources
+ * @{ */
+#define BLE_GATT_TIMEOUT_SRC_PROTOCOL      0x00  /**< ATT Protocol timeout. */
+/** @} */
+
+/** @defgroup BLE_GATT_WRITE_OPS GATT Write operations
+ * @{ */
+#define BLE_GATT_OP_INVALID                0x00  /**< Invalid Operation. */
+#define BLE_GATT_OP_WRITE_REQ              0x01  /**< Write Request. */
+#define BLE_GATT_OP_WRITE_CMD              0x02  /**< Write Command. */
+#define BLE_GATT_OP_SIGN_WRITE_CMD         0x03  /**< Signed Write Command. */
+#define BLE_GATT_OP_PREP_WRITE_REQ         0x04  /**< Prepare Write Request. */
+#define BLE_GATT_OP_EXEC_WRITE_REQ         0x05  /**< Execute Write Request. */
+/** @} */
+
+/** @defgroup BLE_GATT_EXEC_WRITE_FLAGS GATT Execute Write flags
+ * @{ */
+#define BLE_GATT_EXEC_WRITE_FLAG_PREPARED_CANCEL 0x00   /**< Cancel prepared write. */
+#define BLE_GATT_EXEC_WRITE_FLAG_PREPARED_WRITE  0x01   /**< Execute prepared write. */
+/** @} */
+
+/** @defgroup BLE_GATT_HVX_TYPES GATT Handle Value operations
+ * @{ */
+#define BLE_GATT_HVX_INVALID               0x00  /**< Invalid Operation. */
+#define BLE_GATT_HVX_NOTIFICATION          0x01  /**< Handle Value Notification. */
+#define BLE_GATT_HVX_INDICATION            0x02  /**< Handle Value Indication. */
+/** @} */
+
+/** @defgroup BLE_GATT_STATUS_CODES GATT Status Codes
+ * @{ */
+#define BLE_GATT_STATUS_SUCCESS                           0x0000  /**< Success. */
+#define BLE_GATT_STATUS_UNKNOWN                           0x0001  /**< Unknown or not applicable status. */
+#define BLE_GATT_STATUS_ATTERR_INVALID                    0x0100  /**< ATT Error: Invalid Error Code. */
+#define BLE_GATT_STATUS_ATTERR_INVALID_HANDLE             0x0101  /**< ATT Error: Invalid Attribute Handle. */
+#define BLE_GATT_STATUS_ATTERR_READ_NOT_PERMITTED         0x0102  /**< ATT Error: Read not permitted. */
+#define BLE_GATT_STATUS_ATTERR_WRITE_NOT_PERMITTED        0x0103  /**< ATT Error: Write not permitted. */
+#define BLE_GATT_STATUS_ATTERR_INVALID_PDU                0x0104  /**< ATT Error: Used in ATT as Invalid PDU. */
+#define BLE_GATT_STATUS_ATTERR_INSUF_AUTHENTICATION       0x0105  /**< ATT Error: Authenticated link required. */
+#define BLE_GATT_STATUS_ATTERR_REQUEST_NOT_SUPPORTED      0x0106  /**< ATT Error: Used in ATT as Request Not Supported. */
+#define BLE_GATT_STATUS_ATTERR_INVALID_OFFSET             0x0107  /**< ATT Error: Offset specified was past the end of the attribute. */
+#define BLE_GATT_STATUS_ATTERR_INSUF_AUTHORIZATION        0x0108  /**< ATT Error: Used in ATT as Insufficient Authorization. */
+#define BLE_GATT_STATUS_ATTERR_PREPARE_QUEUE_FULL         0x0109  /**< ATT Error: Used in ATT as Prepare Queue Full. */
+#define BLE_GATT_STATUS_ATTERR_ATTRIBUTE_NOT_FOUND        0x010A  /**< ATT Error: Used in ATT as Attribute not found. */
+#define BLE_GATT_STATUS_ATTERR_ATTRIBUTE_NOT_LONG         0x010B  /**< ATT Error: Attribute cannot be read or written using read/write blob requests. */
+#define BLE_GATT_STATUS_ATTERR_INSUF_ENC_KEY_SIZE         0x010C  /**< ATT Error: Encryption key size used is insufficient. */
+#define BLE_GATT_STATUS_ATTERR_INVALID_ATT_VAL_LENGTH     0x010D  /**< ATT Error: Invalid value size. */
+#define BLE_GATT_STATUS_ATTERR_UNLIKELY_ERROR             0x010E  /**< ATT Error: Very unlikely error. */
+#define BLE_GATT_STATUS_ATTERR_INSUF_ENCRYPTION           0x010F  /**< ATT Error: Encrypted link required. */
+#define BLE_GATT_STATUS_ATTERR_UNSUPPORTED_GROUP_TYPE     0x0110  /**< ATT Error: Attribute type is not a supported grouping attribute. */
+#define BLE_GATT_STATUS_ATTERR_INSUF_RESOURCES            0x0111  /**< ATT Error: Insufficient resources. */
+#define BLE_GATT_STATUS_ATTERR_RFU_RANGE1_BEGIN           0x0112  /**< ATT Error: Reserved for Future Use range #1 begin. */
+#define BLE_GATT_STATUS_ATTERR_RFU_RANGE1_END             0x017F  /**< ATT Error: Reserved for Future Use range #1 end. */
+#define BLE_GATT_STATUS_ATTERR_APP_BEGIN                  0x0180  /**< ATT Error: Application range begin. */
+#define BLE_GATT_STATUS_ATTERR_APP_END                    0x019F  /**< ATT Error: Application range end. */
+#define BLE_GATT_STATUS_ATTERR_RFU_RANGE2_BEGIN           0x01A0  /**< ATT Error: Reserved for Future Use range #2 begin. */
+#define BLE_GATT_STATUS_ATTERR_RFU_RANGE2_END             0x01DF  /**< ATT Error: Reserved for Future Use range #2 end. */
+#define BLE_GATT_STATUS_ATTERR_RFU_RANGE3_BEGIN           0x01E0  /**< ATT Error: Reserved for Future Use range #3 begin. */
+#define BLE_GATT_STATUS_ATTERR_RFU_RANGE3_END             0x01FC  /**< ATT Error: Reserved for Future Use range #3 end. */
+#define BLE_GATT_STATUS_ATTERR_CPS_WRITE_REQ_REJECTED     0x01FC  /**< ATT Common Profile and Service Error: Write request rejected. */
+#define BLE_GATT_STATUS_ATTERR_CPS_CCCD_CONFIG_ERROR      0x01FD  /**< ATT Common Profile and Service Error: Client Characteristic Configuration Descriptor improperly configured. */
+#define BLE_GATT_STATUS_ATTERR_CPS_PROC_ALR_IN_PROG       0x01FE  /**< ATT Common Profile and Service Error: Procedure Already in Progress. */
+#define BLE_GATT_STATUS_ATTERR_CPS_OUT_OF_RANGE           0x01FF  /**< ATT Common Profile and Service Error: Out Of Range. */
+/** @} */
+
+
+/** @defgroup BLE_GATT_CPF_FORMATS Characteristic Presentation Formats
+ *  @note Found at http://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.characteristic_presentation_format.xml
+ * @{ */
+#define BLE_GATT_CPF_FORMAT_RFU                 0x00 /**< Reserved For Future Use. */
+#define BLE_GATT_CPF_FORMAT_BOOLEAN             0x01 /**< Boolean. */
+#define BLE_GATT_CPF_FORMAT_2BIT                0x02 /**< Unsigned 2-bit integer. */
+#define BLE_GATT_CPF_FORMAT_NIBBLE              0x03 /**< Unsigned 4-bit integer. */
+#define BLE_GATT_CPF_FORMAT_UINT8               0x04 /**< Unsigned 8-bit integer. */
+#define BLE_GATT_CPF_FORMAT_UINT12              0x05 /**< Unsigned 12-bit integer. */
+#define BLE_GATT_CPF_FORMAT_UINT16              0x06 /**< Unsigned 16-bit integer. */
+#define BLE_GATT_CPF_FORMAT_UINT24              0x07 /**< Unsigned 24-bit integer. */
+#define BLE_GATT_CPF_FORMAT_UINT32              0x08 /**< Unsigned 32-bit integer. */
+#define BLE_GATT_CPF_FORMAT_UINT48              0x09 /**< Unsigned 48-bit integer. */
+#define BLE_GATT_CPF_FORMAT_UINT64              0x0A /**< Unsigned 64-bit integer. */
+#define BLE_GATT_CPF_FORMAT_UINT128             0x0B /**< Unsigned 128-bit integer. */
+#define BLE_GATT_CPF_FORMAT_SINT8               0x0C /**< Signed 2-bit integer. */
+#define BLE_GATT_CPF_FORMAT_SINT12              0x0D /**< Signed 12-bit integer. */
+#define BLE_GATT_CPF_FORMAT_SINT16              0x0E /**< Signed 16-bit integer. */
+#define BLE_GATT_CPF_FORMAT_SINT24              0x0F /**< Signed 24-bit integer. */
+#define BLE_GATT_CPF_FORMAT_SINT32              0x10 /**< Signed 32-bit integer. */
+#define BLE_GATT_CPF_FORMAT_SINT48              0x11 /**< Signed 48-bit integer. */
+#define BLE_GATT_CPF_FORMAT_SINT64              0x12 /**< Signed 64-bit integer. */
+#define BLE_GATT_CPF_FORMAT_SINT128             0x13 /**< Signed 128-bit integer. */
+#define BLE_GATT_CPF_FORMAT_FLOAT32             0x14 /**< IEEE-754 32-bit floating point. */
+#define BLE_GATT_CPF_FORMAT_FLOAT64             0x15 /**< IEEE-754 64-bit floating point. */
+#define BLE_GATT_CPF_FORMAT_SFLOAT              0x16 /**< IEEE-11073 16-bit SFLOAT. */
+#define BLE_GATT_CPF_FORMAT_FLOAT               0x17 /**< IEEE-11073 32-bit FLOAT. */
+#define BLE_GATT_CPF_FORMAT_DUINT16             0x18 /**< IEEE-20601 format. */
+#define BLE_GATT_CPF_FORMAT_UTF8S               0x19 /**< UTF-8 string. */
+#define BLE_GATT_CPF_FORMAT_UTF16S              0x1A /**< UTF-16 string. */
+#define BLE_GATT_CPF_FORMAT_STRUCT              0x1B /**< Opaque Structure. */
+/** @} */
+
+/** @defgroup BLE_GATT_CPF_NAMESPACES GATT Bluetooth Namespaces
+ * @{
+ */
+#define BLE_GATT_CPF_NAMESPACE_BTSIG            0x01 /**< Bluetooth SIG defined Namespace. */
+#define BLE_GATT_CPF_NAMESPACE_DESCRIPTION_UNKNOWN 0x0000 /**< Namespace Description Unknown. */
+/** @} */
+
+/** @} */
+
+/** @addtogroup BLE_GATT_STRUCTURES Structures
+ * @{ */
+
+/**
+ * @brief BLE GATT connection configuration parameters, set with @ref sd_ble_cfg_set.
+ *
+ * @retval ::NRF_ERROR_INVALID_PARAM att_mtu is smaller than @ref BLE_GATT_ATT_MTU_DEFAULT.
+ */
+typedef struct
+{
+  uint16_t  att_mtu;          /**< Maximum size of ATT packet the SoftDevice can send or receive.
+                                   The default and minimum value is @ref BLE_GATT_ATT_MTU_DEFAULT.
+                                   @mscs
+                                   @mmsc{@ref BLE_GATTC_MTU_EXCHANGE}
+                                   @mmsc{@ref BLE_GATTS_MTU_EXCHANGE}
+                                   @endmscs
+                              */
+} ble_gatt_conn_cfg_t;
+
+/**@brief GATT Characteristic Properties. */
+typedef struct
+{
+  /* Standard properties */
+  uint8_t broadcast       :1; /**< Broadcasting of the value permitted. */
+  uint8_t read            :1; /**< Reading the value permitted. */
+  uint8_t write_wo_resp   :1; /**< Writing the value with Write Command permitted. */
+  uint8_t write           :1; /**< Writing the value with Write Request permitted. */
+  uint8_t notify          :1; /**< Notification of the value permitted. */
+  uint8_t indicate        :1; /**< Indications of the value permitted. */
+  uint8_t auth_signed_wr  :1; /**< Writing the value with Signed Write Command permitted. */
+} ble_gatt_char_props_t;
+
+/**@brief GATT Characteristic Extended Properties. */
+typedef struct
+{
+  /* Extended properties */
+  uint8_t reliable_wr     :1; /**< Writing the value with Queued Write operations permitted. */
+  uint8_t wr_aux          :1; /**< Writing the Characteristic User Description descriptor permitted. */
+} ble_gatt_char_ext_props_t;
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+#endif // BLE_GATT_H__
+
+/** @} */

--- a/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble_gattc.h
+++ b/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble_gattc.h
@@ -1,0 +1,755 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+  @addtogroup BLE_GATTC Generic Attribute Profile (GATT) Client
+  @{
+  @brief  Definitions and prototypes for the GATT Client interface.
+ */
+
+#ifndef BLE_GATTC_H__
+#define BLE_GATTC_H__
+
+#include <stdint.h>
+#include "nrf.h"
+#include "nrf_svc.h"
+#include "nrf_error.h"
+#include "ble_ranges.h"
+#include "ble_types.h"
+#include "ble_err.h"
+#include "ble_gatt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @addtogroup BLE_GATTC_ENUMERATIONS Enumerations
+ * @{ */
+
+/**@brief GATTC API SVC numbers. */
+enum BLE_GATTC_SVCS
+{
+  SD_BLE_GATTC_PRIMARY_SERVICES_DISCOVER = BLE_GATTC_SVC_BASE, /**< Primary Service Discovery. */
+  SD_BLE_GATTC_RELATIONSHIPS_DISCOVER,                         /**< Relationship Discovery. */
+  SD_BLE_GATTC_CHARACTERISTICS_DISCOVER,                       /**< Characteristic Discovery. */
+  SD_BLE_GATTC_DESCRIPTORS_DISCOVER,                           /**< Characteristic Descriptor Discovery. */
+  SD_BLE_GATTC_ATTR_INFO_DISCOVER,                             /**< Attribute Information Discovery. */
+  SD_BLE_GATTC_CHAR_VALUE_BY_UUID_READ,                        /**< Read Characteristic Value by UUID. */
+  SD_BLE_GATTC_READ,                                           /**< Generic read. */
+  SD_BLE_GATTC_CHAR_VALUES_READ,                               /**< Read multiple Characteristic Values. */
+  SD_BLE_GATTC_WRITE,                                          /**< Generic write. */
+  SD_BLE_GATTC_HV_CONFIRM,                                     /**< Handle Value Confirmation. */
+  SD_BLE_GATTC_EXCHANGE_MTU_REQUEST,                           /**< Exchange MTU Request. */
+};
+
+/**
+ * @brief GATT Client Event IDs.
+ */
+enum BLE_GATTC_EVTS
+{
+  BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP = BLE_GATTC_EVT_BASE,  /**< Primary Service Discovery Response event.          \n See @ref ble_gattc_evt_prim_srvc_disc_rsp_t.          */
+  BLE_GATTC_EVT_REL_DISC_RSP,                             /**< Relationship Discovery Response event.             \n See @ref ble_gattc_evt_rel_disc_rsp_t.                */
+  BLE_GATTC_EVT_CHAR_DISC_RSP,                            /**< Characteristic Discovery Response event.           \n See @ref ble_gattc_evt_char_disc_rsp_t.               */
+  BLE_GATTC_EVT_DESC_DISC_RSP,                            /**< Descriptor Discovery Response event.               \n See @ref ble_gattc_evt_desc_disc_rsp_t.               */
+  BLE_GATTC_EVT_ATTR_INFO_DISC_RSP,                       /**< Attribute Information Response event.              \n See @ref ble_gattc_evt_attr_info_disc_rsp_t. */
+  BLE_GATTC_EVT_CHAR_VAL_BY_UUID_READ_RSP,                /**< Read By UUID Response event.                       \n See @ref ble_gattc_evt_char_val_by_uuid_read_rsp_t.   */
+  BLE_GATTC_EVT_READ_RSP,                                 /**< Read Response event.                               \n See @ref ble_gattc_evt_read_rsp_t.                    */
+  BLE_GATTC_EVT_CHAR_VALS_READ_RSP,                       /**< Read multiple Response event.                      \n See @ref ble_gattc_evt_char_vals_read_rsp_t.          */
+  BLE_GATTC_EVT_WRITE_RSP,                                /**< Write Response event.                              \n See @ref ble_gattc_evt_write_rsp_t.                   */
+  BLE_GATTC_EVT_HVX,                                      /**< Handle Value Notification or Indication event.     \n Confirm indication with @ref sd_ble_gattc_hv_confirm.  \n See @ref ble_gattc_evt_hvx_t. */
+  BLE_GATTC_EVT_EXCHANGE_MTU_RSP,                         /**< Exchange MTU Response event.                       \n See @ref ble_gattc_evt_exchange_mtu_rsp_t.            */
+  BLE_GATTC_EVT_TIMEOUT,                                  /**< Timeout event.                                     \n See @ref ble_gattc_evt_timeout_t.                     */
+  BLE_GATTC_EVT_WRITE_CMD_TX_COMPLETE                     /**< Write without Response transmission complete.      \n See @ref ble_gattc_evt_write_cmd_tx_complete_t.       */
+};
+
+/**@brief GATTC Option IDs.
+ * IDs that uniquely identify a GATTC option.
+ */
+enum BLE_GATTC_OPTS
+{
+  BLE_GATTC_OPT_UUID_DISC = BLE_GATTC_OPT_BASE,     /**< UUID discovery. @ref ble_gattc_opt_uuid_disc_t  */
+};
+
+/** @} */
+
+/** @addtogroup BLE_GATTC_DEFINES Defines
+ * @{ */
+
+/** @defgroup BLE_ERRORS_GATTC SVC return values specific to GATTC
+ * @{ */
+#define BLE_ERROR_GATTC_PROC_NOT_PERMITTED    (NRF_GATTC_ERR_BASE + 0x000) /**< Procedure not Permitted. */
+/** @} */
+
+/** @defgroup BLE_GATTC_ATTR_INFO_FORMAT Attribute Information Formats
+ * @{ */
+#define BLE_GATTC_ATTR_INFO_FORMAT_16BIT    1 /**< 16-bit Attribute Information Format. */
+#define BLE_GATTC_ATTR_INFO_FORMAT_128BIT   2 /**< 128-bit Attribute Information Format. */
+/** @} */
+
+/** @defgroup BLE_GATTC_DEFAULTS GATT Client defaults
+ * @{ */
+#define BLE_GATTC_WRITE_CMD_TX_QUEUE_SIZE_DEFAULT  1 /**< Default number of Write without Response that can be queued for transmission. */
+/** @} */
+
+/** @} */
+
+/** @addtogroup BLE_GATTC_STRUCTURES Structures
+ * @{ */
+
+/**
+ * @brief BLE GATTC connection configuration parameters, set with @ref sd_ble_cfg_set.
+ */
+typedef struct
+{
+  uint8_t  write_cmd_tx_queue_size; /**< The guaranteed minimum number of Write without Response that can be queued for transmission.
+                                          The default value is @ref BLE_GATTC_WRITE_CMD_TX_QUEUE_SIZE_DEFAULT */
+} ble_gattc_conn_cfg_t;
+
+/**@brief Operation Handle Range. */
+typedef struct
+{
+  uint16_t          start_handle; /**< Start Handle. */
+  uint16_t          end_handle;   /**< End Handle. */
+} ble_gattc_handle_range_t;
+
+
+/**@brief GATT service. */
+typedef struct
+{
+  ble_uuid_t               uuid;          /**< Service UUID. */
+  ble_gattc_handle_range_t handle_range;  /**< Service Handle Range. */
+} ble_gattc_service_t;
+
+
+/**@brief  GATT include. */
+typedef struct
+{
+  uint16_t            handle;           /**< Include Handle. */
+  ble_gattc_service_t included_srvc;    /**< Handle of the included service. */
+} ble_gattc_include_t;
+
+
+/**@brief GATT characteristic. */
+typedef struct
+{
+  ble_uuid_t              uuid;                 /**< Characteristic UUID. */
+  ble_gatt_char_props_t   char_props;           /**< Characteristic Properties. */
+  uint8_t                 char_ext_props : 1;   /**< Extended properties present. */
+  uint16_t                handle_decl;          /**< Handle of the Characteristic Declaration. */
+  uint16_t                handle_value;         /**< Handle of the Characteristic Value. */
+} ble_gattc_char_t;
+
+
+/**@brief GATT descriptor. */
+typedef struct
+{
+  uint16_t          handle;         /**< Descriptor Handle. */
+  ble_uuid_t        uuid;           /**< Descriptor UUID. */
+} ble_gattc_desc_t;
+
+
+/**@brief Write Parameters. */
+typedef struct
+{
+  uint8_t        write_op;             /**< Write Operation to be performed, see @ref BLE_GATT_WRITE_OPS. */
+  uint8_t        flags;                /**< Flags, see @ref BLE_GATT_EXEC_WRITE_FLAGS. */
+  uint16_t       handle;               /**< Handle to the attribute to be written. */
+  uint16_t       offset;               /**< Offset in bytes. @note For WRITE_CMD and WRITE_REQ, offset must be 0. */
+  uint16_t       len;                  /**< Length of data in bytes. */
+  uint8_t const *p_value;              /**< Pointer to the value data. */
+} ble_gattc_write_params_t;
+
+/**@brief Attribute Information for 16-bit Attribute UUID. */
+typedef struct
+{
+  uint16_t       handle;               /**< Attribute handle. */
+  ble_uuid_t     uuid;                 /**< 16-bit Attribute UUID. */
+} ble_gattc_attr_info16_t;
+
+/**@brief Attribute Information for 128-bit Attribute UUID. */
+typedef struct
+{
+  uint16_t       handle;               /**< Attribute handle. */
+  ble_uuid128_t  uuid;                 /**< 128-bit Attribute UUID. */
+} ble_gattc_attr_info128_t;
+
+/**@brief Event structure for @ref BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP. */
+typedef struct
+{
+  uint16_t             count;           /**< Service count. */
+  ble_gattc_service_t services[1];      /**< Service data. @note This is a variable length array. The size of 1 indicated is only a placeholder for compilation.
+                                             See @ref sd_ble_evt_get for more information on how to use event structures with variable length array members. */
+} ble_gattc_evt_prim_srvc_disc_rsp_t;
+
+/**@brief Event structure for @ref BLE_GATTC_EVT_REL_DISC_RSP. */
+typedef struct
+{
+  uint16_t             count;           /**< Include count. */
+  ble_gattc_include_t includes[1];      /**< Include data. @note This is a variable length array. The size of 1 indicated is only a placeholder for compilation.
+                                             See @ref sd_ble_evt_get for more information on how to use event structures with variable length array members. */
+} ble_gattc_evt_rel_disc_rsp_t;
+
+/**@brief Event structure for @ref BLE_GATTC_EVT_CHAR_DISC_RSP. */
+typedef struct
+{
+  uint16_t            count;          /**< Characteristic count. */
+  ble_gattc_char_t    chars[1];       /**< Characteristic data. @note This is a variable length array. The size of 1 indicated is only a placeholder for compilation.
+                                           See @ref sd_ble_evt_get for more information on how to use event structures with variable length array members. */
+} ble_gattc_evt_char_disc_rsp_t;
+
+/**@brief Event structure for @ref BLE_GATTC_EVT_DESC_DISC_RSP. */
+typedef struct
+{
+  uint16_t            count;          /**< Descriptor count. */
+  ble_gattc_desc_t    descs[1];       /**< Descriptor data. @note This is a variable length array. The size of 1 indicated is only a placeholder for compilation.
+                                           See @ref sd_ble_evt_get for more information on how to use event structures with variable length array members. */
+} ble_gattc_evt_desc_disc_rsp_t;
+
+/**@brief Event structure for @ref BLE_GATTC_EVT_ATTR_INFO_DISC_RSP. */
+typedef struct
+{
+  uint16_t                     count;            /**< Attribute count. */
+  uint8_t                      format;           /**< Attribute information format, see @ref BLE_GATTC_ATTR_INFO_FORMAT. */
+  union {
+    ble_gattc_attr_info16_t  attr_info16[1];     /**< Attribute information for 16-bit Attribute UUID.
+                                                      @note This is a variable length array. The size of 1 indicated is only a placeholder for compilation.
+                                                      See @ref sd_ble_evt_get for more information on how to use event structures with variable length array members. */
+    ble_gattc_attr_info128_t attr_info128[1];    /**< Attribute information for 128-bit Attribute UUID.
+                                                      @note This is a variable length array. The size of 1 indicated is only a placeholder for compilation.
+                                                      See @ref sd_ble_evt_get for more information on how to use event structures with variable length array members. */
+  } info;                                        /**< Attribute information union. */
+} ble_gattc_evt_attr_info_disc_rsp_t;
+
+/**@brief GATT read by UUID handle value pair. */
+typedef struct
+{
+  uint16_t            handle;          /**< Attribute Handle. */
+  uint8_t            *p_value;         /**< Pointer to the Attribute Value, length is available in @ref ble_gattc_evt_char_val_by_uuid_read_rsp_t::value_len. */
+} ble_gattc_handle_value_t;
+
+/**@brief Event structure for @ref BLE_GATTC_EVT_CHAR_VAL_BY_UUID_READ_RSP. */
+typedef struct
+{
+  uint16_t                  count;            /**< Handle-Value Pair Count. */
+  uint16_t                  value_len;        /**< Length of the value in Handle-Value(s) list. */
+  uint8_t                   handle_value[1];  /**< Handle-Value(s) list. To iterate through the list use @ref sd_ble_gattc_evt_char_val_by_uuid_read_rsp_iter.
+                                                   @note This is a variable length array. The size of 1 indicated is only a placeholder for compilation.
+                                                   See @ref sd_ble_evt_get for more information on how to use event structures with variable length array members. */
+} ble_gattc_evt_char_val_by_uuid_read_rsp_t;
+
+/**@brief Event structure for @ref BLE_GATTC_EVT_READ_RSP. */
+typedef struct
+{
+  uint16_t            handle;         /**< Attribute Handle. */
+  uint16_t            offset;         /**< Offset of the attribute data. */
+  uint16_t            len;            /**< Attribute data length. */
+  uint8_t             data[1];        /**< Attribute data. @note This is a variable length array. The size of 1 indicated is only a placeholder for compilation.
+                                           See @ref sd_ble_evt_get for more information on how to use event structures with variable length array members. */
+} ble_gattc_evt_read_rsp_t;
+
+/**@brief Event structure for @ref BLE_GATTC_EVT_CHAR_VALS_READ_RSP. */
+typedef struct
+{
+  uint16_t            len;            /**< Concatenated Attribute values length. */
+  uint8_t             values[1];      /**< Attribute values. @note This is a variable length array. The size of 1 indicated is only a placeholder for compilation.
+                                           See @ref sd_ble_evt_get for more information on how to use event structures with variable length array members. */
+} ble_gattc_evt_char_vals_read_rsp_t;
+
+/**@brief Event structure for @ref BLE_GATTC_EVT_WRITE_RSP. */
+typedef struct
+{
+  uint16_t            handle;           /**< Attribute Handle. */
+  uint8_t             write_op;         /**< Type of write operation, see @ref BLE_GATT_WRITE_OPS. */
+  uint16_t            offset;           /**< Data offset. */
+  uint16_t            len;              /**< Data length. */
+  uint8_t             data[1];          /**< Data. @note This is a variable length array. The size of 1 indicated is only a placeholder for compilation.
+                                             See @ref sd_ble_evt_get for more information on how to use event structures with variable length array members. */
+} ble_gattc_evt_write_rsp_t;
+
+/**@brief Event structure for @ref BLE_GATTC_EVT_HVX. */
+typedef struct
+{
+  uint16_t            handle;         /**< Handle to which the HVx operation applies. */
+  uint8_t             type;           /**< Indication or Notification, see @ref BLE_GATT_HVX_TYPES. */
+  uint16_t            len;            /**< Attribute data length. */
+  uint8_t             data[1];        /**< Attribute data. @note This is a variable length array. The size of 1 indicated is only a placeholder for compilation.
+                                           See @ref sd_ble_evt_get for more information on how to use event structures with variable length array members. */
+} ble_gattc_evt_hvx_t;
+
+/**@brief Event structure for @ref BLE_GATTC_EVT_EXCHANGE_MTU_RSP. */
+typedef struct
+{
+  uint16_t          server_rx_mtu;            /**< Server RX MTU size. */
+} ble_gattc_evt_exchange_mtu_rsp_t;
+
+/**@brief Event structure for @ref BLE_GATTC_EVT_TIMEOUT. */
+typedef struct
+{
+  uint8_t          src;                       /**< Timeout source, see @ref BLE_GATT_TIMEOUT_SOURCES. */
+} ble_gattc_evt_timeout_t;
+
+/**@brief Event structure for @ref BLE_GATTC_EVT_WRITE_CMD_TX_COMPLETE. */
+typedef struct
+{
+  uint8_t             count;            /**< Number of write without response transmissions completed. */
+} ble_gattc_evt_write_cmd_tx_complete_t;
+
+/**@brief GATTC event structure. */
+typedef struct
+{
+  uint16_t            conn_handle;                /**< Connection Handle on which event occurred. */
+  uint16_t            gatt_status;                /**< GATT status code for the operation, see @ref BLE_GATT_STATUS_CODES. */
+  uint16_t            error_handle;               /**< In case of error: The handle causing the error. In all other cases @ref BLE_GATT_HANDLE_INVALID. */
+  union
+  {
+    ble_gattc_evt_prim_srvc_disc_rsp_t          prim_srvc_disc_rsp;         /**< Primary Service Discovery Response Event Parameters. */
+    ble_gattc_evt_rel_disc_rsp_t                rel_disc_rsp;               /**< Relationship Discovery Response Event Parameters. */
+    ble_gattc_evt_char_disc_rsp_t               char_disc_rsp;              /**< Characteristic Discovery Response Event Parameters. */
+    ble_gattc_evt_desc_disc_rsp_t               desc_disc_rsp;              /**< Descriptor Discovery Response Event Parameters. */
+    ble_gattc_evt_char_val_by_uuid_read_rsp_t   char_val_by_uuid_read_rsp;  /**< Characteristic Value Read by UUID Response Event Parameters. */
+    ble_gattc_evt_read_rsp_t                    read_rsp;                   /**< Read Response Event Parameters. */
+    ble_gattc_evt_char_vals_read_rsp_t          char_vals_read_rsp;         /**< Characteristic Values Read Response Event Parameters. */
+    ble_gattc_evt_write_rsp_t                   write_rsp;                  /**< Write Response Event Parameters. */
+    ble_gattc_evt_hvx_t                         hvx;                        /**< Handle Value Notification/Indication Event Parameters. */
+    ble_gattc_evt_exchange_mtu_rsp_t            exchange_mtu_rsp;           /**< Exchange MTU Response Event Parameters. */
+    ble_gattc_evt_timeout_t                     timeout;                    /**< Timeout Event Parameters. */
+    ble_gattc_evt_attr_info_disc_rsp_t          attr_info_disc_rsp;         /**< Attribute Information Discovery Event Parameters. */
+    ble_gattc_evt_write_cmd_tx_complete_t       write_cmd_tx_complete;      /**< Write without Response transmission complete Event Parameters. */
+  } params;                                                                 /**< Event Parameters. @note Only valid if @ref gatt_status == @ref BLE_GATT_STATUS_SUCCESS. */
+} ble_gattc_evt_t;
+
+/**@brief UUID discovery option.
+ *
+ * @details Used with @ref sd_ble_opt_set to enable and disable automatic insertion of discovered 128-bit UUIDs to the
+ *          Vendor Specific UUID table. Disabled by default.
+ *          - When disabled, if a procedure initiated by
+ *            @ref sd_ble_gattc_primary_services_discover,
+ *            @ref sd_ble_gattc_relationships_discover,
+ *            @ref sd_ble_gattc_characteristics_discover,
+ *            @ref sd_ble_gattc_descriptors_discover
+ *            finds a 128-bit UUID which was not added by @ref sd_ble_uuid_vs_add, @ref ble_uuid_t::type will be set
+ *            to @ref BLE_UUID_TYPE_UNKNOWN in the corresponding event.
+ *          - When enabled, all found 128-bit UUIDs will be automatically added. The application can use
+ *            @ref sd_ble_uuid_encode to retrieve the 128-bit UUID from @ref ble_uuid_t received in the corresponding
+ *            event. If the total number of Vendor Specific UUIDs exceeds the table capacity, @ref ble_uuid_t::type will
+ *            be set to @ref BLE_UUID_TYPE_UNKNOWN in the corresponding event.
+ *            See also @ref ble_common_cfg_vs_uuid_t, @ref sd_ble_uuid_vs_remove.
+ *
+ * @note @ref sd_ble_opt_get is not supported for this option.
+ *
+ * @retval ::NRF_SUCCESS Set successfully.
+ *
+ */
+typedef struct
+{
+  uint8_t auto_add_vs_enable : 1;   /**< Set to 1 to enable (or 0 to disable) automatic insertion of discovered 128-bit UUIDs. */
+} ble_gattc_opt_uuid_disc_t;
+
+/**@brief Option structure for GATTC options. */
+typedef union
+{
+  ble_gattc_opt_uuid_disc_t uuid_disc;  /**< Parameters for the UUID discovery option. */
+} ble_gattc_opt_t;
+
+/** @} */
+
+/** @addtogroup BLE_GATTC_FUNCTIONS Functions
+ * @{ */
+
+/**@brief Initiate or continue a GATT Primary Service Discovery procedure.
+ *
+ * @details This function initiates or resumes a Primary Service discovery procedure, starting from the supplied handle.
+ *          If the last service has not been reached, this function must be called again with an updated start handle value to continue the search.
+ *          See also @ref ble_gattc_opt_uuid_disc_t.
+ *
+ * @events
+ * @event{@ref BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTC_PRIM_SRVC_DISC_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle The connection handle identifying the connection to perform this procedure on.
+ * @param[in] start_handle Handle to start searching from.
+ * @param[in] p_srvc_uuid Pointer to the service UUID to be found. If it is NULL, all primary services will be returned.
+ *
+ * @retval ::NRF_SUCCESS Successfully started or resumed the Primary Service Discovery procedure.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid Connection State.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ * @retval ::NRF_ERROR_BUSY Client procedure already in progress.
+ * @retval ::NRF_ERROR_TIMEOUT There has been a GATT procedure timeout. No new GATT procedure can be performed without reestablishing the connection.
+ */
+SVCALL(SD_BLE_GATTC_PRIMARY_SERVICES_DISCOVER, uint32_t, sd_ble_gattc_primary_services_discover(uint16_t conn_handle, uint16_t start_handle, ble_uuid_t const *p_srvc_uuid));
+
+
+/**@brief Initiate or continue a GATT Relationship Discovery procedure.
+ *
+ * @details This function initiates or resumes the Find Included Services sub-procedure. If the last included service has not been reached,
+ *          this must be called again with an updated handle range to continue the search.
+ *          See also @ref ble_gattc_opt_uuid_disc_t.
+ *
+ * @events
+ * @event{@ref BLE_GATTC_EVT_REL_DISC_RSP}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTC_REL_DISC_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle The connection handle identifying the connection to perform this procedure on.
+ * @param[in] p_handle_range A pointer to the range of handles of the Service to perform this procedure on.
+ *
+ * @retval ::NRF_SUCCESS Successfully started or resumed the Relationship Discovery procedure.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid Connection State.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ * @retval ::NRF_ERROR_BUSY Client procedure already in progress.
+ * @retval ::NRF_ERROR_TIMEOUT There has been a GATT procedure timeout. No new GATT procedure can be performed without reestablishing the connection.
+ */
+SVCALL(SD_BLE_GATTC_RELATIONSHIPS_DISCOVER, uint32_t, sd_ble_gattc_relationships_discover(uint16_t conn_handle, ble_gattc_handle_range_t const *p_handle_range));
+
+
+/**@brief Initiate or continue a GATT Characteristic Discovery procedure.
+ *
+ * @details This function initiates or resumes a Characteristic discovery procedure. If the last Characteristic has not been reached,
+ *          this must be called again with an updated handle range to continue the discovery.
+ *          See also @ref ble_gattc_opt_uuid_disc_t.
+ *
+ * @events
+ * @event{@ref BLE_GATTC_EVT_CHAR_DISC_RSP}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTC_CHAR_DISC_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle The connection handle identifying the connection to perform this procedure on.
+ * @param[in] p_handle_range A pointer to the range of handles of the Service to perform this procedure on.
+ *
+ * @retval ::NRF_SUCCESS Successfully started or resumed the Characteristic Discovery procedure.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid Connection State.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_BUSY Client procedure already in progress.
+ * @retval ::NRF_ERROR_TIMEOUT There has been a GATT procedure timeout. No new GATT procedure can be performed without reestablishing the connection.
+ */
+SVCALL(SD_BLE_GATTC_CHARACTERISTICS_DISCOVER, uint32_t, sd_ble_gattc_characteristics_discover(uint16_t conn_handle, ble_gattc_handle_range_t const *p_handle_range));
+
+
+/**@brief Initiate or continue a GATT Characteristic Descriptor Discovery procedure.
+ *
+ * @details This function initiates or resumes a Characteristic Descriptor discovery procedure. If the last Descriptor has not been reached,
+ *          this must be called again with an updated handle range to continue the discovery.
+ *          See also @ref ble_gattc_opt_uuid_disc_t.
+ *
+ * @events
+ * @event{@ref BLE_GATTC_EVT_DESC_DISC_RSP}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTC_DESC_DISC_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle The connection handle identifying the connection to perform this procedure on.
+ * @param[in] p_handle_range A pointer to the range of handles of the Characteristic to perform this procedure on.
+ *
+ * @retval ::NRF_SUCCESS Successfully started or resumed the Descriptor Discovery procedure.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid Connection State.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_BUSY Client procedure already in progress.
+ * @retval ::NRF_ERROR_TIMEOUT There has been a GATT procedure timeout. No new GATT procedure can be performed without reestablishing the connection.
+ */
+SVCALL(SD_BLE_GATTC_DESCRIPTORS_DISCOVER, uint32_t, sd_ble_gattc_descriptors_discover(uint16_t conn_handle, ble_gattc_handle_range_t const *p_handle_range));
+
+
+/**@brief Initiate or continue a GATT Read using Characteristic UUID procedure.
+ *
+ * @details This function initiates or resumes a Read using Characteristic UUID procedure. If the last Characteristic has not been reached,
+ *          this must be called again with an updated handle range to continue the discovery.
+ *
+ * @events
+ * @event{@ref BLE_GATTC_EVT_CHAR_VAL_BY_UUID_READ_RSP}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTC_READ_UUID_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle The connection handle identifying the connection to perform this procedure on.
+ * @param[in] p_uuid Pointer to a Characteristic value UUID to read.
+ * @param[in] p_handle_range A pointer to the range of handles to perform this procedure on.
+ *
+ * @retval ::NRF_SUCCESS Successfully started or resumed the Read using Characteristic UUID procedure.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid Connection State.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_BUSY Client procedure already in progress.
+ * @retval ::NRF_ERROR_TIMEOUT There has been a GATT procedure timeout. No new GATT procedure can be performed without reestablishing the connection.
+ */
+SVCALL(SD_BLE_GATTC_CHAR_VALUE_BY_UUID_READ, uint32_t, sd_ble_gattc_char_value_by_uuid_read(uint16_t conn_handle, ble_uuid_t const *p_uuid, ble_gattc_handle_range_t const *p_handle_range));
+
+
+/**@brief Initiate or continue a GATT Read (Long) Characteristic or Descriptor procedure.
+ *
+ * @details This function initiates or resumes a GATT Read (Long) Characteristic or Descriptor procedure. If the Characteristic or Descriptor
+ *          to be read is longer than ATT_MTU - 1, this function must be called multiple times with appropriate offset to read the
+ *          complete value.
+ *
+ * @events
+ * @event{@ref BLE_GATTC_EVT_READ_RSP}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTC_VALUE_READ_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle The connection handle identifying the connection to perform this procedure on.
+ * @param[in] handle The handle of the attribute to be read.
+ * @param[in] offset Offset into the attribute value to be read.
+ *
+ * @retval ::NRF_SUCCESS Successfully started or resumed the Read (Long) procedure.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid Connection State.
+ * @retval ::NRF_ERROR_BUSY Client procedure already in progress.
+ * @retval ::NRF_ERROR_TIMEOUT There has been a GATT procedure timeout. No new GATT procedure can be performed without reestablishing the connection.
+ */
+SVCALL(SD_BLE_GATTC_READ, uint32_t, sd_ble_gattc_read(uint16_t conn_handle, uint16_t handle, uint16_t offset));
+
+
+/**@brief Initiate a GATT Read Multiple Characteristic Values procedure.
+ *
+ * @details This function initiates a GATT Read Multiple Characteristic Values procedure.
+ *
+ * @events
+ * @event{@ref BLE_GATTC_EVT_CHAR_VALS_READ_RSP}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTC_READ_MULT_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle The connection handle identifying the connection to perform this procedure on.
+ * @param[in] p_handles A pointer to the handle(s) of the attribute(s) to be read.
+ * @param[in] handle_count The number of handles in p_handles.
+ *
+ * @retval ::NRF_SUCCESS Successfully started the Read Multiple Characteristic Values procedure.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid Connection State.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_BUSY Client procedure already in progress.
+ * @retval ::NRF_ERROR_TIMEOUT There has been a GATT procedure timeout. No new GATT procedure can be performed without reestablishing the connection.
+ */
+SVCALL(SD_BLE_GATTC_CHAR_VALUES_READ, uint32_t, sd_ble_gattc_char_values_read(uint16_t conn_handle, uint16_t const *p_handles, uint16_t handle_count));
+
+
+/**@brief Perform a Write (Characteristic Value or Descriptor, with or without response, signed or not, long or reliable) procedure.
+ *
+ * @details This function can perform all write procedures described in GATT.
+ *
+ * @note    Only one write with response procedure can be ongoing per connection at a time.
+ *          If the application tries to write with response while another write with response procedure is ongoing,
+ *          the function call will return @ref NRF_ERROR_BUSY.
+ *          A @ref BLE_GATTC_EVT_WRITE_RSP event will be issued as soon as the write response arrives from the peer.
+ *
+ * @note    The number of Write without Response that can be queued is configured by @ref ble_gattc_conn_cfg_t::write_cmd_tx_queue_size
+ *          When the queue is full, the function call will return @ref NRF_ERROR_RESOURCES.
+ *          A @ref BLE_GATTC_EVT_WRITE_CMD_TX_COMPLETE event will be issued as soon as the transmission of the write without response is complete.
+ *
+ * @note    The application can keep track of the available queue element count for writes without responses by following the procedure below:
+ *          - Store initial queue element count in a variable.
+ *          - Decrement the variable, which stores the currently available queue element count, by one when a call to this function returns @ref NRF_SUCCESS.
+ *          - Increment the variable, which stores the current available queue element count, by the count variable in @ref BLE_GATTC_EVT_WRITE_CMD_TX_COMPLETE event.
+ *
+ * @events
+ * @event{@ref BLE_GATTC_EVT_WRITE_CMD_TX_COMPLETE, Write without response transmission complete.}
+ * @event{@ref BLE_GATTC_EVT_WRITE_RSP, Write response received from the peer.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTC_VALUE_WRITE_WITHOUT_RESP_MSC}
+ * @mmsc{@ref BLE_GATTC_VALUE_WRITE_MSC}
+ * @mmsc{@ref BLE_GATTC_VALUE_LONG_WRITE_MSC}
+ * @mmsc{@ref BLE_GATTC_VALUE_RELIABLE_WRITE_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle The connection handle identifying the connection to perform this procedure on.
+ * @param[in] p_write_params A pointer to a write parameters structure.
+ *
+ * @retval ::NRF_SUCCESS Successfully started the Write procedure.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid Connection State.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ * @retval ::NRF_ERROR_DATA_SIZE Invalid data size(s) supplied.
+ * @retval ::NRF_ERROR_BUSY For write with response, procedure already in progress. Wait for a @ref BLE_GATTC_EVT_WRITE_RSP event and retry.
+ * @retval ::NRF_ERROR_RESOURCES Too many writes without responses queued.
+ *                               Wait for a @ref BLE_GATTC_EVT_WRITE_CMD_TX_COMPLETE event and retry.
+ * @retval ::NRF_ERROR_TIMEOUT There has been a GATT procedure timeout. No new GATT procedure can be performed without reestablishing the connection.
+ */
+SVCALL(SD_BLE_GATTC_WRITE, uint32_t, sd_ble_gattc_write(uint16_t conn_handle, ble_gattc_write_params_t const *p_write_params));
+
+
+/**@brief Send a Handle Value Confirmation to the GATT Server.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTC_HVI_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle The connection handle identifying the connection to perform this procedure on.
+ * @param[in] handle The handle of the attribute in the indication.
+ *
+ * @retval ::NRF_SUCCESS Successfully queued the Handle Value Confirmation for transmission.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid Connection State or no Indication pending to be confirmed.
+ * @retval ::BLE_ERROR_INVALID_ATTR_HANDLE Invalid attribute handle.
+ * @retval ::NRF_ERROR_TIMEOUT There has been a GATT procedure timeout. No new GATT procedure can be performed without reestablishing the connection.
+ */
+SVCALL(SD_BLE_GATTC_HV_CONFIRM, uint32_t, sd_ble_gattc_hv_confirm(uint16_t conn_handle, uint16_t handle));
+
+/**@brief Discovers information about a range of attributes on a GATT server.
+ *
+ * @events
+ * @event{@ref BLE_GATTC_EVT_ATTR_INFO_DISC_RSP, Generated when information about a range of attributes has been received.}
+ * @endevents
+ *
+ * @param[in] conn_handle    The connection handle identifying the connection to perform this procedure on.
+ * @param[in] p_handle_range The range of handles to request information about.
+ *
+ * @retval ::NRF_SUCCESS Successfully started an attribute information discovery procedure.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid connection state
+ * @retval ::NRF_ERROR_INVALID_ADDR  Invalid pointer supplied.
+ * @retval ::NRF_ERROR_BUSY Client procedure already in progress.
+ * @retval ::NRF_ERROR_TIMEOUT There has been a GATT procedure timeout. No new GATT procedure can be performed without reestablishing the connection.
+ */
+SVCALL(SD_BLE_GATTC_ATTR_INFO_DISCOVER, uint32_t, sd_ble_gattc_attr_info_discover(uint16_t conn_handle, ble_gattc_handle_range_t const * p_handle_range));
+
+/**@brief Start an ATT_MTU exchange by sending an Exchange MTU Request to the server.
+ *
+ * @details The SoftDevice sets ATT_MTU to the minimum of:
+ *          - The Client RX MTU value, and
+ *          - The Server RX MTU value from @ref BLE_GATTC_EVT_EXCHANGE_MTU_RSP.
+ *
+ *          However, the SoftDevice never sets ATT_MTU lower than @ref BLE_GATT_ATT_MTU_DEFAULT.
+ *
+ * @events
+ * @event{@ref BLE_GATTC_EVT_EXCHANGE_MTU_RSP}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTC_MTU_EXCHANGE}
+ * @endmscs
+ *
+ * @param[in] conn_handle    The connection handle identifying the connection to perform this procedure on.
+ * @param[in] client_rx_mtu  Client RX MTU size.
+ *                           - The minimum value is @ref BLE_GATT_ATT_MTU_DEFAULT.
+ *                           - The maximum value is @ref ble_gatt_conn_cfg_t::att_mtu in the connection configuration
+                               used for this connection.
+ *                           - The value must be equal to Server RX MTU size given in @ref sd_ble_gatts_exchange_mtu_reply
+ *                             if an ATT_MTU exchange has already been performed in the other direction.
+ *
+ * @retval ::NRF_SUCCESS Successfully sent request to the server.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid connection state or an ATT_MTU exchange was already requested once.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid Client RX MTU size supplied.
+ * @retval ::NRF_ERROR_BUSY Client procedure already in progress.
+ * @retval ::NRF_ERROR_TIMEOUT There has been a GATT procedure timeout. No new GATT procedure can be performed without reestablishing the connection.
+ */
+SVCALL(SD_BLE_GATTC_EXCHANGE_MTU_REQUEST, uint32_t, sd_ble_gattc_exchange_mtu_request(uint16_t conn_handle, uint16_t client_rx_mtu));
+
+/**@brief Iterate through Handle-Value(s) list in @ref BLE_GATTC_EVT_CHAR_VAL_BY_UUID_READ_RSP event.
+ *
+ * @param[in] p_gattc_evt  Pointer to event buffer containing @ref BLE_GATTC_EVT_CHAR_VAL_BY_UUID_READ_RSP event.
+ *                         @note If the buffer contains different event, behavior is undefined.
+ * @param[in,out] p_iter   Iterator, points to @ref ble_gattc_handle_value_t structure that will be filled in with
+ *                         the next Handle-Value pair in each iteration. If the function returns other than
+ *                         @ref NRF_SUCCESS, it will not be changed.
+ *                         - To start iteration, initialize the structure to zero.
+ *                         - To continue, pass the value from previous iteration.
+ *
+ * \code
+ * ble_gattc_handle_value_t iter;
+ * memset(&iter, 0, sizeof(ble_gattc_handle_value_t));
+ * while (sd_ble_gattc_evt_char_val_by_uuid_read_rsp_iter(&ble_evt.evt.gattc_evt, &iter) == NRF_SUCCESS)
+ * {
+ *   app_handle = iter.handle;
+ *   memcpy(app_value, iter.p_value, ble_evt.evt.gattc_evt.params.char_val_by_uuid_read_rsp.value_len);
+ * }
+ * \endcode
+ *
+ * @retval ::NRF_SUCCESS Successfully retrieved the next Handle-Value pair.
+ * @retval ::NRF_ERROR_NOT_FOUND No more Handle-Value pairs available in the list.
+ */
+__STATIC_INLINE uint32_t sd_ble_gattc_evt_char_val_by_uuid_read_rsp_iter(ble_gattc_evt_t *p_gattc_evt, ble_gattc_handle_value_t *p_iter);
+
+/** @} */
+
+#ifndef SUPPRESS_INLINE_IMPLEMENTATION
+
+__STATIC_INLINE uint32_t sd_ble_gattc_evt_char_val_by_uuid_read_rsp_iter(ble_gattc_evt_t *p_gattc_evt, ble_gattc_handle_value_t *p_iter)
+{
+  uint32_t value_len = p_gattc_evt->params.char_val_by_uuid_read_rsp.value_len;
+  uint8_t *p_first = p_gattc_evt->params.char_val_by_uuid_read_rsp.handle_value;
+  uint8_t *p_next = p_iter->p_value ? p_iter->p_value + value_len : p_first;
+
+  if ((p_next - p_first) / (sizeof(uint16_t) + value_len) < p_gattc_evt->params.char_val_by_uuid_read_rsp.count)
+  {
+    p_iter->handle = (uint16_t)p_next[1] << 8 | p_next[0];
+    p_iter->p_value = p_next + sizeof(uint16_t);
+    return NRF_SUCCESS;
+  }
+  else
+  {
+    return NRF_ERROR_NOT_FOUND;
+  }
+}
+
+#endif /* SUPPRESS_INLINE_IMPLEMENTATION */
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* BLE_GATTC_H__ */
+
+/**
+  @}
+*/

--- a/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble_gatts.h
+++ b/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble_gatts.h
@@ -1,0 +1,863 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+  @addtogroup BLE_GATTS Generic Attribute Profile (GATT) Server
+  @{
+  @brief  Definitions and prototypes for the GATTS interface.
+ */
+
+#ifndef BLE_GATTS_H__
+#define BLE_GATTS_H__
+
+#include <stdint.h>
+#include "nrf_svc.h"
+#include "nrf_error.h"
+#include "ble_hci.h"
+#include "ble_ranges.h"
+#include "ble_types.h"
+#include "ble_err.h"
+#include "ble_gatt.h"
+#include "ble_gap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @addtogroup BLE_GATTS_ENUMERATIONS Enumerations
+ * @{ */
+
+/**
+ * @brief GATTS API SVC numbers.
+ */
+enum BLE_GATTS_SVCS
+{
+  SD_BLE_GATTS_SERVICE_ADD = BLE_GATTS_SVC_BASE, /**< Add a service. */
+  SD_BLE_GATTS_INCLUDE_ADD,                      /**< Add an included service. */
+  SD_BLE_GATTS_CHARACTERISTIC_ADD,               /**< Add a characteristic. */
+  SD_BLE_GATTS_DESCRIPTOR_ADD,                   /**< Add a generic attribute. */
+  SD_BLE_GATTS_VALUE_SET,                        /**< Set an attribute value. */
+  SD_BLE_GATTS_VALUE_GET,                        /**< Get an attribute value. */
+  SD_BLE_GATTS_HVX,                              /**< Handle Value Notification or Indication. */
+  SD_BLE_GATTS_SERVICE_CHANGED,                  /**< Perform a Service Changed Indication to one or more peers. */
+  SD_BLE_GATTS_RW_AUTHORIZE_REPLY,               /**< Reply to an authorization request for a read or write operation on one or more attributes. */
+  SD_BLE_GATTS_SYS_ATTR_SET,                     /**< Set the persistent system attributes for a connection. */
+  SD_BLE_GATTS_SYS_ATTR_GET,                     /**< Retrieve the persistent system attributes. */
+  SD_BLE_GATTS_INITIAL_USER_HANDLE_GET,          /**< Retrieve the first valid user handle. */
+  SD_BLE_GATTS_ATTR_GET,                         /**< Retrieve the UUID and/or metadata of an attribute. */
+  SD_BLE_GATTS_EXCHANGE_MTU_REPLY                /**< Reply to Exchange MTU Request. */
+};
+
+/**
+ * @brief GATT Server Event IDs.
+ */
+enum BLE_GATTS_EVTS
+{
+  BLE_GATTS_EVT_WRITE = BLE_GATTS_EVT_BASE,       /**< Write operation performed.                                           \n See @ref ble_gatts_evt_write_t.                 */
+  BLE_GATTS_EVT_RW_AUTHORIZE_REQUEST,             /**< Read/Write Authorization request.                                    \n Reply with @ref sd_ble_gatts_rw_authorize_reply. \n See @ref ble_gatts_evt_rw_authorize_request_t. */
+  BLE_GATTS_EVT_SYS_ATTR_MISSING,                 /**< A persistent system attribute access is pending.                     \n Respond with @ref sd_ble_gatts_sys_attr_set.     \n See @ref ble_gatts_evt_sys_attr_missing_t.     */
+  BLE_GATTS_EVT_HVC,                              /**< Handle Value Confirmation.                                           \n See @ref ble_gatts_evt_hvc_t.                   */
+  BLE_GATTS_EVT_SC_CONFIRM,                       /**< Service Changed Confirmation.                                        \n No additional event structure applies.          */
+  BLE_GATTS_EVT_EXCHANGE_MTU_REQUEST,             /**< Exchange MTU Request.                                                \n Reply with @ref sd_ble_gatts_exchange_mtu_reply. \n See @ref ble_gatts_evt_exchange_mtu_request_t. */
+  BLE_GATTS_EVT_TIMEOUT,                          /**< Peer failed to respond to an ATT request in time.                    \n See @ref ble_gatts_evt_timeout_t.               */
+  BLE_GATTS_EVT_HVN_TX_COMPLETE                   /**< Handle Value Notification transmission complete.                     \n See @ref ble_gatts_evt_hvn_tx_complete_t.       */
+};
+
+/**@brief GATTS Configuration IDs.
+ *
+ * IDs that uniquely identify a GATTS configuration.
+ */
+enum BLE_GATTS_CFGS
+{
+  BLE_GATTS_CFG_SERVICE_CHANGED = BLE_GATTS_CFG_BASE, /**< Service changed configuration. */
+  BLE_GATTS_CFG_ATTR_TAB_SIZE,                        /**< Attribute table size configuration. */
+  BLE_GATTS_CFG_SERVICE_CHANGED_CCCD_PERM,            /**< Service changed CCCD permission configuration. */
+};
+
+/** @} */
+
+/** @addtogroup BLE_GATTS_DEFINES Defines
+ * @{ */
+
+/** @defgroup BLE_ERRORS_GATTS SVC return values specific to GATTS
+ * @{ */
+#define BLE_ERROR_GATTS_INVALID_ATTR_TYPE   (NRF_GATTS_ERR_BASE + 0x000) /**< Invalid attribute type. */
+#define BLE_ERROR_GATTS_SYS_ATTR_MISSING    (NRF_GATTS_ERR_BASE + 0x001) /**< System Attributes missing. */
+/** @} */
+
+/** @defgroup BLE_GATTS_ATTR_LENS_MAX Maximum attribute lengths
+ * @{ */
+#define BLE_GATTS_FIX_ATTR_LEN_MAX (510)  /**< Maximum length for fixed length Attribute Values. */
+#define BLE_GATTS_VAR_ATTR_LEN_MAX (512)  /**< Maximum length for variable length Attribute Values. */
+/** @} */
+
+/** @defgroup BLE_GATTS_SRVC_TYPES GATT Server Service Types
+ * @{ */
+#define BLE_GATTS_SRVC_TYPE_INVALID          0x00  /**< Invalid Service Type. */
+#define BLE_GATTS_SRVC_TYPE_PRIMARY          0x01  /**< Primary Service. */
+#define BLE_GATTS_SRVC_TYPE_SECONDARY        0x02  /**< Secondary Type. */
+/** @} */
+
+
+/** @defgroup BLE_GATTS_ATTR_TYPES GATT Server Attribute Types
+ * @{ */
+#define BLE_GATTS_ATTR_TYPE_INVALID         0x00  /**< Invalid Attribute Type. */
+#define BLE_GATTS_ATTR_TYPE_PRIM_SRVC_DECL  0x01  /**< Primary Service Declaration. */
+#define BLE_GATTS_ATTR_TYPE_SEC_SRVC_DECL   0x02  /**< Secondary Service Declaration. */
+#define BLE_GATTS_ATTR_TYPE_INC_DECL        0x03  /**< Include Declaration. */
+#define BLE_GATTS_ATTR_TYPE_CHAR_DECL       0x04  /**< Characteristic Declaration. */
+#define BLE_GATTS_ATTR_TYPE_CHAR_VAL        0x05  /**< Characteristic Value. */
+#define BLE_GATTS_ATTR_TYPE_DESC            0x06  /**< Descriptor. */
+#define BLE_GATTS_ATTR_TYPE_OTHER           0x07  /**< Other, non-GATT specific type. */
+/** @} */
+
+
+/** @defgroup BLE_GATTS_OPS GATT Server Operations
+ * @{ */
+#define BLE_GATTS_OP_INVALID                0x00  /**< Invalid Operation. */
+#define BLE_GATTS_OP_WRITE_REQ              0x01  /**< Write Request. */
+#define BLE_GATTS_OP_WRITE_CMD              0x02  /**< Write Command. */
+#define BLE_GATTS_OP_SIGN_WRITE_CMD         0x03  /**< Signed Write Command. */
+#define BLE_GATTS_OP_PREP_WRITE_REQ         0x04  /**< Prepare Write Request. */
+#define BLE_GATTS_OP_EXEC_WRITE_REQ_CANCEL  0x05  /**< Execute Write Request: Cancel all prepared writes. */
+#define BLE_GATTS_OP_EXEC_WRITE_REQ_NOW     0x06  /**< Execute Write Request: Immediately execute all prepared writes. */
+/** @} */
+
+/** @defgroup BLE_GATTS_VLOCS GATT Value Locations
+ * @{ */
+#define BLE_GATTS_VLOC_INVALID       0x00  /**< Invalid Location. */
+#define BLE_GATTS_VLOC_STACK         0x01  /**< Attribute Value is located in stack memory, no user memory is required. */
+#define BLE_GATTS_VLOC_USER          0x02  /**< Attribute Value is located in user memory. This requires the user to maintain a valid buffer through the lifetime of the attribute, since the stack
+                                                will read and write directly to the memory using the pointer provided in the APIs. There are no alignment requirements for the buffer. */
+/** @} */
+
+/** @defgroup BLE_GATTS_AUTHORIZE_TYPES GATT Server Authorization Types
+ * @{ */
+#define BLE_GATTS_AUTHORIZE_TYPE_INVALID    0x00  /**< Invalid Type. */
+#define BLE_GATTS_AUTHORIZE_TYPE_READ       0x01  /**< Authorize a Read Operation. */
+#define BLE_GATTS_AUTHORIZE_TYPE_WRITE      0x02  /**< Authorize a Write Request Operation. */
+/** @} */
+
+/** @defgroup BLE_GATTS_SYS_ATTR_FLAGS System Attribute Flags
+ * @{ */
+#define BLE_GATTS_SYS_ATTR_FLAG_SYS_SRVCS (1 << 0)  /**< Restrict system attributes to system services only. */
+#define BLE_GATTS_SYS_ATTR_FLAG_USR_SRVCS (1 << 1)  /**< Restrict system attributes to user services only. */
+/** @} */
+
+/** @defgroup BLE_GATTS_SERVICE_CHANGED Service Changed Inclusion Values
+ * @{
+ */
+#define BLE_GATTS_SERVICE_CHANGED_DEFAULT   (1)   /**< Default is to include the Service Changed characteristic in the Attribute Table. */
+/** @} */
+
+/** @defgroup BLE_GATTS_ATTR_TAB_SIZE Attribute Table size
+ * @{
+ */
+#define BLE_GATTS_ATTR_TAB_SIZE_MIN         (248)  /**< Minimum Attribute Table size */
+#define BLE_GATTS_ATTR_TAB_SIZE_DEFAULT     (1408) /**< Default Attribute Table size. */
+/** @} */
+
+/** @defgroup BLE_GATTS_DEFAULTS GATT Server defaults
+ * @{
+ */
+#define BLE_GATTS_HVN_TX_QUEUE_SIZE_DEFAULT  1 /**< Default number of Handle Value Notifications that can be queued for transmission. */
+/** @} */
+
+/** @} */
+
+/** @addtogroup BLE_GATTS_STRUCTURES Structures
+ * @{ */
+
+/**
+ * @brief BLE GATTS connection configuration parameters, set with @ref sd_ble_cfg_set.
+ */
+typedef struct
+{
+  uint8_t  hvn_tx_queue_size; /**< Minimum guaranteed number of Handle Value Notifications that can be queued for transmission.
+                                    The default value is @ref BLE_GATTS_HVN_TX_QUEUE_SIZE_DEFAULT */
+} ble_gatts_conn_cfg_t;
+
+/**@brief Attribute metadata. */
+typedef struct
+{
+  ble_gap_conn_sec_mode_t read_perm;       /**< Read permissions. */
+  ble_gap_conn_sec_mode_t write_perm;      /**< Write permissions. */
+  uint8_t                 vlen       :1;   /**< Variable length attribute. */
+  uint8_t                 vloc       :2;   /**< Value location, see @ref BLE_GATTS_VLOCS.*/
+  uint8_t                 rd_auth    :1;   /**< Read authorization and value will be requested from the application on every read operation. */
+  uint8_t                 wr_auth    :1;   /**< Write authorization will be requested from the application on every Write Request operation (but not Write Command). */
+} ble_gatts_attr_md_t;
+
+
+/**@brief GATT Attribute. */
+typedef struct
+{
+  ble_uuid_t const          *p_uuid;        /**< Pointer to the attribute UUID. */
+  ble_gatts_attr_md_t const *p_attr_md;     /**< Pointer to the attribute metadata structure. */
+  uint16_t                   init_len;      /**< Initial attribute value length in bytes. */
+  uint16_t                   init_offs;     /**< Initial attribute value offset in bytes. If different from zero, the first init_offs bytes of the attribute value will be left uninitialized. */
+  uint16_t                   max_len;       /**< Maximum attribute value length in bytes, see @ref BLE_GATTS_ATTR_LENS_MAX for maximum values. */
+  uint8_t                   *p_value;       /**< Pointer to the attribute data. Please note that if the @ref BLE_GATTS_VLOC_USER value location is selected in the attribute metadata, this will have to point to a buffer
+                                                 that remains valid through the lifetime of the attribute. This excludes usage of automatic variables that may go out of scope or any other temporary location.
+                                                 The stack may access that memory directly without the application's knowledge. For writable characteristics, this value must not be a location in flash memory.*/
+} ble_gatts_attr_t;
+
+/**@brief GATT Attribute Value. */
+typedef struct
+{
+  uint16_t  len;        /**< Length in bytes to be written or read. Length in bytes written or read after successful return.*/
+  uint16_t  offset;     /**< Attribute value offset. */
+  uint8_t  *p_value;    /**< Pointer to where value is stored or will be stored.
+                             If value is stored in user memory, only the attribute length is updated when p_value == NULL.
+                             Set to NULL when reading to obtain the complete length of the attribute value */
+} ble_gatts_value_t;
+
+
+/**@brief GATT Characteristic Presentation Format. */
+typedef struct
+{
+  uint8_t          format;      /**< Format of the value, see @ref BLE_GATT_CPF_FORMATS. */
+  int8_t           exponent;    /**< Exponent for integer data types. */
+  uint16_t         unit;        /**< Unit from Bluetooth Assigned Numbers. */
+  uint8_t          name_space;  /**< Namespace from Bluetooth Assigned Numbers, see @ref BLE_GATT_CPF_NAMESPACES. */
+  uint16_t         desc;        /**< Namespace description from Bluetooth Assigned Numbers, see @ref BLE_GATT_CPF_NAMESPACES. */
+} ble_gatts_char_pf_t;
+
+
+/**@brief GATT Characteristic metadata. */
+typedef struct
+{
+  ble_gatt_char_props_t       char_props;               /**< Characteristic Properties. */
+  ble_gatt_char_ext_props_t   char_ext_props;           /**< Characteristic Extended Properties. */
+  uint8_t const              *p_char_user_desc;         /**< Pointer to a UTF-8 encoded string (non-NULL terminated), NULL if the descriptor is not required. */
+  uint16_t                    char_user_desc_max_size;  /**< The maximum size in bytes of the user description descriptor. */
+  uint16_t                    char_user_desc_size;      /**< The size of the user description, must be smaller or equal to char_user_desc_max_size. */
+  ble_gatts_char_pf_t const  *p_char_pf;                /**< Pointer to a presentation format structure or NULL if the CPF descriptor is not required. */
+  ble_gatts_attr_md_t const  *p_user_desc_md;           /**< Attribute metadata for the User Description descriptor, or NULL for default values. */
+  ble_gatts_attr_md_t const  *p_cccd_md;                /**< Attribute metadata for the Client Characteristic Configuration Descriptor, or NULL for default values. */
+  ble_gatts_attr_md_t const  *p_sccd_md;                /**< Attribute metadata for the Server Characteristic Configuration Descriptor, or NULL for default values. */
+} ble_gatts_char_md_t;
+
+
+/**@brief GATT Characteristic Definition Handles. */
+typedef struct
+{
+  uint16_t          value_handle;       /**< Handle to the characteristic value. */
+  uint16_t          user_desc_handle;   /**< Handle to the User Description descriptor, or @ref BLE_GATT_HANDLE_INVALID if not present. */
+  uint16_t          cccd_handle;        /**< Handle to the Client Characteristic Configuration Descriptor, or @ref BLE_GATT_HANDLE_INVALID if not present. */
+  uint16_t          sccd_handle;        /**< Handle to the Server Characteristic Configuration Descriptor, or @ref BLE_GATT_HANDLE_INVALID if not present. */
+} ble_gatts_char_handles_t;
+
+
+/**@brief GATT HVx parameters. */
+typedef struct
+{
+  uint16_t          handle;             /**< Characteristic Value Handle. */
+  uint8_t           type;               /**< Indication or Notification, see @ref BLE_GATT_HVX_TYPES. */
+  uint16_t          offset;             /**< Offset within the attribute value. */
+  uint16_t         *p_len;              /**< Length in bytes to be written, length in bytes written after return. */
+  uint8_t const    *p_data;             /**< Actual data content, use NULL to use the current attribute value. */
+} ble_gatts_hvx_params_t;
+
+/**@brief GATT Authorization parameters. */
+typedef struct
+{
+  uint16_t          gatt_status;        /**< GATT status code for the operation, see @ref BLE_GATT_STATUS_CODES. */
+  uint8_t           update : 1;         /**< If set, data supplied in p_data will be used to update the attribute value.
+                                             Please note that for @ref BLE_GATTS_AUTHORIZE_TYPE_WRITE operations this bit must always be set,
+                                             as the data to be written needs to be stored and later provided by the application. */
+  uint16_t          offset;             /**< Offset of the attribute value being updated. */
+  uint16_t          len;                /**< Length in bytes of the value in p_data pointer, see @ref BLE_GATTS_ATTR_LENS_MAX. */
+  uint8_t const    *p_data;             /**< Pointer to new value used to update the attribute value. */
+} ble_gatts_authorize_params_t;
+
+/**@brief GATT Read or Write Authorize Reply parameters. */
+typedef struct
+{
+  uint8_t                               type;   /**< Type of authorize operation, see @ref BLE_GATTS_AUTHORIZE_TYPES. */
+  union {
+    ble_gatts_authorize_params_t        read;   /**< Read authorization parameters. */
+    ble_gatts_authorize_params_t        write;  /**< Write authorization parameters. */
+  } params;                                     /**< Reply Parameters. */
+} ble_gatts_rw_authorize_reply_params_t;
+
+/**@brief Service Changed Inclusion configuration parameters, set with @ref sd_ble_cfg_set. */
+typedef struct
+{
+  uint8_t service_changed : 1;       /**< If 1, include the Service Changed characteristic in the Attribute Table. Default is @ref BLE_GATTS_SERVICE_CHANGED_DEFAULT. */
+} ble_gatts_cfg_service_changed_t;
+
+/**@brief Service Changed CCCD permission configuration parameters, set with @ref sd_ble_cfg_set.
+ *
+ * @note @ref ble_gatts_attr_md_t::vlen is ignored and should be set to 0.
+ *
+ * @retval ::NRF_ERROR_INVALID_PARAM One or more of the following is true:
+ *                                   - @ref ble_gatts_attr_md_t::write_perm is out of range.
+ *                                   - @ref ble_gatts_attr_md_t::write_perm is @ref BLE_GAP_CONN_SEC_MODE_SET_NO_ACCESS, that is not allowed by the Bluetooth Specification.
+ *                                   - wrong @ref ble_gatts_attr_md_t::read_perm, only @ref BLE_GAP_CONN_SEC_MODE_SET_OPEN is allowed by the Bluetooth Specification.
+ *                                   - wrong @ref ble_gatts_attr_md_t::vloc, only @ref BLE_GATTS_VLOC_STACK is allowed.
+ * @retval ::NRF_ERROR_NOT_SUPPORTED Security Mode 2 not supported
+ */
+typedef struct
+{
+  ble_gatts_attr_md_t perm;          /**< Permission for Service Changed CCCD. Default is @ref BLE_GAP_CONN_SEC_MODE_SET_OPEN, no authorization. */
+} ble_gatts_cfg_service_changed_cccd_perm_t;
+
+/**@brief Attribute table size configuration parameters, set with @ref sd_ble_cfg_set.
+ *
+ * @retval ::NRF_ERROR_INVALID_LENGTH One or more of the following is true:
+ *                                    - The specified Attribute Table size is too small.
+ *                                      The minimum acceptable size is defined by @ref BLE_GATTS_ATTR_TAB_SIZE_MIN.
+ *                                    - The specified Attribute Table size is not a multiple of 4.
+ */
+typedef struct
+{
+  uint32_t attr_tab_size; /**< Attribute table size. Default is @ref BLE_GATTS_ATTR_TAB_SIZE_DEFAULT, minimum is @ref BLE_GATTS_ATTR_TAB_SIZE_MIN. */
+} ble_gatts_cfg_attr_tab_size_t;
+
+/**@brief Config structure for GATTS configurations. */
+typedef union
+{
+  ble_gatts_cfg_service_changed_t service_changed;  /**< Include service changed characteristic, cfg_id is @ref BLE_GATTS_CFG_SERVICE_CHANGED. */
+  ble_gatts_cfg_service_changed_cccd_perm_t service_changed_cccd_perm; /**< Service changed CCCD permission, cfg_id is @ref BLE_GATTS_CFG_SERVICE_CHANGED_CCCD_PERM. */
+  ble_gatts_cfg_attr_tab_size_t attr_tab_size;      /**< Attribute table size, cfg_id is @ref BLE_GATTS_CFG_ATTR_TAB_SIZE. */
+} ble_gatts_cfg_t;
+
+
+/**@brief Event structure for @ref BLE_GATTS_EVT_WRITE. */
+typedef struct
+{
+  uint16_t                    handle;             /**< Attribute Handle. */
+  ble_uuid_t                  uuid;               /**< Attribute UUID. */
+  uint8_t                     op;                 /**< Type of write operation, see @ref BLE_GATTS_OPS. */
+  uint8_t                     auth_required;      /**< Writing operation deferred due to authorization requirement. Application may use @ref sd_ble_gatts_value_set to finalize the writing operation. */
+  uint16_t                    offset;             /**< Offset for the write operation. */
+  uint16_t                    len;                /**< Length of the received data. */
+  uint8_t                     data[1];            /**< Received data. @note This is a variable length array. The size of 1 indicated is only a placeholder for compilation.
+                                                       See @ref sd_ble_evt_get for more information on how to use event structures with variable length array members. */
+} ble_gatts_evt_write_t;
+
+/**@brief Event substructure for authorized read requests, see @ref ble_gatts_evt_rw_authorize_request_t. */
+typedef struct
+{
+  uint16_t                    handle;             /**< Attribute Handle. */
+  ble_uuid_t                  uuid;               /**< Attribute UUID. */
+  uint16_t                    offset;             /**< Offset for the read operation. */
+} ble_gatts_evt_read_t;
+
+/**@brief Event structure for @ref BLE_GATTS_EVT_RW_AUTHORIZE_REQUEST. */
+typedef struct
+{
+  uint8_t                     type;             /**< Type of authorize operation, see @ref BLE_GATTS_AUTHORIZE_TYPES. */
+  union {
+    ble_gatts_evt_read_t      read;             /**< Attribute Read Parameters. */
+    ble_gatts_evt_write_t     write;            /**< Attribute Write Parameters. */
+  } request;                                    /**< Request Parameters. */
+} ble_gatts_evt_rw_authorize_request_t;
+
+/**@brief Event structure for @ref BLE_GATTS_EVT_SYS_ATTR_MISSING. */
+typedef struct
+{
+  uint8_t hint;                                 /**< Hint (currently unused). */
+} ble_gatts_evt_sys_attr_missing_t;
+
+
+/**@brief Event structure for @ref BLE_GATTS_EVT_HVC. */
+typedef struct
+{
+  uint16_t          handle;                       /**< Attribute Handle. */
+} ble_gatts_evt_hvc_t;
+
+/**@brief Event structure for @ref BLE_GATTS_EVT_EXCHANGE_MTU_REQUEST. */
+typedef struct
+{
+  uint16_t          client_rx_mtu;              /**< Client RX MTU size. */
+} ble_gatts_evt_exchange_mtu_request_t;
+
+/**@brief Event structure for @ref BLE_GATTS_EVT_TIMEOUT. */
+typedef struct
+{
+  uint8_t          src;                       /**< Timeout source, see @ref BLE_GATT_TIMEOUT_SOURCES. */
+} ble_gatts_evt_timeout_t;
+
+/**@brief Event structure for @ref BLE_GATTS_EVT_HVN_TX_COMPLETE. */
+typedef struct
+{
+  uint8_t          count;                     /**< Number of notification transmissions completed. */
+} ble_gatts_evt_hvn_tx_complete_t;
+
+/**@brief GATTS event structure. */
+typedef struct
+{
+  uint16_t conn_handle;                                       /**< Connection Handle on which the event occurred. */
+  union
+  {
+    ble_gatts_evt_write_t                 write;                 /**< Write Event Parameters. */
+    ble_gatts_evt_rw_authorize_request_t  authorize_request;     /**< Read or Write Authorize Request Parameters. */
+    ble_gatts_evt_sys_attr_missing_t      sys_attr_missing;      /**< System attributes missing. */
+    ble_gatts_evt_hvc_t                   hvc;                   /**< Handle Value Confirmation Event Parameters. */
+    ble_gatts_evt_exchange_mtu_request_t  exchange_mtu_request;  /**< Exchange MTU Request Event Parameters. */
+    ble_gatts_evt_timeout_t               timeout;               /**< Timeout Event. */
+    ble_gatts_evt_hvn_tx_complete_t       hvn_tx_complete;       /**< Handle Value Notification transmission complete Event Parameters. */
+  } params;                                                      /**< Event Parameters. */
+} ble_gatts_evt_t;
+
+/** @} */
+
+/** @addtogroup BLE_GATTS_FUNCTIONS Functions
+ * @{ */
+
+/**@brief Add a service declaration to the Attribute Table.
+ *
+ * @note Secondary Services are only relevant in the context of the entity that references them, it is therefore forbidden to
+ *       add a secondary service declaration that is not referenced by another service later in the Attribute Table.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTS_ATT_TABLE_POP_MSC}
+ * @endmscs
+ *
+ * @param[in] type      Toggles between primary and secondary services, see @ref BLE_GATTS_SRVC_TYPES.
+ * @param[in] p_uuid    Pointer to service UUID.
+ * @param[out] p_handle Pointer to a 16-bit word where the assigned handle will be stored.
+ *
+ * @retval ::NRF_SUCCESS Successfully added a service declaration.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied, Vendor Specific UUIDs need to be present in the table.
+ * @retval ::NRF_ERROR_FORBIDDEN Forbidden value supplied, certain UUIDs are reserved for the stack.
+ * @retval ::NRF_ERROR_NO_MEM Not enough memory to complete operation.
+ */
+SVCALL(SD_BLE_GATTS_SERVICE_ADD, uint32_t, sd_ble_gatts_service_add(uint8_t type, ble_uuid_t const *p_uuid, uint16_t *p_handle));
+
+
+/**@brief Add an include declaration to the Attribute Table.
+ *
+ * @note It is currently only possible to add an include declaration to the last added service (i.e. only sequential population is supported at this time).
+ *
+ * @note The included service must already be present in the Attribute Table prior to this call.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTS_ATT_TABLE_POP_MSC}
+ * @endmscs
+ *
+ * @param[in] service_handle    Handle of the service where the included service is to be placed, if @ref BLE_GATT_HANDLE_INVALID is used, it will be placed sequentially.
+ * @param[in] inc_srvc_handle   Handle of the included service.
+ * @param[out] p_include_handle Pointer to a 16-bit word where the assigned handle will be stored.
+ *
+ * @retval ::NRF_SUCCESS Successfully added an include declaration.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied, handle values need to match previously added services.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid state to perform operation, a service context is required.
+ * @retval ::NRF_ERROR_NOT_SUPPORTED Feature is not supported, service_handle must be that of the last added service.
+ * @retval ::NRF_ERROR_FORBIDDEN Forbidden value supplied, self inclusions are not allowed.
+ * @retval ::NRF_ERROR_NO_MEM Not enough memory to complete operation.
+ * @retval ::NRF_ERROR_NOT_FOUND Attribute not found.
+ */
+SVCALL(SD_BLE_GATTS_INCLUDE_ADD, uint32_t, sd_ble_gatts_include_add(uint16_t service_handle, uint16_t inc_srvc_handle, uint16_t *p_include_handle));
+
+
+/**@brief Add a characteristic declaration, a characteristic value declaration and optional characteristic descriptor declarations to the Attribute Table.
+ *
+ * @note It is currently only possible to add a characteristic to the last added service (i.e. only sequential population is supported at this time).
+ *
+ * @note Several restrictions apply to the parameters, such as matching permissions between the user description descriptor and the writable auxiliaries bits,
+ *       readable (no security) and writable (selectable) CCCDs and SCCDs and valid presentation format values.
+ *
+ * @note If no metadata is provided for the optional descriptors, their permissions will be derived from the characteristic permissions.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTS_ATT_TABLE_POP_MSC}
+ * @endmscs
+ *
+ * @param[in] service_handle    Handle of the service where the characteristic is to be placed, if @ref BLE_GATT_HANDLE_INVALID is used, it will be placed sequentially.
+ * @param[in] p_char_md         Characteristic metadata.
+ * @param[in] p_attr_char_value Pointer to the attribute structure corresponding to the characteristic value.
+ * @param[out] p_handles        Pointer to the structure where the assigned handles will be stored.
+ *
+ * @retval ::NRF_SUCCESS Successfully added a characteristic.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied, service handle, Vendor Specific UUIDs, lengths, and permissions need to adhere to the constraints.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid state to perform operation, a service context is required.
+ * @retval ::NRF_ERROR_FORBIDDEN Forbidden value supplied, certain UUIDs are reserved for the stack.
+ * @retval ::NRF_ERROR_NO_MEM Not enough memory to complete operation.
+ * @retval ::NRF_ERROR_DATA_SIZE Invalid data size(s) supplied, attribute lengths are restricted by @ref BLE_GATTS_ATTR_LENS_MAX.
+ */
+SVCALL(SD_BLE_GATTS_CHARACTERISTIC_ADD, uint32_t, sd_ble_gatts_characteristic_add(uint16_t service_handle, ble_gatts_char_md_t const *p_char_md, ble_gatts_attr_t const *p_attr_char_value, ble_gatts_char_handles_t *p_handles));
+
+
+/**@brief Add a descriptor to the Attribute Table.
+ *
+ * @note It is currently only possible to add a descriptor to the last added characteristic (i.e. only sequential population is supported at this time).
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTS_ATT_TABLE_POP_MSC}
+ * @endmscs
+ *
+ * @param[in] char_handle   Handle of the characteristic where the descriptor is to be placed, if @ref BLE_GATT_HANDLE_INVALID is used, it will be placed sequentially.
+ * @param[in] p_attr        Pointer to the attribute structure.
+ * @param[out] p_handle     Pointer to a 16-bit word where the assigned handle will be stored.
+ *
+ * @retval ::NRF_SUCCESS Successfully added a descriptor.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied, characteristic handle, Vendor Specific UUIDs, lengths, and permissions need to adhere to the constraints.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid state to perform operation, a characteristic context is required.
+ * @retval ::NRF_ERROR_FORBIDDEN Forbidden value supplied, certain UUIDs are reserved for the stack.
+ * @retval ::NRF_ERROR_NO_MEM Not enough memory to complete operation.
+ * @retval ::NRF_ERROR_DATA_SIZE Invalid data size(s) supplied, attribute lengths are restricted by @ref BLE_GATTS_ATTR_LENS_MAX.
+ */
+SVCALL(SD_BLE_GATTS_DESCRIPTOR_ADD, uint32_t, sd_ble_gatts_descriptor_add(uint16_t char_handle, ble_gatts_attr_t const *p_attr, uint16_t *p_handle));
+
+/**@brief Set the value of a given attribute.
+ *
+ * @note Values other than system attributes can be set at any time, regardless of whether any active connections exist.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTS_QUEUED_WRITE_QUEUE_FULL_MSC}
+ * @mmsc{@ref BLE_GATTS_QUEUED_WRITE_NOBUF_NOAUTH_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle  Connection handle. Ignored if the value does not belong to a system attribute.
+ * @param[in] handle       Attribute handle.
+ * @param[in,out] p_value  Attribute value information.
+ *
+ * @retval ::NRF_SUCCESS Successfully set the value of the attribute.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ * @retval ::NRF_ERROR_NOT_FOUND Attribute not found.
+ * @retval ::NRF_ERROR_FORBIDDEN Forbidden handle supplied, certain attributes are not modifiable by the application.
+ * @retval ::NRF_ERROR_DATA_SIZE Invalid data size(s) supplied, attribute lengths are restricted by @ref BLE_GATTS_ATTR_LENS_MAX.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied on a system attribute.
+ */
+SVCALL(SD_BLE_GATTS_VALUE_SET, uint32_t, sd_ble_gatts_value_set(uint16_t conn_handle, uint16_t handle, ble_gatts_value_t *p_value));
+
+/**@brief Get the value of a given attribute.
+ *
+ * @note                 If the attribute value is longer than the size of the supplied buffer,
+ *                       @ref ble_gatts_value_t::len will return the total attribute value length (excluding offset),
+ *                       and not the number of bytes actually returned in @ref ble_gatts_value_t::p_value.
+ *                       The application may use this information to allocate a suitable buffer size.
+ *
+ * @note                 When retrieving system attribute values with this function, the connection handle
+ *                       may refer to an already disconnected connection. Refer to the documentation of
+ *                       @ref sd_ble_gatts_sys_attr_get for further information.
+ *
+ * @param[in] conn_handle  Connection handle. Ignored if the value does not belong to a system attribute.
+ * @param[in] handle       Attribute handle.
+ * @param[in,out] p_value  Attribute value information.
+ *
+ * @retval ::NRF_SUCCESS Successfully retrieved the value of the attribute.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_NOT_FOUND Attribute not found.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid attribute offset supplied.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid connection handle supplied on a system attribute.
+ * @retval ::BLE_ERROR_GATTS_SYS_ATTR_MISSING System attributes missing, use @ref sd_ble_gatts_sys_attr_set to set them to a known value.
+ */
+SVCALL(SD_BLE_GATTS_VALUE_GET, uint32_t, sd_ble_gatts_value_get(uint16_t conn_handle, uint16_t handle, ble_gatts_value_t *p_value));
+
+/**@brief Notify or Indicate an attribute value.
+ *
+ * @details This function checks for the relevant Client Characteristic Configuration descriptor value to verify that the relevant operation
+ *          (notification or indication) has been enabled by the client. It is also able to update the attribute value before issuing the PDU, so that
+ *          the application can atomically perform a value update and a server initiated transaction with a single API call.
+ *
+ * @note    The local attribute value may be updated even if an outgoing packet is not sent to the peer due to an error during execution.
+ *          The Attribute Table has been updated if one of the following error codes is returned: @ref NRF_ERROR_INVALID_STATE, @ref NRF_ERROR_BUSY,
+ *          @ref NRF_ERROR_FORBIDDEN, @ref BLE_ERROR_GATTS_SYS_ATTR_MISSING and @ref NRF_ERROR_RESOURCES.
+ *          The caller can check whether the value has been updated by looking at the contents of *(@ref ble_gatts_hvx_params_t::p_len).
+ *
+ * @note    Only one indication procedure can be ongoing per connection at a time.
+ *          If the application tries to indicate an attribute value while another indication procedure is ongoing,
+ *          the function call will return @ref NRF_ERROR_BUSY.
+ *          A @ref BLE_GATTS_EVT_HVC event will be issued as soon as the confirmation arrives from the peer.
+ *
+ * @note    The number of Handle Value Notifications that can be queued is configured by @ref ble_gatts_conn_cfg_t::hvn_tx_queue_size
+ *          When the queue is full, the function call will return @ref NRF_ERROR_RESOURCES.
+ *          A @ref BLE_GATTS_EVT_HVN_TX_COMPLETE event will be issued as soon as the transmission of the notification is complete.
+ *
+ * @note    The application can keep track of the available queue element count for notifications by following the procedure below:
+ *          - Store initial queue element count in a variable.
+ *          - Decrement the variable, which stores the currently available queue element count, by one when a call to this function returns @ref NRF_SUCCESS.
+ *          - Increment the variable, which stores the current available queue element count, by the count variable in @ref BLE_GATTS_EVT_HVN_TX_COMPLETE event.
+ *
+ * @events
+ * @event{@ref BLE_GATTS_EVT_HVN_TX_COMPLETE, Notification transmission complete.}
+ * @event{@ref BLE_GATTS_EVT_HVC, Confirmation received from the peer.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTS_HVX_SYS_ATTRS_MISSING_MSC}
+ * @mmsc{@ref BLE_GATTS_HVN_MSC}
+ * @mmsc{@ref BLE_GATTS_HVI_MSC}
+ * @mmsc{@ref BLE_GATTS_HVX_DISABLED_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle      Connection handle.
+ * @param[in,out] p_hvx_params Pointer to an HVx parameters structure. If @ref ble_gatts_hvx_params_t::p_data
+ *                             contains a non-NULL pointer the attribute value will be updated with the contents
+ *                             pointed by it before sending the notification or indication. If the attribute value
+ *                             is updated, @ref ble_gatts_hvx_params_t::p_len is updated by the SoftDevice to
+ *                             contain the number of actual bytes written, else it will be set to 0.
+ *
+ * @retval ::NRF_SUCCESS Successfully queued a notification or indication for transmission, and optionally updated the attribute value.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_STATE One or more of the following is true:
+ *                                   - Invalid Connection State
+ *                                   - Notifications and/or indications not enabled in the CCCD
+ *                                   - An ATT_MTU exchange is ongoing
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ * @retval ::BLE_ERROR_INVALID_ATTR_HANDLE Invalid attribute handle(s) supplied. Only attributes added directly by the application are available to notify and indicate.
+ * @retval ::BLE_ERROR_GATTS_INVALID_ATTR_TYPE Invalid attribute type(s) supplied, only characteristic values may be notified and indicated.
+ * @retval ::NRF_ERROR_NOT_FOUND Attribute not found.
+ * @retval ::NRF_ERROR_FORBIDDEN The connection's current security level is lower than the one required by the write permissions of the CCCD associated with this characteristic.
+ * @retval ::NRF_ERROR_DATA_SIZE Invalid data size(s) supplied.
+ * @retval ::NRF_ERROR_BUSY For @ref BLE_GATT_HVX_INDICATION Procedure already in progress. Wait for a @ref BLE_GATTS_EVT_HVC event and retry.
+ * @retval ::BLE_ERROR_GATTS_SYS_ATTR_MISSING System attributes missing, use @ref sd_ble_gatts_sys_attr_set to set them to a known value.
+ * @retval ::NRF_ERROR_RESOURCES Too many notifications queued.
+ *                               Wait for a @ref BLE_GATTS_EVT_HVN_TX_COMPLETE event and retry.
+ * @retval ::NRF_ERROR_TIMEOUT There has been a GATT procedure timeout. No new GATT procedure can be performed without reestablishing the connection.
+ */
+SVCALL(SD_BLE_GATTS_HVX, uint32_t, sd_ble_gatts_hvx(uint16_t conn_handle, ble_gatts_hvx_params_t const *p_hvx_params));
+
+/**@brief Indicate the Service Changed attribute value.
+ *
+ * @details This call will send a Handle Value Indication to one or more peers connected to inform them that the Attribute
+ *          Table layout has changed. As soon as the peer has confirmed the indication, a @ref BLE_GATTS_EVT_SC_CONFIRM event will
+ *          be issued.
+ *
+ * @note    Some of the restrictions and limitations that apply to @ref sd_ble_gatts_hvx also apply here.
+ *
+ * @events
+ * @event{@ref BLE_GATTS_EVT_SC_CONFIRM, Confirmation of attribute table change received from peer.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTS_SC_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle  Connection handle.
+ * @param[in] start_handle Start of affected attribute handle range.
+ * @param[in] end_handle   End of affected attribute handle range.
+ *
+ * @retval ::NRF_SUCCESS Successfully queued the Service Changed indication for transmission.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
+ * @retval ::NRF_ERROR_NOT_SUPPORTED Service Changed not enabled at initialization. See @ref
+ *                                   sd_ble_cfg_set and @ref ble_gatts_cfg_service_changed_t.
+ * @retval ::NRF_ERROR_INVALID_STATE One or more of the following is true:
+ *                                   - Invalid Connection State
+ *                                   - Notifications and/or indications not enabled in the CCCD
+ *                                   - An ATT_MTU exchange is ongoing
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
+ * @retval ::BLE_ERROR_INVALID_ATTR_HANDLE Invalid attribute handle(s) supplied, handles must be in the range populated by the application.
+ * @retval ::NRF_ERROR_BUSY Procedure already in progress.
+ * @retval ::BLE_ERROR_GATTS_SYS_ATTR_MISSING System attributes missing, use @ref sd_ble_gatts_sys_attr_set to set them to a known value.
+ * @retval ::NRF_ERROR_TIMEOUT There has been a GATT procedure timeout. No new GATT procedure can be performed without reestablishing the connection.
+ */
+SVCALL(SD_BLE_GATTS_SERVICE_CHANGED, uint32_t, sd_ble_gatts_service_changed(uint16_t conn_handle, uint16_t start_handle, uint16_t end_handle));
+
+/**@brief Respond to a Read/Write authorization request.
+ *
+ * @note This call should only be used as a response to a @ref BLE_GATTS_EVT_RW_AUTHORIZE_REQUEST event issued to the application.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTS_QUEUED_WRITE_NOBUF_AUTH_MSC}
+ * @mmsc{@ref BLE_GATTS_QUEUED_WRITE_BUF_AUTH_MSC}
+ * @mmsc{@ref BLE_GATTS_QUEUED_WRITE_NOBUF_NOAUTH_MSC}
+ * @mmsc{@ref BLE_GATTS_READ_REQ_AUTH_MSC}
+ * @mmsc{@ref BLE_GATTS_WRITE_REQ_AUTH_MSC}
+ * @mmsc{@ref BLE_GATTS_QUEUED_WRITE_QUEUE_FULL_MSC}
+ * @mmsc{@ref BLE_GATTS_QUEUED_WRITE_PEER_CANCEL_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle                 Connection handle.
+ * @param[in] p_rw_authorize_reply_params Pointer to a structure with the attribute provided by the application.
+ *
+ * @note @ref ble_gatts_authorize_params_t::p_data is ignored when this function is used to respond
+ *       to a @ref BLE_GATTS_AUTHORIZE_TYPE_READ event if @ref ble_gatts_authorize_params_t::update
+ *       is set to 0.
+ *
+ * @retval ::NRF_SUCCESS               Successfully queued a response to the peer, and in the case of a write operation, Attribute Table updated.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
+ * @retval ::NRF_ERROR_BUSY            The stack is busy, process pending events and retry.
+ * @retval ::NRF_ERROR_INVALID_ADDR    Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_STATE   Invalid Connection State or no authorization request pending.
+ * @retval ::NRF_ERROR_INVALID_PARAM   Authorization op invalid,
+ *                                         handle supplied does not match requested handle,
+ *                                         or invalid data to be written provided by the application.
+ * @retval ::NRF_ERROR_TIMEOUT There has been a GATT procedure timeout. No new GATT procedure can be performed without reestablishing the connection.
+ */
+SVCALL(SD_BLE_GATTS_RW_AUTHORIZE_REPLY, uint32_t, sd_ble_gatts_rw_authorize_reply(uint16_t conn_handle, ble_gatts_rw_authorize_reply_params_t const *p_rw_authorize_reply_params));
+
+
+/**@brief Update persistent system attribute information.
+ *
+ * @details Supply information about persistent system attributes to the stack,
+ *          previously obtained using @ref sd_ble_gatts_sys_attr_get.
+ *          This call is only allowed for active connections, and is usually
+ *          made immediately after a connection is established with an known bonded device,
+ *          often as a response to a @ref BLE_GATTS_EVT_SYS_ATTR_MISSING.
+ *
+ *          p_sysattrs may point directly to the application's stored copy of the system attributes
+ *          obtained using @ref sd_ble_gatts_sys_attr_get.
+ *          If the pointer is NULL, the system attribute info is initialized, assuming that
+ *          the application does not have any previously saved system attribute data for this device.
+ *
+ * @note The state of persistent system attributes is reset upon connection establishment and then remembered for its duration.
+ *
+ * @note If this call returns with an error code different from @ref NRF_SUCCESS, the storage of persistent system attributes may have been completed only partially.
+ *       This means that the state of the attribute table is undefined, and the application should either provide a new set of attributes using this same call or
+ *       reset the SoftDevice to return to a known state.
+ *
+ * @note When the @ref BLE_GATTS_SYS_ATTR_FLAG_SYS_SRVCS is used with this function, only the system attributes included in system services will be modified.
+ * @note When the @ref BLE_GATTS_SYS_ATTR_FLAG_USR_SRVCS is used with this function, only the system attributes included in user services will be modified.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTS_HVX_SYS_ATTRS_MISSING_MSC}
+ * @mmsc{@ref BLE_GATTS_SYS_ATTRS_UNK_PEER_MSC}
+ * @mmsc{@ref BLE_GATTS_SYS_ATTRS_BONDED_PEER_MSC}
+ * @endmscs
+ *
+ * @param[in]  conn_handle        Connection handle.
+ * @param[in]  p_sys_attr_data    Pointer to a saved copy of system attributes supplied to the stack, or NULL.
+ * @param[in]  len                Size of data pointed by p_sys_attr_data, in octets.
+ * @param[in]  flags              Optional additional flags, see @ref BLE_GATTS_SYS_ATTR_FLAGS
+ *
+ * @retval ::NRF_SUCCESS Successfully set the system attribute information.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid Connection State.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid flags supplied.
+ * @retval ::NRF_ERROR_INVALID_DATA Invalid data supplied, the data should be exactly the same as retrieved with @ref sd_ble_gatts_sys_attr_get.
+ * @retval ::NRF_ERROR_NO_MEM Not enough memory to complete operation.
+ */
+SVCALL(SD_BLE_GATTS_SYS_ATTR_SET, uint32_t, sd_ble_gatts_sys_attr_set(uint16_t conn_handle, uint8_t const *p_sys_attr_data, uint16_t len, uint32_t flags));
+
+
+/**@brief Retrieve persistent system attribute information from the stack.
+ *
+ * @details This call is used to retrieve information about values to be stored persistently by the application
+ *          during the lifetime of a connection or after it has been terminated. When a new connection is established with the same bonded device,
+ *          the system attribute information retrieved with this function should be restored using using @ref sd_ble_gatts_sys_attr_set.
+ *          If retrieved after disconnection, the data should be read before a new connection established. The connection handle for
+ *          the previous, now disconnected, connection will remain valid until a new one is created to allow this API call to refer to it.
+ *          Connection handles belonging to active connections can be used as well, but care should be taken since the system attributes
+ *          may be written to at any time by the peer during a connection's lifetime.
+ *
+ * @note When the @ref BLE_GATTS_SYS_ATTR_FLAG_SYS_SRVCS is used with this function, only the system attributes included in system services will be returned.
+ * @note When the @ref BLE_GATTS_SYS_ATTR_FLAG_USR_SRVCS is used with this function, only the system attributes included in user services will be returned.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTS_SYS_ATTRS_BONDED_PEER_MSC}
+ * @endmscs
+ *
+ * @param[in]     conn_handle       Connection handle of the recently terminated connection.
+ * @param[out]    p_sys_attr_data   Pointer to a buffer where updated information about system attributes will be filled in. The format of the data is described
+ *                                  in @ref BLE_GATTS_SYS_ATTRS_FORMAT. NULL can be provided to obtain the length of the data.
+ * @param[in,out] p_len             Size of application buffer if p_sys_attr_data is not NULL. Unconditionally updated to actual length of system attribute data.
+ * @param[in]     flags             Optional additional flags, see @ref BLE_GATTS_SYS_ATTR_FLAGS
+ *
+ * @retval ::NRF_SUCCESS Successfully retrieved the system attribute information.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid flags supplied.
+ * @retval ::NRF_ERROR_DATA_SIZE The system attribute information did not fit into the provided buffer.
+ * @retval ::NRF_ERROR_NOT_FOUND No system attributes found.
+ */
+SVCALL(SD_BLE_GATTS_SYS_ATTR_GET, uint32_t, sd_ble_gatts_sys_attr_get(uint16_t conn_handle, uint8_t *p_sys_attr_data, uint16_t *p_len, uint32_t flags));
+
+
+/**@brief Retrieve the first valid user attribute handle.
+ *
+ * @param[out] p_handle   Pointer to an integer where the handle will be stored.
+ *
+ * @retval ::NRF_SUCCESS Successfully retrieved the handle.
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ */
+SVCALL(SD_BLE_GATTS_INITIAL_USER_HANDLE_GET, uint32_t, sd_ble_gatts_initial_user_handle_get(uint16_t *p_handle));
+
+/**@brief Retrieve the attribute UUID and/or metadata.
+ *
+ * @param[in]  handle Attribute handle
+ * @param[out] p_uuid UUID of the attribute. Use NULL to omit this field.
+ * @param[out] p_md Metadata of the attribute. Use NULL to omit this field.
+ *
+ * @retval ::NRF_SUCCESS Successfully retrieved the attribute metadata,
+ * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameters supplied. Returned when both @c p_uuid and @c p_md are NULL.
+ * @retval ::NRF_ERROR_NOT_FOUND Attribute was not found.
+ */
+SVCALL(SD_BLE_GATTS_ATTR_GET, uint32_t, sd_ble_gatts_attr_get(uint16_t handle, ble_uuid_t * p_uuid, ble_gatts_attr_md_t * p_md));
+
+/**@brief Reply to an ATT_MTU exchange request by sending an Exchange MTU Response to the client.
+ *
+ * @details This function is only used to reply to a @ref BLE_GATTS_EVT_EXCHANGE_MTU_REQUEST event.
+ *
+ * @details The SoftDevice sets ATT_MTU to the minimum of:
+ *          - The Client RX MTU value from @ref BLE_GATTS_EVT_EXCHANGE_MTU_REQUEST, and
+ *          - The Server RX MTU value.
+ *
+ *          However, the SoftDevice never sets ATT_MTU lower than @ref BLE_GATT_ATT_MTU_DEFAULT.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_GATTS_MTU_EXCHANGE}
+ * @endmscs
+ *
+ * @param[in] conn_handle    The connection handle identifying the connection to perform this procedure on.
+ * @param[in] server_rx_mtu  Server RX MTU size.
+ *                           - The minimum value is @ref BLE_GATT_ATT_MTU_DEFAULT.
+ *                           - The maximum value is @ref ble_gatt_conn_cfg_t::att_mtu in the connection configuration
+ *                             used for this connection.
+ *                           - The value must be equal to Client RX MTU size given in @ref sd_ble_gattc_exchange_mtu_request
+ *                             if an ATT_MTU exchange has already been performed in the other direction.
+ *
+ * @retval ::NRF_SUCCESS Successfully sent response to the client.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_STATE Invalid Connection State or no ATT_MTU exchange request pending.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid Server RX MTU size supplied.
+ * @retval ::NRF_ERROR_TIMEOUT There has been a GATT procedure timeout. No new GATT procedure can be performed without reestablishing the connection.
+ */
+SVCALL(SD_BLE_GATTS_EXCHANGE_MTU_REPLY, uint32_t, sd_ble_gatts_exchange_mtu_reply(uint16_t conn_handle, uint16_t server_rx_mtu));
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+#endif // BLE_GATTS_H__
+
+/**
+  @}
+*/

--- a/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble_hci.h
+++ b/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble_hci.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+  @addtogroup BLE_COMMON
+  @{
+*/
+
+
+#ifndef BLE_HCI_H__
+#define BLE_HCI_H__
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @defgroup BLE_HCI_STATUS_CODES Bluetooth status codes
+ * @{ */
+
+#define BLE_HCI_STATUS_CODE_SUCCESS                        0x00   /**< Success. */
+#define BLE_HCI_STATUS_CODE_UNKNOWN_BTLE_COMMAND           0x01   /**< Unknown BLE Command. */
+#define BLE_HCI_STATUS_CODE_UNKNOWN_CONNECTION_IDENTIFIER  0x02   /**< Unknown Connection Identifier. */
+/*0x03 Hardware Failure
+0x04 Page Timeout
+*/
+#define BLE_HCI_AUTHENTICATION_FAILURE                     0x05   /**< Authentication Failure. */
+#define BLE_HCI_STATUS_CODE_PIN_OR_KEY_MISSING             0x06   /**< Pin or Key missing. */
+#define BLE_HCI_MEMORY_CAPACITY_EXCEEDED                   0x07   /**< Memory Capacity Exceeded. */
+#define BLE_HCI_CONNECTION_TIMEOUT                         0x08   /**< Connection Timeout. */
+/*0x09 Connection Limit Exceeded
+0x0A Synchronous Connection Limit To A Device Exceeded
+0x0B ACL Connection Already Exists*/
+#define BLE_HCI_STATUS_CODE_COMMAND_DISALLOWED             0x0C   /**< Command Disallowed. */
+/*0x0D Connection Rejected due to Limited Resources
+0x0E Connection Rejected Due To Security Reasons
+0x0F Connection Rejected due to Unacceptable BD_ADDR
+0x10 Connection Accept Timeout Exceeded
+0x11 Unsupported Feature or Parameter Value*/
+#define BLE_HCI_STATUS_CODE_INVALID_BTLE_COMMAND_PARAMETERS 0x12  /**< Invalid BLE Command Parameters. */
+#define BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION           0x13  /**< Remote User Terminated Connection. */
+#define BLE_HCI_REMOTE_DEV_TERMINATION_DUE_TO_LOW_RESOURCES 0x14  /**< Remote Device Terminated Connection due to low resources.*/
+#define BLE_HCI_REMOTE_DEV_TERMINATION_DUE_TO_POWER_OFF     0x15  /**< Remote Device Terminated Connection due to power off. */
+#define BLE_HCI_LOCAL_HOST_TERMINATED_CONNECTION            0x16  /**< Local Host Terminated Connection. */
+/*
+0x17 Repeated Attempts
+0x18 Pairing Not Allowed
+0x19 Unknown LMP PDU
+*/
+#define BLE_HCI_UNSUPPORTED_REMOTE_FEATURE 0x1A                   /**< Unsupported Remote Feature. */
+/*
+0x1B SCO Offset Rejected
+0x1C SCO Interval Rejected
+0x1D SCO Air Mode Rejected*/
+#define BLE_HCI_STATUS_CODE_INVALID_LMP_PARAMETERS     0x1E       /**< Invalid LMP Parameters. */
+#define BLE_HCI_STATUS_CODE_UNSPECIFIED_ERROR          0x1F       /**< Unspecified Error. */
+/*0x20 Unsupported LMP Parameter Value
+0x21 Role Change Not Allowed
+*/
+#define BLE_HCI_STATUS_CODE_LMP_RESPONSE_TIMEOUT            0x22       /**< LMP Response Timeout. */
+#define BLE_HCI_STATUS_CODE_LMP_ERROR_TRANSACTION_COLLISION 0x23  /**< LMP Error Transaction Collision/LL Procedure Collision. */
+#define BLE_HCI_STATUS_CODE_LMP_PDU_NOT_ALLOWED             0x24       /**< LMP PDU Not Allowed. */
+/*0x25 Encryption Mode Not Acceptable
+0x26 Link Key Can Not be Changed
+0x27 Requested QoS Not Supported
+*/
+#define BLE_HCI_INSTANT_PASSED                         0x28       /**< Instant Passed. */
+#define BLE_HCI_PAIRING_WITH_UNIT_KEY_UNSUPPORTED      0x29       /**< Pairing with Unit Key Unsupported. */
+#define BLE_HCI_DIFFERENT_TRANSACTION_COLLISION        0x2A       /**< Different Transaction Collision. */
+/*
+0x2B Reserved
+0x2C QoS Unacceptable Parameter
+0x2D QoS Rejected
+0x2E Channel Classification Not Supported
+0x2F Insufficient Security
+*/
+#define BLE_HCI_PARAMETER_OUT_OF_MANDATORY_RANGE       0x30            /**< Parameter Out Of Mandatory Range. */
+/*
+0x31 Reserved
+0x32 Role Switch Pending
+0x33 Reserved
+0x34 Reserved Slot Violation
+0x35 Role Switch Failed
+0x36 Extended Inquiry Response Too Large
+0x37 Secure Simple Pairing Not Supported By Host.
+0x38 Host Busy - Pairing
+0x39 Connection Rejected due to No Suitable Channel Found*/
+#define BLE_HCI_CONTROLLER_BUSY                        0x3A       /**< Controller Busy. */
+#define BLE_HCI_CONN_INTERVAL_UNACCEPTABLE             0x3B       /**< Connection Interval Unacceptable. */
+#define BLE_HCI_DIRECTED_ADVERTISER_TIMEOUT            0x3C       /**< Directed Advertisement Timeout. */
+#define BLE_HCI_CONN_TERMINATED_DUE_TO_MIC_FAILURE     0x3D       /**< Connection Terminated due to MIC Failure. */
+#define BLE_HCI_CONN_FAILED_TO_BE_ESTABLISHED          0x3E       /**< Connection Failed to be Established. */
+
+/** @} */
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif // BLE_HCI_H__
+
+/** @} */

--- a/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble_l2cap.h
+++ b/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble_l2cap.h
@@ -1,0 +1,507 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+  @addtogroup BLE_L2CAP Logical Link Control and Adaptation Protocol (L2CAP)
+  @{
+  @brief Definitions and prototypes for the L2CAP interface.
+ */
+
+#ifndef BLE_L2CAP_H__
+#define BLE_L2CAP_H__
+
+#include <stdint.h>
+#include "nrf_svc.h"
+#include "nrf_error.h"
+#include "ble_ranges.h"
+#include "ble_types.h"
+#include "ble_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**@addtogroup BLE_L2CAP_TERMINOLOGY Terminology
+ * @{
+ * @details
+ *
+ * L2CAP SDU
+ * - A data unit that the application can send/receive to/from a peer.
+ *
+ * L2CAP PDU
+ * - A data unit that is exchanged between local and remote L2CAP entities.
+ *   It consists of L2CAP protocol control information and payload fields.
+ *   The payload field can contain an L2CAP SDU or a part of an L2CAP SDU.
+ *
+ * L2CAP MTU
+ * - The maximum length of an L2CAP SDU.
+ *
+ * L2CAP MPS
+ * - The maximum length of an L2CAP PDU payload field.
+ *
+ * Credits
+ * - A value indicating the number of L2CAP PDUs that the receiver of the credit can send to the peer.
+ * @} */
+
+/**@addtogroup BLE_L2CAP_ENUMERATIONS Enumerations
+ * @{ */
+
+/**@brief L2CAP API SVC numbers. */
+enum BLE_L2CAP_SVCS
+{
+  SD_BLE_L2CAP_CH_SETUP        = BLE_L2CAP_SVC_BASE + 0, /**< Set up an L2CAP channel. */
+  SD_BLE_L2CAP_CH_RELEASE      = BLE_L2CAP_SVC_BASE + 1, /**< Release an L2CAP channel. */
+  SD_BLE_L2CAP_CH_RX           = BLE_L2CAP_SVC_BASE + 2, /**< Receive an SDU on an L2CAP channel. */
+  SD_BLE_L2CAP_CH_TX           = BLE_L2CAP_SVC_BASE + 3, /**< Transmit an SDU on an L2CAP channel. */
+  SD_BLE_L2CAP_CH_FLOW_CONTROL = BLE_L2CAP_SVC_BASE + 4, /**< Advanced SDU reception flow control. */
+};
+
+/**@brief L2CAP Event IDs. */
+enum BLE_L2CAP_EVTS
+{
+  BLE_L2CAP_EVT_CH_SETUP_REQUEST    = BLE_L2CAP_EVT_BASE + 0,    /**< L2CAP Channel Setup Request event.
+                                                                   \n Reply with @ref sd_ble_l2cap_ch_setup.
+                                                                   \n See @ref ble_l2cap_evt_ch_setup_request_t. */
+  BLE_L2CAP_EVT_CH_SETUP_REFUSED    = BLE_L2CAP_EVT_BASE + 1,    /**< L2CAP Channel Setup Refused event.
+                                                                   \n See @ref ble_l2cap_evt_ch_setup_refused_t. */
+  BLE_L2CAP_EVT_CH_SETUP            = BLE_L2CAP_EVT_BASE + 2,    /**< L2CAP Channel Setup Completed event.
+                                                                   \n See @ref ble_l2cap_evt_ch_setup_t. */
+  BLE_L2CAP_EVT_CH_RELEASED         = BLE_L2CAP_EVT_BASE + 3,    /**< L2CAP Channel Released event.
+                                                                   \n No additional event structure applies. */
+  BLE_L2CAP_EVT_CH_SDU_BUF_RELEASED = BLE_L2CAP_EVT_BASE + 4,    /**< L2CAP Channel SDU data buffer released event.
+                                                                   \n See @ref ble_l2cap_evt_ch_sdu_buf_released_t. */
+  BLE_L2CAP_EVT_CH_CREDIT           = BLE_L2CAP_EVT_BASE + 5,    /**< L2CAP Channel Credit received.
+                                                                   \n See @ref ble_l2cap_evt_ch_credit_t. */
+  BLE_L2CAP_EVT_CH_RX               = BLE_L2CAP_EVT_BASE + 6,    /**< L2CAP Channel SDU received.
+                                                                   \n See @ref ble_l2cap_evt_ch_rx_t. */
+  BLE_L2CAP_EVT_CH_TX               = BLE_L2CAP_EVT_BASE + 7,   /**< L2CAP Channel SDU transmitted.
+                                                                   \n See @ref ble_l2cap_evt_ch_tx_t. */
+};
+
+/** @} */
+
+/**@addtogroup BLE_L2CAP_DEFINES Defines
+ * @{ */
+
+/**@brief Maximum number of L2CAP channels per connection. */
+#define BLE_L2CAP_CH_COUNT_MAX    (64)
+
+/**@brief Minimum L2CAP MTU, in bytes. */
+#define BLE_L2CAP_MTU_MIN         (23)
+
+/**@brief Minimum L2CAP MPS, in bytes. */
+#define BLE_L2CAP_MPS_MIN         (23)
+
+/**@brief Invalid CID. */
+#define BLE_L2CAP_CID_INVALID     (0x0000)
+
+/**@brief Default number of credits for @ref sd_ble_l2cap_ch_flow_control. */
+#define BLE_L2CAP_CREDITS_DEFAULT (1)
+
+/**@defgroup BLE_L2CAP_CH_SETUP_REFUSED_SRCS L2CAP channel setup refused sources
+ * @{ */
+#define BLE_L2CAP_CH_SETUP_REFUSED_SRC_LOCAL            (0x01)    /**< Local. */
+#define BLE_L2CAP_CH_SETUP_REFUSED_SRC_REMOTE           (0x02)    /**< Remote. */
+ /** @}  */
+
+ /** @defgroup BLE_L2CAP_CH_STATUS_CODES L2CAP channel status codes
+ * @{ */
+#define BLE_L2CAP_CH_STATUS_CODE_SUCCESS                (0x0000)  /**< Success. */
+#define BLE_L2CAP_CH_STATUS_CODE_LE_PSM_NOT_SUPPORTED   (0x0002)  /**< LE_PSM not supported. */
+#define BLE_L2CAP_CH_STATUS_CODE_NO_RESOURCES           (0x0004)  /**< No resources available. */
+#define BLE_L2CAP_CH_STATUS_CODE_INSUFF_AUTHENTICATION  (0x0005)  /**< Insufficient authentication. */
+#define BLE_L2CAP_CH_STATUS_CODE_INSUFF_AUTHORIZATION   (0x0006)  /**< Insufficient authorization. */
+#define BLE_L2CAP_CH_STATUS_CODE_INSUFF_ENC_KEY_SIZE    (0x0007)  /**< Insufficient encryption key size. */
+#define BLE_L2CAP_CH_STATUS_CODE_INSUFF_ENC             (0x0008)  /**< Insufficient encryption. */
+#define BLE_L2CAP_CH_STATUS_CODE_INVALID_SCID           (0x0009)  /**< Invalid Source CID. */
+#define BLE_L2CAP_CH_STATUS_CODE_SCID_ALLOCATED         (0x000A)  /**< Source CID already allocated. */
+#define BLE_L2CAP_CH_STATUS_CODE_UNACCEPTABLE_PARAMS    (0x000B)  /**< Unacceptable parameters. */
+#define BLE_L2CAP_CH_STATUS_CODE_NOT_UNDERSTOOD         (0x8000)  /**< Command Reject received instead of LE Credit Based Connection Response. */
+#define BLE_L2CAP_CH_STATUS_CODE_TIMEOUT                (0xC000)  /**< Operation timed out. */
+/** @} */
+
+/** @} */
+
+/**@addtogroup BLE_L2CAP_STRUCTURES Structures
+ * @{ */
+
+/**
+ * @brief BLE L2CAP connection configuration parameters, set with @ref sd_ble_cfg_set.
+ *
+ * @note  These parameters are set per connection, so all L2CAP channels created on this connection
+ *        will have the same parameters.
+ *
+ * @retval ::NRF_ERROR_INVALID_PARAM  One or more of the following is true:
+ *                                    - rx_mps is smaller than @ref BLE_L2CAP_MPS_MIN.
+ *                                    - tx_mps is smaller than @ref BLE_L2CAP_MPS_MIN.
+ *                                    - ch_count is greater than @ref BLE_L2CAP_CH_COUNT_MAX.
+ * @retval ::NRF_ERROR_NO_MEM         rx_mps or tx_mps is set too high.
+ */
+typedef struct
+{
+  uint16_t    rx_mps;        /**< The maximum L2CAP PDU payload size, in bytes, that L2CAP shall
+                                  be able to receive on L2CAP channels on connections with this
+                                  configuration. The minimum value is @ref BLE_L2CAP_MPS_MIN. */
+  uint16_t    tx_mps;        /**< The maximum L2CAP PDU payload size, in bytes, that L2CAP shall
+                                  be able to transmit on L2CAP channels on connections with this
+                                  configuration. The minimum value is @ref BLE_L2CAP_MPS_MIN. */
+  uint8_t     rx_queue_size; /**< Number of SDU data buffers that can be queued for reception per
+                                  L2CAP channel. The minimum value is one. */
+  uint8_t     tx_queue_size; /**< Number of SDU data buffers that can be queued for transmission
+                                  per L2CAP channel. The minimum value is one. */
+  uint8_t     ch_count;      /**< Number of L2CAP channels the application can create per connection
+                                  with this configuration. The default value is zero, the maximum
+                                  value is @ref BLE_L2CAP_CH_COUNT_MAX.
+                                  @note if this parameter is set to zero, all other parameters in
+                                  @ref ble_l2cap_conn_cfg_t are ignored. */
+} ble_l2cap_conn_cfg_t;
+
+/**@brief L2CAP channel RX parameters. */
+typedef struct
+{
+  uint16_t    rx_mtu;        /**< The maximum L2CAP SDU size, in bytes, that L2CAP shall be able to
+                                  receive on this L2CAP channel.
+                                  - Must be equal to or greater than @ref BLE_L2CAP_MTU_MIN. */
+  uint16_t    rx_mps;        /**< The maximum L2CAP PDU payload size, in bytes, that L2CAP shall be
+                                  able to receive on this L2CAP channel.
+                                  - Must be equal to or greater than @ref BLE_L2CAP_MPS_MIN.
+                                  - Must be equal to or less than @ref ble_l2cap_conn_cfg_t::rx_mps. */
+  ble_data_t  sdu_buf;       /**< SDU data buffer for reception.
+                                  - If @ref ble_data_t::p_data is non-NULL, initial credits are
+                                    issued to the peer.
+                                  - If @ref ble_data_t::p_data is NULL, no initial credits are
+                                    issued to the peer. */
+} ble_l2cap_ch_rx_params_t;
+
+/**@brief L2CAP channel setup parameters. */
+typedef struct
+{
+  ble_l2cap_ch_rx_params_t      rx_params;  /**< L2CAP channel RX parameters. */
+  uint16_t                      le_psm;     /**< LE Protocol/Service Multiplexer. Used when requesting
+                                                 setup of an L2CAP channel, ignored otherwise. */
+  uint16_t                      status;     /**< Status code, see @ref BLE_L2CAP_CH_STATUS_CODES.
+                                                 Used when replying to a setup request of an L2CAP
+                                                 channel, ignored otherwise. */
+} ble_l2cap_ch_setup_params_t;
+
+/**@brief L2CAP channel TX parameters. */
+typedef struct
+{
+  uint16_t    tx_mtu;        /**< The maximum L2CAP SDU size, in bytes, that L2CAP is able to
+                                  transmit on this L2CAP channel. */
+  uint16_t    peer_mps;      /**< The maximum L2CAP PDU payload size, in bytes, that the peer is
+                                  able to receive on this L2CAP channel. */
+  uint16_t    tx_mps;        /**< The maximum L2CAP PDU payload size, in bytes, that L2CAP is able
+                                  to transmit on this L2CAP channel. This is effective tx_mps,
+                                  selected by the SoftDevice as
+                                  MIN( @ref ble_l2cap_ch_tx_params_t::peer_mps, @ref ble_l2cap_conn_cfg_t::tx_mps ) */
+  uint16_t    credits;       /**< Initial credits given by the peer. */
+} ble_l2cap_ch_tx_params_t;
+
+/**@brief L2CAP Channel Setup Request event. */
+typedef struct
+{
+  ble_l2cap_ch_tx_params_t  tx_params;  /**< L2CAP channel TX parameters. */
+  uint16_t                  le_psm;     /**< LE Protocol/Service Multiplexer. */
+} ble_l2cap_evt_ch_setup_request_t;
+
+/**@brief L2CAP Channel Setup Refused event. */
+typedef struct
+{
+  uint8_t  source;           /**< Source, see @ref BLE_L2CAP_CH_SETUP_REFUSED_SRCS */
+  uint16_t status;           /**< Status code, see @ref BLE_L2CAP_CH_STATUS_CODES */
+} ble_l2cap_evt_ch_setup_refused_t;
+
+/**@brief L2CAP Channel Setup Completed event. */
+typedef struct
+{
+  ble_l2cap_ch_tx_params_t tx_params;  /**< L2CAP channel TX parameters. */
+} ble_l2cap_evt_ch_setup_t;
+
+/**@brief L2CAP Channel SDU Data Buffer Released event. */
+typedef struct
+{
+  ble_data_t  sdu_buf;       /**< Returned reception or transmission SDU data buffer. The SoftDevice
+                                  returns SDU data buffers supplied by the application, which have
+                                  not yet been returned previously via a @ref BLE_L2CAP_EVT_CH_RX or
+                                  @ref BLE_L2CAP_EVT_CH_TX event. */
+} ble_l2cap_evt_ch_sdu_buf_released_t;
+
+/**@brief L2CAP Channel Credit received event. */
+typedef struct
+{
+  uint16_t  credits;         /**< Additional credits given by the peer. */
+} ble_l2cap_evt_ch_credit_t;
+
+/**@brief L2CAP Channel received SDU event. */
+typedef struct
+{
+  uint16_t    sdu_len;       /**< Total SDU length, in bytes. */
+  ble_data_t  sdu_buf;       /**< SDU data buffer.
+                                  @note If there is not enough space in the buffer
+                                        (sdu_buf.len < sdu_len) then the rest of the SDU will be
+                                        silently discarded by the SoftDevice. */
+} ble_l2cap_evt_ch_rx_t;
+
+/**@brief L2CAP Channel transmitted SDU event. */
+typedef struct
+{
+  ble_data_t  sdu_buf;       /**< SDU data buffer. */
+} ble_l2cap_evt_ch_tx_t;
+
+/**@brief L2CAP event structure. */
+typedef struct
+{
+  uint16_t conn_handle;                                     /**< Connection Handle on which the event occured. */
+  uint16_t local_cid;                                       /**< Local Channel ID of the L2CAP channel, or
+                                                                 @ref BLE_L2CAP_CID_INVALID if not present. */
+  union
+  {
+    ble_l2cap_evt_ch_setup_request_t    ch_setup_request;   /**< L2CAP Channel Setup Request Event Parameters. */
+    ble_l2cap_evt_ch_setup_refused_t    ch_setup_refused;   /**< L2CAP Channel Setup Refused Event Parameters. */
+    ble_l2cap_evt_ch_setup_t            ch_setup;           /**< L2CAP Channel Setup Completed Event Parameters. */
+    ble_l2cap_evt_ch_sdu_buf_released_t ch_sdu_buf_released;/**< L2CAP Channel SDU Data Buffer Released Event Parameters. */
+    ble_l2cap_evt_ch_credit_t           credit;             /**< L2CAP Channel Credit Received Event Parameters. */
+    ble_l2cap_evt_ch_rx_t               rx;                 /**< L2CAP Channel SDU Received Event Parameters. */
+    ble_l2cap_evt_ch_tx_t               tx;                 /**< L2CAP Channel SDU Transmitted Event Parameters. */
+  } params;                                                 /**< Event Parameters. */
+} ble_l2cap_evt_t;
+
+/** @} */
+
+/**@addtogroup BLE_L2CAP_FUNCTIONS Functions
+ * @{ */
+
+/**@brief Set up an L2CAP channel.
+ *
+ * @details This function is used to:
+ *          - Request setup of an L2CAP channel: sends an LE Credit Based Connection Request packet to a peer.
+ *          - Reply to a setup request of an L2CAP channel (if called in response to a
+ *            @ref BLE_L2CAP_EVT_CH_SETUP_REQUEST event): sends an LE Credit Based Connection
+ *            Response packet to a peer.
+ *
+ * @note    A call to this function will require the application to keep the SDU data buffer alive
+ *          until the SDU data buffer is returned in @ref BLE_L2CAP_EVT_CH_RX or
+ *          @ref BLE_L2CAP_EVT_CH_SDU_BUF_RELEASED event.
+ *
+ * @events
+ * @event{@ref BLE_L2CAP_EVT_CH_SETUP, Setup successful.}
+ * @event{@ref BLE_L2CAP_EVT_CH_SETUP_REFUSED, Setup failed.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_L2CAP_CH_SETUP_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle      Connection Handle.
+ * @param[in,out] p_local_cid  Pointer to a uint16_t containing Local Channel ID of the L2CAP channel:
+ *                             - As input: @ref BLE_L2CAP_CID_INVALID when requesting setup of an L2CAP
+ *                               channel or local_cid provided in the @ref BLE_L2CAP_EVT_CH_SETUP_REQUEST
+ *                               event when replying to a setup request of an L2CAP channel.
+ *                             - As output: local_cid for this channel.
+ * @param[in] p_params         L2CAP channel parameters.
+ *
+ * @retval ::NRF_SUCCESS                    Successfully queued request or response for transmission.
+ * @retval ::NRF_ERROR_BUSY                 The stack is busy, process pending events and retry.
+ * @retval ::NRF_ERROR_INVALID_ADDR         Invalid pointer supplied.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE  Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_PARAM        Invalid parameter(s) supplied.
+ * @retval ::NRF_ERROR_INVALID_LENGTH       Supplied higher rx_mps than has been configured on this link.
+ * @retval ::NRF_ERROR_INVALID_STATE        Invalid State to perform operation (L2CAP channel already set up).
+ * @retval ::NRF_ERROR_NOT_FOUND            CID not found.
+ * @retval ::NRF_ERROR_RESOURCES            The limit has been reached for available L2CAP channels,
+ *                                          see @ref ble_l2cap_conn_cfg_t::ch_count.
+ */
+SVCALL(SD_BLE_L2CAP_CH_SETUP, uint32_t, sd_ble_l2cap_ch_setup(uint16_t conn_handle, uint16_t *p_local_cid, ble_l2cap_ch_setup_params_t const *p_params));
+
+/**@brief Release an L2CAP channel.
+ *
+ * @details This sends a Disconnection Request packet to a peer.
+ *
+ * @events
+ * @event{@ref BLE_L2CAP_EVT_CH_RELEASED, Release complete.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_L2CAP_CH_RELEASE_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle   Connection Handle.
+ * @param[in] local_cid     Local Channel ID of the L2CAP channel.
+ *
+ * @retval ::NRF_SUCCESS                    Successfully queued request for transmission.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE  Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_STATE        Invalid State to perform operation (Setup or release is
+ *                                          in progress for the L2CAP channel).
+ * @retval ::NRF_ERROR_NOT_FOUND            CID not found.
+ */
+SVCALL(SD_BLE_L2CAP_CH_RELEASE, uint32_t, sd_ble_l2cap_ch_release(uint16_t conn_handle, uint16_t local_cid));
+
+/**@brief Receive an SDU on an L2CAP channel.
+ *
+ * @details This may issue additional credits to the peer using an LE Flow Control Credit packet.
+ *
+ * @note    A call to this function will require the application to keep the memory pointed by
+ *          @ref ble_data_t::p_data alive until the SDU data buffer is returned in @ref BLE_L2CAP_EVT_CH_RX
+ *          or @ref BLE_L2CAP_EVT_CH_SDU_BUF_RELEASED event.
+ *
+ * @note    The SoftDevice can queue up to @ref ble_l2cap_conn_cfg_t::rx_queue_size SDU data buffers
+ *          for reception per L2CAP channel.
+ *
+ * @events
+ * @event{@ref BLE_L2CAP_EVT_CH_RX, The SDU is received.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_L2CAP_CH_RX_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle Connection Handle.
+ * @param[in] local_cid   Local Channel ID of the L2CAP channel.
+ * @param[in] p_sdu_buf   Pointer to the SDU data buffer.
+ *
+ * @retval ::NRF_SUCCESS                    Buffer accepted.
+ * @retval ::NRF_ERROR_INVALID_ADDR         Invalid pointer supplied.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE  Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_STATE        Invalid State to perform operation (Setup or release is
+ *                                          in progress for an L2CAP channel).
+ * @retval ::NRF_ERROR_NOT_FOUND            CID not found.
+ * @retval ::NRF_ERROR_RESOURCES            Too many SDU data buffers supplied. Wait for a
+ *                                          @ref BLE_L2CAP_EVT_CH_RX event and retry.
+ */
+SVCALL(SD_BLE_L2CAP_CH_RX, uint32_t, sd_ble_l2cap_ch_rx(uint16_t conn_handle, uint16_t local_cid, ble_data_t const *p_sdu_buf));
+
+/**@brief Transmit an SDU on an L2CAP channel.
+ *
+ * @note    A call to this function will require the application to keep the memory pointed by
+ *          @ref ble_data_t::p_data alive until the SDU data buffer is returned in @ref BLE_L2CAP_EVT_CH_TX
+ *          or @ref BLE_L2CAP_EVT_CH_SDU_BUF_RELEASED event.
+ *
+ * @note    The SoftDevice can queue up to @ref ble_l2cap_conn_cfg_t::tx_queue_size SDUs for
+ *          transmission per L2CAP channel.
+ *
+ * @note    The application can keep track of the available credits for transmission by following
+ *          the procedure below:
+ *          - Store initial credits given by the peer in a variable.
+ *            (Initial credits are provided in a @ref BLE_L2CAP_EVT_CH_SETUP event.)
+ *          - Decrement the variable, which stores the currently available credits, by
+ *            ceiling((@ref ble_data_t::len + 2) / tx_mps) when a call to this function returns
+ *            @ref NRF_SUCCESS. (tx_mps is provided in a @ref BLE_L2CAP_EVT_CH_SETUP event.)
+ *          - Increment the variable, which stores the currently available credits, by additional
+ *            credits given by the peer in a @ref BLE_L2CAP_EVT_CH_CREDIT event.
+ *
+ * @events
+ * @event{@ref BLE_L2CAP_EVT_CH_TX, The SDU is transmitted.}
+ * @endevents
+ *
+ * @mscs
+ * @mmsc{@ref BLE_L2CAP_CH_TX_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle Connection Handle.
+ * @param[in] local_cid   Local Channel ID of the L2CAP channel.
+ * @param[in] p_sdu_buf   Pointer to the SDU data buffer.
+ *
+ * @retval ::NRF_SUCCESS                    Successfully queued L2CAP SDU for transmission.
+ * @retval ::NRF_ERROR_INVALID_ADDR         Invalid pointer supplied.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE  Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_STATE        Invalid State to perform operation (Setup or release is
+ *                                          in progress for the L2CAP channel).
+ * @retval ::NRF_ERROR_NOT_FOUND            CID not found.
+ * @retval ::NRF_ERROR_DATA_SIZE            Invalid SDU length supplied, must not be more than
+ *                                          @ref ble_l2cap_ch_tx_params_t::tx_mtu provided in
+ *                                          @ref BLE_L2CAP_EVT_CH_SETUP event.
+ * @retval ::NRF_ERROR_RESOURCES            Too many SDUs queued for transmission. Wait for a
+ *                                          @ref BLE_L2CAP_EVT_CH_TX event and retry.
+ */
+SVCALL(SD_BLE_L2CAP_CH_TX, uint32_t, sd_ble_l2cap_ch_tx(uint16_t conn_handle, uint16_t local_cid, ble_data_t const *p_sdu_buf));
+
+/**@brief Advanced SDU reception flow control.
+ *
+ * @details Adjust the way the SoftDevice issues credits to the peer.
+ *          This may issue additional credits to the peer using an LE Flow Control Credit packet.
+ *
+ * @mscs
+ * @mmsc{@ref BLE_L2CAP_CH_FLOW_CONTROL_MSC}
+ * @endmscs
+ *
+ * @param[in] conn_handle Connection Handle.
+ * @param[in] local_cid   Local Channel ID of the L2CAP channel or @ref BLE_L2CAP_CID_INVALID to set
+ *                        the value that will be used for newly created channels.
+ * @param[in] credits     Number of credits that the SoftDevice will make sure the peer has every
+ *                        time it starts using a new reception buffer.
+ *                        - @ref BLE_L2CAP_CREDITS_DEFAULT is the default value the SoftDevice will
+ *                          use if this function is not called.
+ *                        - If set to zero, the SoftDevice will stop issuing credits for new reception
+ *                          buffers the application provides or has provided. SDU reception that is
+ *                          currently ongoing will be allowed to complete.
+ * @param[out] p_credits  NULL or pointer to a uint16_t. If a valid pointer is provided, it will be
+ *                        written by the SoftDevice with the number of credits that is or will be
+ *                        available to the peer. If the value written by the SoftDevice is 0 when
+ *                        credits parameter was set to 0, the peer will not be able to send more
+ *                        data until more credits are provided by calling this function again with
+ *                        credits > 0. This parameter is ignored when local_cid is set to
+ *                        @ref BLE_L2CAP_CID_INVALID.
+ *
+ * @note Application should take care when setting number of credits higher than default value. In
+ *       this case the application must make sure that the SoftDevice always has reception buffers
+ *       available (see @ref sd_ble_l2cap_ch_rx) for that channel. If the SoftDevice does not have
+ *       such buffers available, packets may be NACKed on the Link Layer and all Bluetooth traffic
+ *       on the connection handle may be stalled until the SoftDevice again has an available
+ *       reception buffer. This applies even if the application has used this call to set the
+ *       credits back to default, or zero.
+ *
+ * @retval ::NRF_SUCCESS                    Flow control parameters accepted.
+ * @retval ::NRF_ERROR_INVALID_ADDR         Invalid pointer supplied.
+ * @retval ::BLE_ERROR_INVALID_CONN_HANDLE  Invalid Connection Handle.
+ * @retval ::NRF_ERROR_INVALID_STATE        Invalid State to perform operation (Setup or release is
+ *                                          in progress for an L2CAP channel).
+ * @retval ::NRF_ERROR_NOT_FOUND            CID not found.
+ */
+SVCALL(SD_BLE_L2CAP_CH_FLOW_CONTROL, uint32_t, sd_ble_l2cap_ch_flow_control(uint16_t conn_handle, uint16_t local_cid, uint16_t credits, uint16_t *p_credits));
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+#endif // BLE_L2CAP_H__
+
+/**
+  @}
+*/

--- a/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble_ranges.h
+++ b/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble_ranges.h
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+  @addtogroup BLE_COMMON
+  @{
+  @defgroup ble_ranges Module specific SVC, event and option number subranges
+  @{
+
+  @brief Definition of SVC, event and option number subranges for each API module.
+
+  @note
+  SVCs, event and option numbers are split into subranges for each API module.
+  Each module receives its entire allocated range of SVC calls, whether implemented or not,
+  but return BLE_ERROR_NOT_SUPPORTED for unimplemented or undefined calls in its range.
+
+  Note that the symbols BLE_<module>_SVC_LAST is the end of the allocated SVC range,
+  rather than the last SVC function call actually defined and implemented.
+
+  Specific SVC, event and option values are defined in each module's ble_<module>.h file,
+  which defines names of each individual SVC code based on the range start value.
+*/
+
+#ifndef BLE_RANGES_H__
+#define BLE_RANGES_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define BLE_SVC_BASE           0x60       /**< Common BLE SVC base. */
+#define BLE_SVC_LAST           0x6B       /**< Common BLE SVC last. */
+
+#define BLE_GAP_SVC_BASE       0x6C       /**< GAP BLE SVC base. */
+#define BLE_GAP_SVC_LAST       0x9A       /**< GAP BLE SVC last. */
+
+#define BLE_GATTC_SVC_BASE     0x9B       /**< GATTC BLE SVC base. */
+#define BLE_GATTC_SVC_LAST     0xA7       /**< GATTC BLE SVC last. */
+
+#define BLE_GATTS_SVC_BASE     0xA8       /**< GATTS BLE SVC base. */
+#define BLE_GATTS_SVC_LAST     0xB7       /**< GATTS BLE SVC last. */
+
+#define BLE_L2CAP_SVC_BASE     0xB8       /**< L2CAP BLE SVC base. */
+#define BLE_L2CAP_SVC_LAST     0xBF       /**< L2CAP BLE SVC last. */
+
+
+#define BLE_EVT_INVALID        0x00       /**< Invalid BLE Event. */
+
+#define BLE_EVT_BASE           0x01       /**< Common BLE Event base. */
+#define BLE_EVT_LAST           0x0F       /**< Common BLE Event last. */
+
+#define BLE_GAP_EVT_BASE       0x10       /**< GAP BLE Event base. */
+#define BLE_GAP_EVT_LAST       0x2F       /**< GAP BLE Event last. */
+
+#define BLE_GATTC_EVT_BASE     0x30       /**< GATTC BLE Event base. */
+#define BLE_GATTC_EVT_LAST     0x4F       /**< GATTC BLE Event last. */
+
+#define BLE_GATTS_EVT_BASE     0x50       /**< GATTS BLE Event base. */
+#define BLE_GATTS_EVT_LAST     0x6F       /**< GATTS BLE Event last. */
+
+#define BLE_L2CAP_EVT_BASE     0x70       /**< L2CAP BLE Event base. */
+#define BLE_L2CAP_EVT_LAST     0x8F       /**< L2CAP BLE Event last. */
+
+
+#define BLE_OPT_INVALID        0x00       /**< Invalid BLE Option. */
+
+#define BLE_OPT_BASE           0x01       /**< Common BLE Option base. */
+#define BLE_OPT_LAST           0x1F       /**< Common BLE Option last. */
+
+#define BLE_GAP_OPT_BASE       0x20       /**< GAP BLE Option base. */
+#define BLE_GAP_OPT_LAST       0x3F       /**< GAP BLE Option last. */
+
+#define BLE_GATT_OPT_BASE      0x40       /**< GATT BLE Option base. */
+#define BLE_GATT_OPT_LAST      0x5F       /**< GATT BLE Option last. */
+
+#define BLE_GATTC_OPT_BASE     0x60       /**< GATTC BLE Option base. */
+#define BLE_GATTC_OPT_LAST     0x7F       /**< GATTC BLE Option last. */
+
+#define BLE_GATTS_OPT_BASE     0x80       /**< GATTS BLE Option base. */
+#define BLE_GATTS_OPT_LAST     0x9F       /**< GATTS BLE Option last. */
+
+#define BLE_L2CAP_OPT_BASE     0xA0       /**< L2CAP BLE Option base. */
+#define BLE_L2CAP_OPT_LAST     0xBF       /**< L2CAP BLE Option last. */
+
+
+#define BLE_CFG_INVALID        0x00       /**< Invalid BLE configuration. */
+
+#define BLE_CFG_BASE           0x01       /**< Common BLE configuration base. */
+#define BLE_CFG_LAST           0x1F       /**< Common BLE configuration last. */
+
+#define BLE_CONN_CFG_BASE      0x20       /**< BLE connection configuration base. */
+#define BLE_CONN_CFG_LAST      0x3F       /**< BLE connection configuration last. */
+
+#define BLE_GAP_CFG_BASE       0x40       /**< GAP BLE configuration base. */
+#define BLE_GAP_CFG_LAST       0x5F       /**< GAP BLE configuration last. */
+
+#define BLE_GATT_CFG_BASE      0x60       /**< GATT BLE configuration base. */
+#define BLE_GATT_CFG_LAST      0x7F       /**< GATT BLE configuration last. */
+
+#define BLE_GATTC_CFG_BASE     0x80       /**< GATTC BLE configuration base. */
+#define BLE_GATTC_CFG_LAST     0x9F       /**< GATTC BLE configuration last. */
+
+#define BLE_GATTS_CFG_BASE     0xA0       /**< GATTS BLE configuration base. */
+#define BLE_GATTS_CFG_LAST     0xBF       /**< GATTS BLE configuration last. */
+
+#define BLE_L2CAP_CFG_BASE     0xC0       /**< L2CAP BLE configuration base. */
+#define BLE_L2CAP_CFG_LAST     0xDF       /**< L2CAP BLE configuration last. */
+
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* BLE_RANGES_H__ */
+
+/**
+  @}
+  @}
+*/

--- a/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble_types.h
+++ b/variants/t1000-e/s140_nrf52_7.3.0_API/include/ble_types.h
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+  @addtogroup BLE_COMMON
+  @{
+  @defgroup ble_types Common types and macro definitions
+  @{
+
+  @brief Common types and macro definitions for the BLE SoftDevice.
+ */
+
+#ifndef BLE_TYPES_H__
+#define BLE_TYPES_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @addtogroup BLE_TYPES_DEFINES Defines
+ * @{ */
+
+/** @defgroup BLE_CONN_HANDLES BLE Connection Handles
+ * @{ */
+#define BLE_CONN_HANDLE_INVALID 0xFFFF  /**< Invalid Connection Handle. */
+#define BLE_CONN_HANDLE_ALL     0xFFFE  /**< Applies to all Connection Handles. */
+/** @} */
+
+
+/** @defgroup BLE_UUID_VALUES Assigned Values for BLE UUIDs
+ * @{ */
+/* Generic UUIDs, applicable to all services */
+#define BLE_UUID_UNKNOWN                              0x0000 /**< Reserved UUID. */
+#define BLE_UUID_SERVICE_PRIMARY                      0x2800 /**< Primary Service. */
+#define BLE_UUID_SERVICE_SECONDARY                    0x2801 /**< Secondary Service. */
+#define BLE_UUID_SERVICE_INCLUDE                      0x2802 /**< Include. */
+#define BLE_UUID_CHARACTERISTIC                       0x2803 /**< Characteristic. */
+#define BLE_UUID_DESCRIPTOR_CHAR_EXT_PROP             0x2900 /**< Characteristic Extended Properties Descriptor. */
+#define BLE_UUID_DESCRIPTOR_CHAR_USER_DESC            0x2901 /**< Characteristic User Description Descriptor. */
+#define BLE_UUID_DESCRIPTOR_CLIENT_CHAR_CONFIG        0x2902 /**< Client Characteristic Configuration Descriptor. */
+#define BLE_UUID_DESCRIPTOR_SERVER_CHAR_CONFIG        0x2903 /**< Server Characteristic Configuration Descriptor. */
+#define BLE_UUID_DESCRIPTOR_CHAR_PRESENTATION_FORMAT  0x2904 /**< Characteristic Presentation Format Descriptor. */
+#define BLE_UUID_DESCRIPTOR_CHAR_AGGREGATE_FORMAT     0x2905 /**< Characteristic Aggregate Format Descriptor. */
+/* GATT specific UUIDs */
+#define BLE_UUID_GATT                                 0x1801 /**< Generic Attribute Profile. */
+#define BLE_UUID_GATT_CHARACTERISTIC_SERVICE_CHANGED  0x2A05 /**< Service Changed Characteristic. */
+/* GAP specific UUIDs */
+#define BLE_UUID_GAP                                  0x1800 /**< Generic Access Profile. */
+#define BLE_UUID_GAP_CHARACTERISTIC_DEVICE_NAME       0x2A00 /**< Device Name Characteristic. */
+#define BLE_UUID_GAP_CHARACTERISTIC_APPEARANCE        0x2A01 /**< Appearance Characteristic. */
+#define BLE_UUID_GAP_CHARACTERISTIC_RECONN_ADDR       0x2A03 /**< Reconnection Address Characteristic. */
+#define BLE_UUID_GAP_CHARACTERISTIC_PPCP              0x2A04 /**< Peripheral Preferred Connection Parameters Characteristic. */
+#define BLE_UUID_GAP_CHARACTERISTIC_CAR               0x2AA6 /**< Central Address Resolution Characteristic. */
+#define BLE_UUID_GAP_CHARACTERISTIC_RPA_ONLY          0x2AC9 /**< Resolvable Private Address Only Characteristic. */
+/** @} */
+
+
+/** @defgroup BLE_UUID_TYPES Types of UUID
+ * @{ */
+#define BLE_UUID_TYPE_UNKNOWN       0x00 /**< Invalid UUID type. */
+#define BLE_UUID_TYPE_BLE           0x01 /**< Bluetooth SIG UUID (16-bit). */
+#define BLE_UUID_TYPE_VENDOR_BEGIN  0x02 /**< Vendor UUID types start at this index (128-bit). */
+/** @} */
+
+
+/** @defgroup BLE_APPEARANCES Bluetooth Appearance values
+ *  @note Retrieved from http://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.appearance.xml
+ * @{ */
+#define BLE_APPEARANCE_UNKNOWN                                0 /**< Unknown. */
+#define BLE_APPEARANCE_GENERIC_PHONE                         64 /**< Generic Phone. */
+#define BLE_APPEARANCE_GENERIC_COMPUTER                     128 /**< Generic Computer. */
+#define BLE_APPEARANCE_GENERIC_WATCH                        192 /**< Generic Watch. */
+#define BLE_APPEARANCE_WATCH_SPORTS_WATCH                   193 /**< Watch: Sports Watch. */
+#define BLE_APPEARANCE_GENERIC_CLOCK                        256 /**< Generic Clock. */
+#define BLE_APPEARANCE_GENERIC_DISPLAY                      320 /**< Generic Display. */
+#define BLE_APPEARANCE_GENERIC_REMOTE_CONTROL               384 /**< Generic Remote Control. */
+#define BLE_APPEARANCE_GENERIC_EYE_GLASSES                  448 /**< Generic Eye-glasses. */
+#define BLE_APPEARANCE_GENERIC_TAG                          512 /**< Generic Tag. */
+#define BLE_APPEARANCE_GENERIC_KEYRING                      576 /**< Generic Keyring. */
+#define BLE_APPEARANCE_GENERIC_MEDIA_PLAYER                 640 /**< Generic Media Player. */
+#define BLE_APPEARANCE_GENERIC_BARCODE_SCANNER              704 /**< Generic Barcode Scanner. */
+#define BLE_APPEARANCE_GENERIC_THERMOMETER                  768 /**< Generic Thermometer. */
+#define BLE_APPEARANCE_THERMOMETER_EAR                      769 /**< Thermometer: Ear. */
+#define BLE_APPEARANCE_GENERIC_HEART_RATE_SENSOR            832 /**< Generic Heart rate Sensor. */
+#define BLE_APPEARANCE_HEART_RATE_SENSOR_HEART_RATE_BELT    833 /**< Heart Rate Sensor: Heart Rate Belt. */
+#define BLE_APPEARANCE_GENERIC_BLOOD_PRESSURE               896 /**< Generic Blood Pressure. */
+#define BLE_APPEARANCE_BLOOD_PRESSURE_ARM                   897 /**< Blood Pressure: Arm. */
+#define BLE_APPEARANCE_BLOOD_PRESSURE_WRIST                 898 /**< Blood Pressure: Wrist. */
+#define BLE_APPEARANCE_GENERIC_HID                          960 /**< Human Interface Device (HID). */
+#define BLE_APPEARANCE_HID_KEYBOARD                         961 /**< Keyboard (HID Subtype). */
+#define BLE_APPEARANCE_HID_MOUSE                            962 /**< Mouse (HID Subtype). */
+#define BLE_APPEARANCE_HID_JOYSTICK                         963 /**< Joystick (HID Subtype). */
+#define BLE_APPEARANCE_HID_GAMEPAD                          964 /**< Gamepad (HID Subtype). */
+#define BLE_APPEARANCE_HID_DIGITIZERSUBTYPE                 965 /**< Digitizer Tablet (HID Subtype). */
+#define BLE_APPEARANCE_HID_CARD_READER                      966 /**< Card Reader (HID Subtype). */
+#define BLE_APPEARANCE_HID_DIGITAL_PEN                      967 /**< Digital Pen (HID Subtype). */
+#define BLE_APPEARANCE_HID_BARCODE                          968 /**< Barcode Scanner (HID Subtype). */
+#define BLE_APPEARANCE_GENERIC_GLUCOSE_METER               1024 /**< Generic Glucose Meter. */
+#define BLE_APPEARANCE_GENERIC_RUNNING_WALKING_SENSOR      1088 /**< Generic Running Walking Sensor. */
+#define BLE_APPEARANCE_RUNNING_WALKING_SENSOR_IN_SHOE      1089 /**< Running Walking Sensor: In-Shoe. */
+#define BLE_APPEARANCE_RUNNING_WALKING_SENSOR_ON_SHOE      1090 /**< Running Walking Sensor: On-Shoe. */
+#define BLE_APPEARANCE_RUNNING_WALKING_SENSOR_ON_HIP       1091 /**< Running Walking Sensor: On-Hip. */
+#define BLE_APPEARANCE_GENERIC_CYCLING                     1152 /**< Generic Cycling. */
+#define BLE_APPEARANCE_CYCLING_CYCLING_COMPUTER            1153 /**< Cycling: Cycling Computer. */
+#define BLE_APPEARANCE_CYCLING_SPEED_SENSOR                1154 /**< Cycling: Speed Sensor. */
+#define BLE_APPEARANCE_CYCLING_CADENCE_SENSOR              1155 /**< Cycling: Cadence Sensor. */
+#define BLE_APPEARANCE_CYCLING_POWER_SENSOR                1156 /**< Cycling: Power Sensor. */
+#define BLE_APPEARANCE_CYCLING_SPEED_CADENCE_SENSOR        1157 /**< Cycling: Speed and Cadence Sensor. */
+#define BLE_APPEARANCE_GENERIC_PULSE_OXIMETER              3136 /**< Generic Pulse Oximeter. */
+#define BLE_APPEARANCE_PULSE_OXIMETER_FINGERTIP            3137 /**< Fingertip (Pulse Oximeter subtype). */
+#define BLE_APPEARANCE_PULSE_OXIMETER_WRIST_WORN           3138 /**< Wrist Worn(Pulse Oximeter subtype). */
+#define BLE_APPEARANCE_GENERIC_WEIGHT_SCALE                3200 /**< Generic Weight Scale. */
+#define BLE_APPEARANCE_GENERIC_OUTDOOR_SPORTS_ACT          5184 /**< Generic Outdoor Sports Activity. */
+#define BLE_APPEARANCE_OUTDOOR_SPORTS_ACT_LOC_DISP         5185 /**< Location Display Device (Outdoor Sports Activity subtype). */
+#define BLE_APPEARANCE_OUTDOOR_SPORTS_ACT_LOC_AND_NAV_DISP 5186 /**< Location and Navigation Display Device (Outdoor Sports Activity subtype). */
+#define BLE_APPEARANCE_OUTDOOR_SPORTS_ACT_LOC_POD          5187 /**< Location Pod (Outdoor Sports Activity subtype). */
+#define BLE_APPEARANCE_OUTDOOR_SPORTS_ACT_LOC_AND_NAV_POD  5188 /**< Location and Navigation Pod (Outdoor Sports Activity subtype). */
+/** @} */
+
+/** @brief Set .type and .uuid fields of ble_uuid_struct to specified UUID value. */
+#define BLE_UUID_BLE_ASSIGN(instance, value) do {\
+            instance.type = BLE_UUID_TYPE_BLE; \
+            instance.uuid = value;} while(0)
+
+/** @brief Copy type and uuid members from src to dst ble_uuid_t pointer. Both pointers must be valid/non-null. */
+#define BLE_UUID_COPY_PTR(dst, src) do {\
+            (dst)->type = (src)->type; \
+            (dst)->uuid = (src)->uuid;} while(0)
+
+/** @brief Copy type and uuid members from src to dst ble_uuid_t struct. */
+#define BLE_UUID_COPY_INST(dst, src) do {\
+            (dst).type = (src).type; \
+            (dst).uuid = (src).uuid;} while(0)
+
+/** @brief Compare for equality both type and uuid members of two (valid, non-null) ble_uuid_t pointers. */
+#define BLE_UUID_EQ(p_uuid1, p_uuid2) \
+            (((p_uuid1)->type == (p_uuid2)->type) && ((p_uuid1)->uuid == (p_uuid2)->uuid))
+
+/** @brief Compare for difference both type and uuid members of two (valid, non-null) ble_uuid_t pointers. */
+#define BLE_UUID_NEQ(p_uuid1, p_uuid2) \
+            (((p_uuid1)->type != (p_uuid2)->type) || ((p_uuid1)->uuid != (p_uuid2)->uuid))
+
+/** @} */
+
+/** @addtogroup BLE_TYPES_STRUCTURES Structures
+ * @{ */
+
+/** @brief 128 bit UUID values. */
+typedef struct
+{
+  uint8_t uuid128[16]; /**< Little-Endian UUID bytes. */
+} ble_uuid128_t;
+
+/** @brief  Bluetooth Low Energy UUID type, encapsulates both 16-bit and 128-bit UUIDs. */
+typedef struct
+{
+  uint16_t    uuid; /**< 16-bit UUID value or octets 12-13 of 128-bit UUID. */
+  uint8_t     type; /**< UUID type, see @ref BLE_UUID_TYPES. If type is @ref BLE_UUID_TYPE_UNKNOWN, the value of uuid is undefined. */
+} ble_uuid_t;
+
+/**@brief Data structure. */
+typedef struct
+{
+  uint8_t     *p_data;  /**< Pointer to the data buffer provided to/from the application. */
+  uint16_t     len;     /**< Length of the data buffer, in bytes. */
+} ble_data_t;
+
+/** @} */
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BLE_TYPES_H__ */
+
+/**
+  @}
+  @}
+*/

--- a/variants/t1000-e/s140_nrf52_7.3.0_API/include/nrf52/nrf_mbr.h
+++ b/variants/t1000-e/s140_nrf52_7.3.0_API/include/nrf52/nrf_mbr.h
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2014 - 2017, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+  @defgroup nrf_mbr_api Master Boot Record API
+  @{
+
+  @brief APIs for updating SoftDevice and BootLoader
+
+*/
+
+#ifndef NRF_MBR_H__
+#define NRF_MBR_H__
+
+#include "nrf_svc.h"
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @addtogroup NRF_MBR_DEFINES Defines
+ * @{ */
+
+/**@brief MBR SVC Base number. */
+#define MBR_SVC_BASE            (0x18)
+
+/**@brief Page size in words. */
+#define MBR_PAGE_SIZE_IN_WORDS  (1024)
+
+/** @brief The size that must be reserved for the MBR when a SoftDevice is written to flash.
+This is the offset where the first byte of the SoftDevice hex file is written. */
+#define MBR_SIZE                (0x1000)
+
+/** @brief Location (in the flash memory) of the bootloader address. */
+#define MBR_BOOTLOADER_ADDR      (0xFF8)
+
+/** @brief Location (in UICR) of the bootloader address. */
+#define MBR_UICR_BOOTLOADER_ADDR (&(NRF_UICR->NRFFW[0]))
+
+/** @brief Location (in the flash memory) of the address of the MBR parameter page. */
+#define MBR_PARAM_PAGE_ADDR      (0xFFC)
+
+/** @brief Location (in UICR) of the address of the MBR parameter page. */
+#define MBR_UICR_PARAM_PAGE_ADDR (&(NRF_UICR->NRFFW[1]))
+
+
+/** @} */
+
+/** @addtogroup NRF_MBR_ENUMS Enumerations
+ * @{ */
+
+/**@brief nRF Master Boot Record API SVC numbers. */
+enum NRF_MBR_SVCS
+{
+  SD_MBR_COMMAND = MBR_SVC_BASE, /**< ::sd_mbr_command */
+};
+
+/**@brief Possible values for ::sd_mbr_command_t.command */
+enum NRF_MBR_COMMANDS
+{
+  SD_MBR_COMMAND_COPY_BL,                 /**< Copy a new BootLoader. @see ::sd_mbr_command_copy_bl_t*/
+  SD_MBR_COMMAND_COPY_SD,                 /**< Copy a new SoftDevice. @see ::sd_mbr_command_copy_sd_t*/
+  SD_MBR_COMMAND_INIT_SD,                 /**< Initialize forwarding interrupts to SD, and run reset function in SD. Does not require any parameters in ::sd_mbr_command_t params.*/
+  SD_MBR_COMMAND_COMPARE,                 /**< This command works like memcmp. @see ::sd_mbr_command_compare_t*/
+  SD_MBR_COMMAND_VECTOR_TABLE_BASE_SET,   /**< Change the address the MBR starts after a reset. @see ::sd_mbr_command_vector_table_base_set_t*/
+  SD_MBR_COMMAND_RESERVED,
+  SD_MBR_COMMAND_IRQ_FORWARD_ADDRESS_SET, /**< Start forwarding all interrupts to this address. @see ::sd_mbr_command_irq_forward_address_set_t*/
+};
+
+/** @} */
+
+/** @addtogroup NRF_MBR_TYPES Types
+ * @{ */
+
+/**@brief This command copies part of a new SoftDevice
+ *
+ * The destination area is erased before copying.
+ * If dst is in the middle of a flash page, that whole flash page will be erased.
+ * If (dst+len) is in the middle of a flash page, that whole flash page will be erased.
+ *
+ * The user of this function is responsible for setting the BPROT registers.
+ *
+ * @retval ::NRF_SUCCESS indicates that the contents of the memory blocks where copied correctly.
+ * @retval ::NRF_ERROR_INTERNAL indicates that the contents of the memory blocks where not verified correctly after copying.
+ */
+typedef struct
+{
+  uint32_t *src;  /**< Pointer to the source of data to be copied.*/
+  uint32_t *dst;  /**< Pointer to the destination where the content is to be copied.*/
+  uint32_t len;   /**< Number of 32 bit words to copy. Must be a multiple of @ref MBR_PAGE_SIZE_IN_WORDS words.*/
+} sd_mbr_command_copy_sd_t;
+
+
+/**@brief This command works like memcmp, but takes the length in words.
+ *
+ * @retval ::NRF_SUCCESS indicates that the contents of both memory blocks are equal.
+ * @retval ::NRF_ERROR_NULL indicates that the contents of the memory blocks are not equal.
+ */
+typedef struct
+{
+  uint32_t *ptr1; /**< Pointer to block of memory. */
+  uint32_t *ptr2; /**< Pointer to block of memory. */
+  uint32_t len;   /**< Number of 32 bit words to compare.*/
+} sd_mbr_command_compare_t;
+
+
+/**@brief This command copies a new BootLoader.
+ *
+ * The MBR assumes that either @ref MBR_BOOTLOADER_ADDR or @ref MBR_UICR_BOOTLOADER_ADDR is set to
+ * the address where the bootloader will be copied. If both addresses are set, the MBR will prioritize
+ * @ref MBR_BOOTLOADER_ADDR.
+ *
+ * The bootloader destination is erased by this function.
+ * If (destination+bl_len) is in the middle of a flash page, that whole flash page will be erased.
+ *
+ * This command requires that @ref MBR_PARAM_PAGE_ADDR or @ref MBR_UICR_PARAM_PAGE_ADDR is set,
+ * see @ref sd_mbr_command.
+ *
+ * This command will use the flash protect peripheral (BPROT or ACL) to protect the flash that is
+ * not intended to be written.
+ *
+ * On success, this function will not return. It will start the new bootloader from reset-vector as normal.
+ *
+ * @retval ::NRF_ERROR_INTERNAL indicates an internal error that should not happen.
+ * @retval ::NRF_ERROR_FORBIDDEN if the bootloader address is not set.
+ * @retval ::NRF_ERROR_INVALID_LENGTH if parameters attempts to read or write outside flash area.
+ * @retval ::NRF_ERROR_NO_MEM No MBR parameter page is provided. See @ref sd_mbr_command.
+ */
+typedef struct
+{
+  uint32_t *bl_src;  /**< Pointer to the source of the bootloader to be be copied.*/
+  uint32_t bl_len;   /**< Number of 32 bit words to copy for BootLoader. */
+} sd_mbr_command_copy_bl_t;
+
+/**@brief Change the address the MBR starts after a reset
+ *
+ * Once this function has been called, this address is where the MBR will start to forward
+ * interrupts to after a reset.
+ *
+ * To restore default forwarding, this function should be called with @ref address set to 0. If a
+ * bootloader is present, interrupts will be forwarded to the bootloader. If not, interrupts will
+ * be forwarded to the SoftDevice.
+ *
+ * The location of a bootloader can be specified in @ref MBR_BOOTLOADER_ADDR or
+ * @ref MBR_UICR_BOOTLOADER_ADDR. If both addresses are set, the MBR will prioritize
+ * @ref MBR_BOOTLOADER_ADDR.
+ *
+ * This command requires that @ref MBR_PARAM_PAGE_ADDR or @ref MBR_UICR_PARAM_PAGE_ADDR is set,
+ * see @ref sd_mbr_command.
+ *
+ * On success, this function will not return. It will reset the device.
+ *
+ * @retval ::NRF_ERROR_INTERNAL indicates an internal error that should not happen.
+ * @retval ::NRF_ERROR_INVALID_ADDR if parameter address is outside of the flash size.
+ * @retval ::NRF_ERROR_NO_MEM No MBR parameter page is provided. See @ref sd_mbr_command.
+ */
+typedef struct
+{
+  uint32_t address; /**< The base address of the interrupt vector table for forwarded interrupts.*/
+} sd_mbr_command_vector_table_base_set_t;
+
+/**@brief Sets the base address of the interrupt vector table for interrupts forwarded from the MBR
+ *
+ * Unlike sd_mbr_command_vector_table_base_set_t, this function does not reset, and it does not
+ * change where the MBR starts after reset.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+typedef struct
+{
+  uint32_t address; /**< The base address of the interrupt vector table for forwarded interrupts.*/
+} sd_mbr_command_irq_forward_address_set_t;
+
+/**@brief Input structure containing data used when calling ::sd_mbr_command
+ *
+ * Depending on what command value that is set, the corresponding params value type must also be
+ * set. See @ref NRF_MBR_COMMANDS for command types and corresponding params value type. If command
+ * @ref SD_MBR_COMMAND_INIT_SD is set, it is not necessary to set any values under params.
+ */
+typedef struct
+{
+  uint32_t command;  /**< Type of command to be issued. See @ref NRF_MBR_COMMANDS. */
+  union
+  {
+    sd_mbr_command_copy_sd_t copy_sd;  /**< Parameters for copy SoftDevice.*/
+    sd_mbr_command_compare_t compare;  /**< Parameters for verify.*/
+    sd_mbr_command_copy_bl_t copy_bl;  /**< Parameters for copy BootLoader. Requires parameter page. */
+    sd_mbr_command_vector_table_base_set_t base_set; /**< Parameters for vector table base set. Requires parameter page.*/
+    sd_mbr_command_irq_forward_address_set_t irq_forward_address_set; /**< Parameters for irq forward address set*/
+  } params; /**< Command parameters. */
+} sd_mbr_command_t;
+
+/** @} */
+
+/** @addtogroup NRF_MBR_FUNCTIONS Functions
+ * @{ */
+
+/**@brief Issue Master Boot Record commands
+ *
+ * Commands used when updating a SoftDevice and bootloader.
+ *
+ * The @ref SD_MBR_COMMAND_COPY_BL and @ref SD_MBR_COMMAND_VECTOR_TABLE_BASE_SET requires
+ * parameters to be retained by the MBR when resetting the IC. This is done in a separate flash
+ * page. The location of the flash page should be provided by the application in either
+ * @ref MBR_PARAM_PAGE_ADDR or @ref MBR_UICR_PARAM_PAGE_ADDR. If both addresses are set, the MBR
+ * will prioritize @ref MBR_PARAM_PAGE_ADDR. This page will be cleared by the MBR and is used to
+ * store the command before reset. When an address is specified, the page it refers to must not be
+ * used by the application. If no address is provided by the application, i.e. both
+ * @ref MBR_PARAM_PAGE_ADDR and @ref MBR_UICR_PARAM_PAGE_ADDR is 0xFFFFFFFF, MBR commands which use
+ * flash will be unavailable and return @ref NRF_ERROR_NO_MEM.
+ *
+ * @param[in]  param Pointer to a struct describing the command.
+ *
+ * @note For a complete set of return values, see ::sd_mbr_command_copy_sd_t,
+ *       ::sd_mbr_command_copy_bl_t, ::sd_mbr_command_compare_t,
+ *       ::sd_mbr_command_vector_table_base_set_t, ::sd_mbr_command_irq_forward_address_set_t
+ *
+ * @retval ::NRF_ERROR_NO_MEM No MBR parameter page provided
+ * @retval ::NRF_ERROR_INVALID_PARAM if an invalid command is given.
+*/
+SVCALL(SD_MBR_COMMAND, uint32_t, sd_mbr_command(sd_mbr_command_t* param));
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+#endif // NRF_MBR_H__
+
+/**
+  @}
+*/

--- a/variants/t1000-e/s140_nrf52_7.3.0_API/include/nrf_error.h
+++ b/variants/t1000-e/s140_nrf52_7.3.0_API/include/nrf_error.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+ /**
+  @defgroup nrf_error SoftDevice Global Error Codes
+  @{
+
+  @brief Global Error definitions
+*/
+
+/* Header guard */
+#ifndef NRF_ERROR_H__
+#define NRF_ERROR_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @defgroup NRF_ERRORS_BASE Error Codes Base number definitions
+ * @{ */
+#define NRF_ERROR_BASE_NUM      (0x0)       ///< Global error base
+#define NRF_ERROR_SDM_BASE_NUM  (0x1000)    ///< SDM error base
+#define NRF_ERROR_SOC_BASE_NUM  (0x2000)    ///< SoC error base
+#define NRF_ERROR_STK_BASE_NUM  (0x3000)    ///< STK error base
+/** @} */
+
+#define NRF_SUCCESS                           (NRF_ERROR_BASE_NUM + 0)  ///< Successful command
+#define NRF_ERROR_SVC_HANDLER_MISSING         (NRF_ERROR_BASE_NUM + 1)  ///< SVC handler is missing
+#define NRF_ERROR_SOFTDEVICE_NOT_ENABLED      (NRF_ERROR_BASE_NUM + 2)  ///< SoftDevice has not been enabled
+#define NRF_ERROR_INTERNAL                    (NRF_ERROR_BASE_NUM + 3)  ///< Internal Error
+#define NRF_ERROR_NO_MEM                      (NRF_ERROR_BASE_NUM + 4)  ///< No Memory for operation
+#define NRF_ERROR_NOT_FOUND                   (NRF_ERROR_BASE_NUM + 5)  ///< Not found
+#define NRF_ERROR_NOT_SUPPORTED               (NRF_ERROR_BASE_NUM + 6)  ///< Not supported
+#define NRF_ERROR_INVALID_PARAM               (NRF_ERROR_BASE_NUM + 7)  ///< Invalid Parameter
+#define NRF_ERROR_INVALID_STATE               (NRF_ERROR_BASE_NUM + 8)  ///< Invalid state, operation disallowed in this state
+#define NRF_ERROR_INVALID_LENGTH              (NRF_ERROR_BASE_NUM + 9)  ///< Invalid Length
+#define NRF_ERROR_INVALID_FLAGS               (NRF_ERROR_BASE_NUM + 10) ///< Invalid Flags
+#define NRF_ERROR_INVALID_DATA                (NRF_ERROR_BASE_NUM + 11) ///< Invalid Data
+#define NRF_ERROR_DATA_SIZE                   (NRF_ERROR_BASE_NUM + 12) ///< Invalid Data size
+#define NRF_ERROR_TIMEOUT                     (NRF_ERROR_BASE_NUM + 13) ///< Operation timed out
+#define NRF_ERROR_NULL                        (NRF_ERROR_BASE_NUM + 14) ///< Null Pointer
+#define NRF_ERROR_FORBIDDEN                   (NRF_ERROR_BASE_NUM + 15) ///< Forbidden Operation
+#define NRF_ERROR_INVALID_ADDR                (NRF_ERROR_BASE_NUM + 16) ///< Bad Memory Address
+#define NRF_ERROR_BUSY                        (NRF_ERROR_BASE_NUM + 17) ///< Busy
+#define NRF_ERROR_CONN_COUNT                  (NRF_ERROR_BASE_NUM + 18) ///< Maximum connection count exceeded.
+#define NRF_ERROR_RESOURCES                   (NRF_ERROR_BASE_NUM + 19) ///< Not enough resources for operation
+
+#ifdef __cplusplus
+}
+#endif
+#endif // NRF_ERROR_H__
+
+/**
+  @}
+*/

--- a/variants/t1000-e/s140_nrf52_7.3.0_API/include/nrf_error_sdm.h
+++ b/variants/t1000-e/s140_nrf52_7.3.0_API/include/nrf_error_sdm.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+ /**
+  @addtogroup nrf_sdm_api
+  @{
+  @defgroup nrf_sdm_error SoftDevice Manager Error Codes
+  @{
+
+  @brief Error definitions for the SDM API
+*/
+
+/* Header guard */
+#ifndef NRF_ERROR_SDM_H__
+#define NRF_ERROR_SDM_H__
+
+#include "nrf_error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define NRF_ERROR_SDM_LFCLK_SOURCE_UNKNOWN              (NRF_ERROR_SDM_BASE_NUM + 0)  ///< Unknown LFCLK source.
+#define NRF_ERROR_SDM_INCORRECT_INTERRUPT_CONFIGURATION (NRF_ERROR_SDM_BASE_NUM + 1)  ///< Incorrect interrupt configuration (can be caused by using illegal priority levels, or having enabled SoftDevice interrupts).
+#define NRF_ERROR_SDM_INCORRECT_CLENR0                  (NRF_ERROR_SDM_BASE_NUM + 2)  ///< Incorrect CLENR0 (can be caused by erroneous SoftDevice flashing).
+
+#ifdef __cplusplus
+}
+#endif
+#endif // NRF_ERROR_SDM_H__
+
+/**
+  @}
+  @}
+*/

--- a/variants/t1000-e/s140_nrf52_7.3.0_API/include/nrf_error_soc.h
+++ b/variants/t1000-e/s140_nrf52_7.3.0_API/include/nrf_error_soc.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+  @addtogroup nrf_soc_api
+  @{
+  @defgroup nrf_soc_error SoC Library Error Codes
+  @{
+
+  @brief Error definitions for the SoC library
+
+*/
+
+/* Header guard */
+#ifndef NRF_ERROR_SOC_H__
+#define NRF_ERROR_SOC_H__
+
+#include "nrf_error.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Mutex Errors */
+#define NRF_ERROR_SOC_MUTEX_ALREADY_TAKEN                 (NRF_ERROR_SOC_BASE_NUM + 0)  ///< Mutex already taken
+
+/* NVIC errors */
+#define NRF_ERROR_SOC_NVIC_INTERRUPT_NOT_AVAILABLE        (NRF_ERROR_SOC_BASE_NUM + 1)  ///< NVIC interrupt not available
+#define NRF_ERROR_SOC_NVIC_INTERRUPT_PRIORITY_NOT_ALLOWED (NRF_ERROR_SOC_BASE_NUM + 2)  ///< NVIC interrupt priority not allowed
+#define NRF_ERROR_SOC_NVIC_SHOULD_NOT_RETURN              (NRF_ERROR_SOC_BASE_NUM + 3)  ///< NVIC should not return
+
+/* Power errors */
+#define NRF_ERROR_SOC_POWER_MODE_UNKNOWN                  (NRF_ERROR_SOC_BASE_NUM + 4)  ///< Power mode unknown
+#define NRF_ERROR_SOC_POWER_POF_THRESHOLD_UNKNOWN         (NRF_ERROR_SOC_BASE_NUM + 5)  ///< Power POF threshold unknown
+#define NRF_ERROR_SOC_POWER_OFF_SHOULD_NOT_RETURN         (NRF_ERROR_SOC_BASE_NUM + 6)  ///< Power off should not return
+
+/* Rand errors */
+#define NRF_ERROR_SOC_RAND_NOT_ENOUGH_VALUES              (NRF_ERROR_SOC_BASE_NUM + 7)  ///< RAND not enough values
+
+/* PPI errors */
+#define NRF_ERROR_SOC_PPI_INVALID_CHANNEL                 (NRF_ERROR_SOC_BASE_NUM + 8)  ///< Invalid PPI Channel
+#define NRF_ERROR_SOC_PPI_INVALID_GROUP                   (NRF_ERROR_SOC_BASE_NUM + 9)  ///< Invalid PPI Group
+
+#ifdef __cplusplus
+}
+#endif
+#endif // NRF_ERROR_SOC_H__
+/**
+  @}
+  @}
+*/

--- a/variants/t1000-e/s140_nrf52_7.3.0_API/include/nrf_nvic.h
+++ b/variants/t1000-e/s140_nrf52_7.3.0_API/include/nrf_nvic.h
@@ -1,0 +1,491 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @defgroup nrf_nvic_api SoftDevice NVIC API
+ * @{
+ *
+ * @note In order to use this module, the following code has to be added to a .c file:
+ *     \code
+ *     nrf_nvic_state_t nrf_nvic_state = {0};
+ *     \endcode
+ *
+ * @note Definitions and declarations starting with __ (double underscore) in this header file are
+ * not intended for direct use by the application.
+ *
+ * @brief APIs for the accessing NVIC when using a SoftDevice.
+ *
+ */
+
+#ifndef NRF_NVIC_H__
+#define NRF_NVIC_H__
+
+#include <stdint.h>
+#include "nrf.h"
+#include "nrf_svc.h"
+#include "nrf_error.h"
+#include "nrf_error_soc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**@addtogroup NRF_NVIC_DEFINES Defines
+ * @{ */
+
+/**@defgroup NRF_NVIC_ISER_DEFINES SoftDevice NVIC internal definitions
+ * @{ */
+
+#define __NRF_NVIC_NVMC_IRQn (30) /**< The peripheral ID of the NVMC. IRQ numbers are used to identify peripherals, but the NVMC doesn't have an IRQ number in the MDK. */
+
+#define __NRF_NVIC_ISER_COUNT (2) /**< The number of ISER/ICER registers in the NVIC that are used. */
+
+/**@brief Interrupt priority levels used by the SoftDevice. */
+#define __NRF_NVIC_SD_IRQ_PRIOS ((uint8_t)( \
+      (1U << 0)  /**< Priority level high .*/   \
+    | (1U << 1)  /**< Priority level medium. */ \
+    | (1U << 4)  /**< Priority level low. */    \
+  ))
+
+/**@brief Interrupt priority levels available to the application. */
+#define __NRF_NVIC_APP_IRQ_PRIOS ((uint8_t)~__NRF_NVIC_SD_IRQ_PRIOS)
+
+/**@brief Interrupts used by the SoftDevice, with IRQn in the range 0-31. */
+#define __NRF_NVIC_SD_IRQS_0 ((uint32_t)( \
+      (1U << POWER_CLOCK_IRQn) \
+    | (1U << RADIO_IRQn) \
+    | (1U << RTC0_IRQn) \
+    | (1U << TIMER0_IRQn) \
+    | (1U << RNG_IRQn) \
+    | (1U << ECB_IRQn) \
+    | (1U << CCM_AAR_IRQn) \
+    | (1U << TEMP_IRQn) \
+    | (1U << __NRF_NVIC_NVMC_IRQn) \
+    | (1U << (uint32_t)SWI5_IRQn) \
+  ))
+
+/**@brief Interrupts used by the SoftDevice, with IRQn in the range 32-63. */
+#define __NRF_NVIC_SD_IRQS_1 ((uint32_t)0)
+
+/**@brief Interrupts available for to application, with IRQn in the range 0-31. */
+#define __NRF_NVIC_APP_IRQS_0 (~__NRF_NVIC_SD_IRQS_0)
+
+/**@brief Interrupts available for to application, with IRQn in the range 32-63. */
+#define __NRF_NVIC_APP_IRQS_1 (~__NRF_NVIC_SD_IRQS_1)
+
+/**@} */
+
+/**@} */
+
+/**@addtogroup NRF_NVIC_VARIABLES Variables
+ * @{ */
+
+/**@brief Type representing the state struct for the SoftDevice NVIC module. */
+typedef struct
+{
+  uint32_t volatile __irq_masks[__NRF_NVIC_ISER_COUNT]; /**< IRQs enabled by the application in the NVIC. */
+  uint32_t volatile __cr_flag;                          /**< Non-zero if already in a critical region */
+} nrf_nvic_state_t;
+
+/**@brief Variable keeping the state for the SoftDevice NVIC module. This must be declared in an
+ * application source file. */
+extern nrf_nvic_state_t nrf_nvic_state;
+
+/**@} */
+
+/**@addtogroup NRF_NVIC_INTERNAL_FUNCTIONS SoftDevice NVIC internal functions
+ * @{ */
+
+/**@brief Disables IRQ interrupts globally, including the SoftDevice's interrupts.
+ *
+ * @retval  The value of PRIMASK prior to disabling the interrupts.
+ */
+__STATIC_INLINE int __sd_nvic_irq_disable(void);
+
+/**@brief Enables IRQ interrupts globally, including the SoftDevice's interrupts.
+ */
+__STATIC_INLINE void __sd_nvic_irq_enable(void);
+
+/**@brief Checks if IRQn is available to application
+ * @param[in]  IRQn  IRQ to check
+ *
+ * @retval  1 (true) if the IRQ to check is available to the application
+ */
+__STATIC_INLINE uint32_t __sd_nvic_app_accessible_irq(IRQn_Type IRQn);
+
+/**@brief Checks if priority is available to application
+ * @param[in]  priority  priority to check
+ *
+ * @retval  1 (true) if the priority to check is available to the application
+ */
+__STATIC_INLINE uint32_t __sd_nvic_is_app_accessible_priority(uint32_t priority);
+
+/**@} */
+
+/**@addtogroup NRF_NVIC_FUNCTIONS SoftDevice NVIC public functions
+ * @{ */
+
+/**@brief Enable External Interrupt.
+ * @note Corresponds to NVIC_EnableIRQ in CMSIS.
+ *
+ * @pre IRQn is valid and not reserved by the stack.
+ *
+ * @param[in] IRQn See the NVIC_EnableIRQ documentation in CMSIS.
+ *
+ * @retval ::NRF_SUCCESS The interrupt was enabled.
+ * @retval ::NRF_ERROR_SOC_NVIC_INTERRUPT_NOT_AVAILABLE The interrupt is not available for the application.
+ * @retval ::NRF_ERROR_SOC_NVIC_INTERRUPT_PRIORITY_NOT_ALLOWED The interrupt has a priority not available for the application.
+ */
+__STATIC_INLINE uint32_t sd_nvic_EnableIRQ(IRQn_Type IRQn);
+
+/**@brief  Disable External Interrupt.
+ * @note Corresponds to NVIC_DisableIRQ in CMSIS.
+ *
+ * @pre IRQn is valid and not reserved by the stack.
+ *
+ * @param[in] IRQn See the NVIC_DisableIRQ documentation in CMSIS.
+ *
+ * @retval ::NRF_SUCCESS The interrupt was disabled.
+ * @retval ::NRF_ERROR_SOC_NVIC_INTERRUPT_NOT_AVAILABLE The interrupt is not available for the application.
+ */
+__STATIC_INLINE uint32_t sd_nvic_DisableIRQ(IRQn_Type IRQn);
+
+/**@brief  Get Pending Interrupt.
+ * @note Corresponds to NVIC_GetPendingIRQ in CMSIS.
+ *
+ * @pre IRQn is valid and not reserved by the stack.
+ *
+ * @param[in]   IRQn          See the NVIC_GetPendingIRQ documentation in CMSIS.
+ * @param[out]  p_pending_irq Return value from NVIC_GetPendingIRQ.
+ *
+ * @retval ::NRF_SUCCESS The interrupt is available for the application.
+ * @retval ::NRF_ERROR_SOC_NVIC_INTERRUPT_NOT_AVAILABLE IRQn is not available for the application.
+ */
+__STATIC_INLINE uint32_t sd_nvic_GetPendingIRQ(IRQn_Type IRQn, uint32_t * p_pending_irq);
+
+/**@brief  Set Pending Interrupt.
+ * @note Corresponds to NVIC_SetPendingIRQ in CMSIS.
+ *
+ * @pre IRQn is valid and not reserved by the stack.
+ *
+ * @param[in] IRQn See the NVIC_SetPendingIRQ documentation in CMSIS.
+ *
+ * @retval ::NRF_SUCCESS The interrupt is set pending.
+ * @retval ::NRF_ERROR_SOC_NVIC_INTERRUPT_NOT_AVAILABLE IRQn is not available for the application.
+ */
+__STATIC_INLINE uint32_t sd_nvic_SetPendingIRQ(IRQn_Type IRQn);
+
+/**@brief  Clear Pending Interrupt.
+ * @note Corresponds to NVIC_ClearPendingIRQ in CMSIS.
+ *
+ * @pre IRQn is valid and not reserved by the stack.
+ *
+ * @param[in] IRQn See the NVIC_ClearPendingIRQ documentation in CMSIS.
+ *
+ * @retval ::NRF_SUCCESS The interrupt pending flag is cleared.
+ * @retval ::NRF_ERROR_SOC_NVIC_INTERRUPT_NOT_AVAILABLE IRQn is not available for the application.
+ */
+__STATIC_INLINE uint32_t sd_nvic_ClearPendingIRQ(IRQn_Type IRQn);
+
+/**@brief Set Interrupt Priority.
+ * @note Corresponds to NVIC_SetPriority in CMSIS.
+ *
+ * @pre IRQn is valid and not reserved by the stack.
+ * @pre Priority is valid and not reserved by the stack.
+ *
+ * @param[in] IRQn      See the NVIC_SetPriority documentation in CMSIS.
+ * @param[in] priority  A valid IRQ priority for use by the application.
+ *
+ * @retval ::NRF_SUCCESS The interrupt and priority level is available for the application.
+ * @retval ::NRF_ERROR_SOC_NVIC_INTERRUPT_NOT_AVAILABLE IRQn is not available for the application.
+ * @retval ::NRF_ERROR_SOC_NVIC_INTERRUPT_PRIORITY_NOT_ALLOWED The interrupt priority is not available for the application.
+ */
+__STATIC_INLINE uint32_t sd_nvic_SetPriority(IRQn_Type IRQn, uint32_t priority);
+
+/**@brief Get Interrupt Priority.
+ * @note Corresponds to NVIC_GetPriority in CMSIS.
+ *
+ * @pre IRQn is valid and not reserved by the stack.
+ *
+ * @param[in]  IRQn         See the NVIC_GetPriority documentation in CMSIS.
+ * @param[out] p_priority   Return value from NVIC_GetPriority.
+ *
+ * @retval ::NRF_SUCCESS The interrupt priority is returned in p_priority.
+ * @retval ::NRF_ERROR_SOC_NVIC_INTERRUPT_NOT_AVAILABLE - IRQn is not available for the application.
+ */
+__STATIC_INLINE uint32_t sd_nvic_GetPriority(IRQn_Type IRQn, uint32_t * p_priority);
+
+/**@brief System Reset.
+ * @note Corresponds to NVIC_SystemReset in CMSIS.
+ *
+ * @retval ::NRF_ERROR_SOC_NVIC_SHOULD_NOT_RETURN
+ */
+__STATIC_INLINE uint32_t sd_nvic_SystemReset(void);
+
+/**@brief Enter critical region.
+ *
+ * @post Application interrupts will be disabled.
+ * @note sd_nvic_critical_region_enter() and ::sd_nvic_critical_region_exit() must be called in matching pairs inside each
+ * execution context
+ * @sa sd_nvic_critical_region_exit
+ *
+ * @param[out] p_is_nested_critical_region If 1, the application is now in a nested critical region.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+__STATIC_INLINE uint32_t sd_nvic_critical_region_enter(uint8_t * p_is_nested_critical_region);
+
+/**@brief Exit critical region.
+ *
+ * @pre Application has entered a critical region using ::sd_nvic_critical_region_enter.
+ * @post If not in a nested critical region, the application interrupts will restored to the state before ::sd_nvic_critical_region_enter was called.
+ *
+ * @param[in] is_nested_critical_region If this is set to 1, the critical region won't be exited. @sa sd_nvic_critical_region_enter.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+__STATIC_INLINE uint32_t sd_nvic_critical_region_exit(uint8_t is_nested_critical_region);
+
+/**@} */
+
+#ifndef SUPPRESS_INLINE_IMPLEMENTATION
+
+__STATIC_INLINE int __sd_nvic_irq_disable(void)
+{
+  int pm = __get_PRIMASK();
+  __disable_irq();
+  return pm;
+}
+
+__STATIC_INLINE void __sd_nvic_irq_enable(void)
+{
+  __enable_irq();
+}
+
+__STATIC_INLINE uint32_t __sd_nvic_app_accessible_irq(IRQn_Type IRQn)
+{
+  if (IRQn < 32)
+  {
+    return ((1UL<<IRQn) & __NRF_NVIC_APP_IRQS_0) != 0;
+  }
+  else if (IRQn < 64)
+  {
+    return ((1UL<<(IRQn-32)) & __NRF_NVIC_APP_IRQS_1) != 0;
+  }
+  else
+  {
+    return 1;
+  }
+}
+
+__STATIC_INLINE uint32_t __sd_nvic_is_app_accessible_priority(uint32_t priority)
+{
+  if( (priority >= (1 << __NVIC_PRIO_BITS))
+   || (((1 << priority) & __NRF_NVIC_APP_IRQ_PRIOS) == 0)
+    )
+  {
+    return 0;
+  }
+  return 1;
+}
+
+
+__STATIC_INLINE uint32_t sd_nvic_EnableIRQ(IRQn_Type IRQn)
+{
+  if (!__sd_nvic_app_accessible_irq(IRQn))
+  {
+    return NRF_ERROR_SOC_NVIC_INTERRUPT_NOT_AVAILABLE;
+  }
+  if (!__sd_nvic_is_app_accessible_priority(NVIC_GetPriority(IRQn)))
+  {
+    return NRF_ERROR_SOC_NVIC_INTERRUPT_PRIORITY_NOT_ALLOWED;
+  }
+
+  if (nrf_nvic_state.__cr_flag)
+  {
+    nrf_nvic_state.__irq_masks[(uint32_t)((int32_t)IRQn) >> 5] |= (uint32_t)(1 << ((uint32_t)((int32_t)IRQn) & (uint32_t)0x1F));
+  }
+  else
+  {
+    NVIC_EnableIRQ(IRQn);
+  }
+  return NRF_SUCCESS;
+}
+
+__STATIC_INLINE uint32_t sd_nvic_DisableIRQ(IRQn_Type IRQn)
+{
+  if (!__sd_nvic_app_accessible_irq(IRQn))
+  {
+    return NRF_ERROR_SOC_NVIC_INTERRUPT_NOT_AVAILABLE;
+  }
+
+  if (nrf_nvic_state.__cr_flag)
+  {
+    nrf_nvic_state.__irq_masks[(uint32_t)((int32_t)IRQn) >> 5] &= ~(1UL << ((uint32_t)(IRQn) & 0x1F));
+  }
+  else
+  {
+    NVIC_DisableIRQ(IRQn);
+  }
+
+  return NRF_SUCCESS;
+}
+
+__STATIC_INLINE uint32_t sd_nvic_GetPendingIRQ(IRQn_Type IRQn, uint32_t * p_pending_irq)
+{
+  if (__sd_nvic_app_accessible_irq(IRQn))
+  {
+    *p_pending_irq = NVIC_GetPendingIRQ(IRQn);
+    return NRF_SUCCESS;
+  }
+  else
+  {
+    return NRF_ERROR_SOC_NVIC_INTERRUPT_NOT_AVAILABLE;
+  }
+}
+
+__STATIC_INLINE uint32_t sd_nvic_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if (__sd_nvic_app_accessible_irq(IRQn))
+  {
+    NVIC_SetPendingIRQ(IRQn);
+    return NRF_SUCCESS;
+  }
+  else
+  {
+    return NRF_ERROR_SOC_NVIC_INTERRUPT_NOT_AVAILABLE;
+  }
+}
+
+__STATIC_INLINE uint32_t sd_nvic_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if (__sd_nvic_app_accessible_irq(IRQn))
+  {
+    NVIC_ClearPendingIRQ(IRQn);
+    return NRF_SUCCESS;
+  }
+  else
+  {
+    return NRF_ERROR_SOC_NVIC_INTERRUPT_NOT_AVAILABLE;
+  }
+}
+
+__STATIC_INLINE uint32_t sd_nvic_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if (!__sd_nvic_app_accessible_irq(IRQn))
+  {
+    return NRF_ERROR_SOC_NVIC_INTERRUPT_NOT_AVAILABLE;
+  }
+
+  if (!__sd_nvic_is_app_accessible_priority(priority))
+  {
+    return NRF_ERROR_SOC_NVIC_INTERRUPT_PRIORITY_NOT_ALLOWED;
+  }
+
+  NVIC_SetPriority(IRQn, (uint32_t)priority);
+  return NRF_SUCCESS;
+}
+
+__STATIC_INLINE uint32_t sd_nvic_GetPriority(IRQn_Type IRQn, uint32_t * p_priority)
+{
+  if (__sd_nvic_app_accessible_irq(IRQn))
+  {
+    *p_priority = (NVIC_GetPriority(IRQn) & 0xFF);
+    return NRF_SUCCESS;
+  }
+  else
+  {
+    return NRF_ERROR_SOC_NVIC_INTERRUPT_NOT_AVAILABLE;
+  }
+}
+
+__STATIC_INLINE uint32_t sd_nvic_SystemReset(void)
+{
+  NVIC_SystemReset();
+  return NRF_ERROR_SOC_NVIC_SHOULD_NOT_RETURN;
+}
+
+__STATIC_INLINE uint32_t sd_nvic_critical_region_enter(uint8_t * p_is_nested_critical_region)
+{
+  int was_masked = __sd_nvic_irq_disable();
+  if (!nrf_nvic_state.__cr_flag)
+  {
+    nrf_nvic_state.__cr_flag = 1;
+    nrf_nvic_state.__irq_masks[0] = ( NVIC->ICER[0] & __NRF_NVIC_APP_IRQS_0 );
+    NVIC->ICER[0] = __NRF_NVIC_APP_IRQS_0;
+    nrf_nvic_state.__irq_masks[1] = ( NVIC->ICER[1] & __NRF_NVIC_APP_IRQS_1 );
+    NVIC->ICER[1] = __NRF_NVIC_APP_IRQS_1;
+    *p_is_nested_critical_region = 0;
+  }
+  else
+  {
+    *p_is_nested_critical_region = 1;
+  }
+  if (!was_masked)
+  {
+    __sd_nvic_irq_enable();
+  }
+  return NRF_SUCCESS;
+}
+
+__STATIC_INLINE uint32_t sd_nvic_critical_region_exit(uint8_t is_nested_critical_region)
+{
+  if (nrf_nvic_state.__cr_flag && (is_nested_critical_region == 0))
+  {
+    int was_masked = __sd_nvic_irq_disable();
+    NVIC->ISER[0] = nrf_nvic_state.__irq_masks[0];
+    NVIC->ISER[1] = nrf_nvic_state.__irq_masks[1];
+    nrf_nvic_state.__cr_flag = 0;
+    if (!was_masked)
+    {
+      __sd_nvic_irq_enable();
+    }
+  }
+
+  return NRF_SUCCESS;
+}
+
+#endif /* SUPPRESS_INLINE_IMPLEMENTATION */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRF_NVIC_H__
+
+/**@} */

--- a/variants/t1000-e/s140_nrf52_7.3.0_API/include/nrf_sdm.h
+++ b/variants/t1000-e/s140_nrf52_7.3.0_API/include/nrf_sdm.h
@@ -1,0 +1,371 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+  @defgroup nrf_sdm_api SoftDevice Manager API
+  @{
+
+  @brief APIs for SoftDevice management.
+
+*/
+
+#ifndef NRF_SDM_H__
+#define NRF_SDM_H__
+
+#include <stdint.h>
+#include "nrf.h"
+#include "nrf_svc.h"
+#include "nrf_error.h"
+#include "nrf_error_sdm.h"
+#include "nrf_soc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @addtogroup NRF_SDM_DEFINES Defines
+ * @{ */
+#ifdef NRFSOC_DOXYGEN
+/// Declared in nrf_mbr.h
+#define MBR_SIZE 0
+#warning test
+#endif
+
+/** @brief The major version for the SoftDevice binary distributed with this header file. */
+#define SD_MAJOR_VERSION  (7)
+
+/** @brief The minor version for the SoftDevice binary distributed with this header file. */
+#define SD_MINOR_VERSION  (3)
+
+/** @brief The bugfix version for the SoftDevice binary distributed with this header file. */
+#define SD_BUGFIX_VERSION (0)
+
+/** @brief The SoftDevice variant of this firmware. */
+#define SD_VARIANT_ID 140
+
+/** @brief The full version number for the SoftDevice binary this header file was distributed
+ *         with, as a decimal number in the form Mmmmbbb, where:
+ *           - M is major version (one or more digits)
+ *           - mmm is minor version (three digits)
+ *           - bbb is bugfix version (three digits). */
+#define SD_VERSION (SD_MAJOR_VERSION * 1000000 + SD_MINOR_VERSION * 1000 + SD_BUGFIX_VERSION)
+
+/** @brief SoftDevice Manager SVC Base number. */
+#define SDM_SVC_BASE 0x10
+
+/** @brief SoftDevice unique string size in bytes. */
+#define SD_UNIQUE_STR_SIZE 20
+
+/** @brief Invalid info field. Returned when an info field does not exist. */
+#define SDM_INFO_FIELD_INVALID (0)
+
+/** @brief Defines the SoftDevice Information Structure location (address) as an offset from
+the start of the SoftDevice (without MBR)*/
+#define SOFTDEVICE_INFO_STRUCT_OFFSET (0x2000)
+
+/** @brief Defines the absolute SoftDevice Information Structure location (address) when the
+ *         SoftDevice is installed just above the MBR (the usual case). */
+#define SOFTDEVICE_INFO_STRUCT_ADDRESS (SOFTDEVICE_INFO_STRUCT_OFFSET + MBR_SIZE)
+
+/** @brief Defines the offset for the SoftDevice Information Structure size value relative to the
+ *         SoftDevice base address. The size value is of type uint8_t. */
+#define SD_INFO_STRUCT_SIZE_OFFSET (SOFTDEVICE_INFO_STRUCT_OFFSET)
+
+/** @brief Defines the offset for the SoftDevice size value relative to the SoftDevice base address.
+ *         The size value is of type uint32_t. */
+#define SD_SIZE_OFFSET (SOFTDEVICE_INFO_STRUCT_OFFSET + 0x08)
+
+/** @brief Defines the offset for FWID value relative to the SoftDevice base address. The FWID value
+ *         is of type uint16_t.  */
+#define SD_FWID_OFFSET (SOFTDEVICE_INFO_STRUCT_OFFSET + 0x0C)
+
+/** @brief Defines the offset for the SoftDevice ID relative to the SoftDevice base address. The ID
+ *         is of type uint32_t. */
+#define SD_ID_OFFSET (SOFTDEVICE_INFO_STRUCT_OFFSET + 0x10)
+
+/** @brief Defines the offset for the SoftDevice version relative to the SoftDevice base address in
+ *         the same format as @ref SD_VERSION, stored as an uint32_t. */
+#define SD_VERSION_OFFSET (SOFTDEVICE_INFO_STRUCT_OFFSET + 0x14)
+
+/** @brief Defines the offset for the SoftDevice unique string relative to the SoftDevice base address.
+ *         The SD_UNIQUE_STR is stored as an array of uint8_t. The size of array is @ref SD_UNIQUE_STR_SIZE.
+ */
+#define SD_UNIQUE_STR_OFFSET (SOFTDEVICE_INFO_STRUCT_OFFSET + 0x18)
+
+/** @brief Defines a macro for retrieving the actual SoftDevice Information Structure size value
+ *         from a given base address. Use @ref MBR_SIZE as the argument when the SoftDevice is
+ *         installed just above the MBR (the usual case). */
+#define SD_INFO_STRUCT_SIZE_GET(baseaddr) (*((uint8_t *) ((baseaddr) + SD_INFO_STRUCT_SIZE_OFFSET)))
+
+/** @brief Defines a macro for retrieving the actual SoftDevice size value from a given base
+ *         address. Use @ref MBR_SIZE as the argument when the SoftDevice is installed just above
+ *         the MBR (the usual case). */
+#define SD_SIZE_GET(baseaddr) (*((uint32_t *) ((baseaddr) + SD_SIZE_OFFSET)))
+
+/** @brief Defines the amount of flash that is used by the SoftDevice.
+ *         Add @ref MBR_SIZE to find the first available flash address when the SoftDevice is installed
+ *         just above the MBR (the usual case).
+ */
+#define SD_FLASH_SIZE 0x26000
+
+/** @brief Defines a macro for retrieving the actual FWID value from a given base address. Use
+ *         @ref MBR_SIZE as the argument when the SoftDevice is installed just above the MBR (the usual
+ *         case). */
+#define SD_FWID_GET(baseaddr) (*((uint16_t *) ((baseaddr) + SD_FWID_OFFSET)))
+
+/** @brief Defines a macro for retrieving the actual SoftDevice ID from a given base address. Use
+ *         @ref MBR_SIZE as the argument when the SoftDevice is installed just above the MBR (the
+ *         usual case). */
+#define SD_ID_GET(baseaddr) ((SD_INFO_STRUCT_SIZE_GET(baseaddr) > (SD_ID_OFFSET - SOFTDEVICE_INFO_STRUCT_OFFSET)) \
+        ? (*((uint32_t *) ((baseaddr) + SD_ID_OFFSET))) : SDM_INFO_FIELD_INVALID)
+
+/** @brief Defines a macro for retrieving the actual SoftDevice version from a given base address.
+ *         Use @ref MBR_SIZE as the argument when the SoftDevice is installed just above the MBR
+ *         (the usual case). */
+#define SD_VERSION_GET(baseaddr) ((SD_INFO_STRUCT_SIZE_GET(baseaddr) > (SD_VERSION_OFFSET - SOFTDEVICE_INFO_STRUCT_OFFSET)) \
+        ? (*((uint32_t *) ((baseaddr) + SD_VERSION_OFFSET))) : SDM_INFO_FIELD_INVALID)
+
+/** @brief Defines a macro for retrieving the address of SoftDevice unique str based on a given base address.
+ *         Use @ref MBR_SIZE as the argument when the SoftDevice is installed just above the MBR
+ *         (the usual case). */
+#define SD_UNIQUE_STR_ADDR_GET(baseaddr) ((SD_INFO_STRUCT_SIZE_GET(baseaddr) > (SD_UNIQUE_STR_OFFSET - SOFTDEVICE_INFO_STRUCT_OFFSET)) \
+        ? (((uint8_t *) ((baseaddr) + SD_UNIQUE_STR_OFFSET))) : SDM_INFO_FIELD_INVALID)
+
+/**@defgroup NRF_FAULT_ID_RANGES Fault ID ranges
+ * @{ */
+#define NRF_FAULT_ID_SD_RANGE_START     0x00000000            /**< SoftDevice ID range start. */
+#define NRF_FAULT_ID_APP_RANGE_START    0x00001000            /**< Application ID range start. */
+/**@} */
+
+/**@defgroup NRF_FAULT_IDS Fault ID types
+ * @{ */
+#define NRF_FAULT_ID_SD_ASSERT    (NRF_FAULT_ID_SD_RANGE_START  + 1)          /**< SoftDevice assertion. The info parameter is reserved for future used. */
+#define NRF_FAULT_ID_APP_MEMACC   (NRF_FAULT_ID_APP_RANGE_START + 1)          /**< Application invalid memory access. The info parameter will contain 0x00000000,
+                                                                                   in case of SoftDevice RAM access violation. In case of SoftDevice peripheral
+                                                                                   register violation the info parameter will contain the sub-region number of
+                                                                                   PREGION[0], on whose address range the disallowed write access caused the
+                                                                                   memory access fault. */
+/**@} */
+
+/** @} */
+
+/** @addtogroup NRF_SDM_ENUMS Enumerations
+ * @{ */
+
+/**@brief nRF SoftDevice Manager API SVC numbers. */
+enum NRF_SD_SVCS
+{
+  SD_SOFTDEVICE_ENABLE = SDM_SVC_BASE, /**< ::sd_softdevice_enable */
+  SD_SOFTDEVICE_DISABLE,               /**< ::sd_softdevice_disable */
+  SD_SOFTDEVICE_IS_ENABLED,            /**< ::sd_softdevice_is_enabled */
+  SD_SOFTDEVICE_VECTOR_TABLE_BASE_SET, /**< ::sd_softdevice_vector_table_base_set */
+  SVC_SDM_LAST                         /**< Placeholder for last SDM SVC */
+};
+
+/** @} */
+
+/** @addtogroup NRF_SDM_DEFINES Defines
+ * @{ */
+
+/**@defgroup NRF_CLOCK_LF_ACCURACY Clock accuracy
+ * @{ */
+
+#define NRF_CLOCK_LF_ACCURACY_250_PPM (0) /**< Default: 250 ppm */
+#define NRF_CLOCK_LF_ACCURACY_500_PPM (1) /**< 500 ppm */
+#define NRF_CLOCK_LF_ACCURACY_150_PPM (2) /**< 150 ppm */
+#define NRF_CLOCK_LF_ACCURACY_100_PPM (3) /**< 100 ppm */
+#define NRF_CLOCK_LF_ACCURACY_75_PPM  (4) /**< 75 ppm */
+#define NRF_CLOCK_LF_ACCURACY_50_PPM  (5) /**< 50 ppm */
+#define NRF_CLOCK_LF_ACCURACY_30_PPM  (6) /**< 30 ppm */
+#define NRF_CLOCK_LF_ACCURACY_20_PPM  (7) /**< 20 ppm */
+#define NRF_CLOCK_LF_ACCURACY_10_PPM  (8) /**< 10 ppm */
+#define NRF_CLOCK_LF_ACCURACY_5_PPM   (9) /**<  5 ppm */
+#define NRF_CLOCK_LF_ACCURACY_2_PPM  (10) /**<  2 ppm */
+#define NRF_CLOCK_LF_ACCURACY_1_PPM  (11) /**<  1 ppm */
+
+/** @} */
+
+/**@defgroup NRF_CLOCK_LF_SRC Possible LFCLK oscillator sources
+ * @{ */
+
+#define NRF_CLOCK_LF_SRC_RC      (0)                        /**< LFCLK RC oscillator. */
+#define NRF_CLOCK_LF_SRC_XTAL    (1)                        /**< LFCLK crystal oscillator. */
+#define NRF_CLOCK_LF_SRC_SYNTH   (2)                        /**< LFCLK Synthesized from HFCLK. */
+
+/** @} */
+
+/** @} */
+
+/** @addtogroup NRF_SDM_TYPES Types
+ * @{ */
+
+/**@brief Type representing LFCLK oscillator source. */
+typedef struct
+{
+  uint8_t source;         /**< LF oscillator clock source, see @ref NRF_CLOCK_LF_SRC. */
+  uint8_t rc_ctiv;        /**< Only for ::NRF_CLOCK_LF_SRC_RC: Calibration timer interval in 1/4 second
+                               units (nRF52: 1-32).
+                               @note To avoid excessive clock drift, 0.5 degrees Celsius is the
+                                     maximum temperature change allowed in one calibration timer
+                                     interval. The interval should be selected to ensure this.
+
+                                  @note Must be 0 if source is not ::NRF_CLOCK_LF_SRC_RC.  */
+  uint8_t rc_temp_ctiv;   /**<  Only for ::NRF_CLOCK_LF_SRC_RC: How often (in number of calibration
+                                intervals) the RC oscillator shall be calibrated if the temperature
+                                hasn't changed.
+                                     0: Always calibrate even if the temperature hasn't changed.
+                                     1: Only calibrate if the temperature has changed (legacy - nRF51 only).
+                                     2-33: Check the temperature and only calibrate if it has changed,
+                                           however calibration will take place every rc_temp_ctiv
+                                           intervals in any case.
+
+                                @note Must be 0 if source is not ::NRF_CLOCK_LF_SRC_RC.
+
+                                @note For nRF52, the application must ensure calibration at least once
+                                      every 8 seconds to ensure +/-500 ppm clock stability. The
+                                      recommended configuration for ::NRF_CLOCK_LF_SRC_RC on nRF52 is
+                                      rc_ctiv=16 and rc_temp_ctiv=2. This will ensure calibration at
+                                      least once every 8 seconds and for temperature changes of 0.5
+                                      degrees Celsius every 4 seconds. See the Product Specification
+                                      for the nRF52 device being used for more information.*/
+  uint8_t accuracy;       /**< External clock accuracy used in the LL to compute timing
+                               windows, see @ref NRF_CLOCK_LF_ACCURACY.*/
+} nrf_clock_lf_cfg_t;
+
+/**@brief Fault Handler type.
+ *
+ * When certain unrecoverable errors occur within the application or SoftDevice the fault handler will be called back.
+ * The protocol stack will be in an undefined state when this happens and the only way to recover will be to
+ * perform a reset, using e.g. CMSIS NVIC_SystemReset().
+ * If the application returns from the fault handler the SoftDevice will call NVIC_SystemReset().
+ *
+ * @note It is recommended to either perform a reset in the fault handler or to let the SoftDevice reset the device.
+ *       Otherwise SoC peripherals may behave in an undefined way. For example, the RADIO peripherial may
+ *       continously transmit packets.
+ *
+ * @note This callback is executed in HardFault context, thus SVC functions cannot be called from the fault callback.
+ *
+ * @param[in] id Fault identifier. See @ref NRF_FAULT_IDS.
+ * @param[in] pc The program counter of the instruction that triggered the fault.
+ * @param[in] info Optional additional information regarding the fault. Refer to each Fault identifier for details.
+ *
+ * @note When id is set to @ref NRF_FAULT_ID_APP_MEMACC, pc will contain the address of the instruction being executed at the time when
+ * the fault is detected by the CPU. The CPU program counter may have advanced up to 2 instructions (no branching) after the one that triggered the fault.
+ */
+typedef void (*nrf_fault_handler_t)(uint32_t id, uint32_t pc, uint32_t info);
+
+/** @} */
+
+/** @addtogroup NRF_SDM_FUNCTIONS Functions
+ * @{ */
+
+/**@brief Enables the SoftDevice and by extension the protocol stack.
+ *
+ * @note Some care must be taken if a low frequency clock source is already running when calling this function:
+ *       If the LF clock has a different source then the one currently running, it will be stopped. Then, the new
+ *       clock source will be started.
+ *
+ * @note This function has no effect when returning with an error.
+ *
+ * @post If return code is ::NRF_SUCCESS
+ *       - SoC library and protocol stack APIs are made available.
+ *       - A portion of RAM will be unavailable (see relevant SDS documentation).
+ *       - Some peripherals will be unavailable or available only through the SoC API (see relevant SDS documentation).
+ *       - Interrupts will not arrive from protected peripherals or interrupts.
+ *       - nrf_nvic_ functions must be used instead of CMSIS NVIC_ functions for reliable usage of the SoftDevice.
+ *       - Interrupt latency may be affected by the SoftDevice  (see relevant SDS documentation).
+ *       - Chosen low frequency clock source will be running.
+ *
+ * @param p_clock_lf_cfg Low frequency clock source and accuracy.
+                         If NULL the clock will be configured as an RC source with rc_ctiv = 16 and .rc_temp_ctiv = 2
+                         In the case of XTAL source, the PPM accuracy of the chosen clock source must be greater than or equal to the actual characteristics of your XTAL clock.
+ * @param fault_handler Callback to be invoked in case of fault, cannot be NULL.
+ *
+ * @retval ::NRF_SUCCESS
+ * @retval ::NRF_ERROR_INVALID_ADDR  Invalid or NULL pointer supplied.
+ * @retval ::NRF_ERROR_INVALID_STATE SoftDevice is already enabled, and the clock source and fault handler cannot be updated.
+ * @retval ::NRF_ERROR_SDM_INCORRECT_INTERRUPT_CONFIGURATION SoftDevice interrupt is already enabled, or an enabled interrupt has an illegal priority level.
+ * @retval ::NRF_ERROR_SDM_LFCLK_SOURCE_UNKNOWN Unknown low frequency clock source selected.
+ * @retval ::NRF_ERROR_INVALID_PARAM Invalid clock source configuration supplied in p_clock_lf_cfg.
+ */
+SVCALL(SD_SOFTDEVICE_ENABLE, uint32_t, sd_softdevice_enable(nrf_clock_lf_cfg_t const * p_clock_lf_cfg, nrf_fault_handler_t fault_handler));
+
+
+/**@brief Disables the SoftDevice and by extension the protocol stack.
+ *
+ * Idempotent function to disable the SoftDevice.
+ *
+ * @post SoC library and protocol stack APIs are made unavailable.
+ * @post All interrupts that was protected by the SoftDevice will be disabled and initialized to priority 0 (highest).
+ * @post All peripherals used by the SoftDevice will be reset to default values.
+ * @post All of RAM become available.
+ * @post All interrupts are forwarded to the application.
+ * @post LFCLK source chosen in ::sd_softdevice_enable will be left running.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_SOFTDEVICE_DISABLE, uint32_t, sd_softdevice_disable(void));
+
+/**@brief Check if the SoftDevice is enabled.
+ *
+ * @param[out]  p_softdevice_enabled If the SoftDevice is enabled: 1 else 0.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_SOFTDEVICE_IS_ENABLED, uint32_t, sd_softdevice_is_enabled(uint8_t * p_softdevice_enabled));
+
+/**@brief Sets the base address of the interrupt vector table for interrupts forwarded from the SoftDevice
+ *
+ * This function is only intended to be called when a bootloader is enabled.
+ *
+ * @param[in] address The base address of the interrupt vector table for forwarded interrupts.
+
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_SOFTDEVICE_VECTOR_TABLE_BASE_SET, uint32_t, sd_softdevice_vector_table_base_set(uint32_t address));
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+#endif // NRF_SDM_H__
+
+/**
+  @}
+*/

--- a/variants/t1000-e/s140_nrf52_7.3.0_API/include/nrf_soc.h
+++ b/variants/t1000-e/s140_nrf52_7.3.0_API/include/nrf_soc.h
@@ -1,0 +1,1080 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @defgroup nrf_soc_api SoC Library API
+ * @{
+ *
+ * @brief APIs for the SoC library.
+ *
+ */
+
+#ifndef NRF_SOC_H__
+#define NRF_SOC_H__
+
+#include <stdint.h>
+#include "nrf.h"
+#include "nrf_svc.h"
+#include "nrf_error.h"
+#include "nrf_error_soc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**@addtogroup NRF_SOC_DEFINES Defines
+ * @{ */
+
+/**@brief The number of the lowest SVC number reserved for the SoC library. */
+#define SOC_SVC_BASE               (0x20)                   /**< Base value for SVCs that are available when the SoftDevice is disabled. */
+#define SOC_SVC_BASE_NOT_AVAILABLE (0x2C)                   /**< Base value for SVCs that are not available when the SoftDevice is disabled. */
+
+/**@brief Guaranteed time for application to process radio inactive notification. */
+#define NRF_RADIO_NOTIFICATION_INACTIVE_GUARANTEED_TIME_US  (62)
+
+/**@brief The minimum allowed timeslot extension time. */
+#define NRF_RADIO_MINIMUM_TIMESLOT_LENGTH_EXTENSION_TIME_US (200)
+
+/**@brief The maximum processing time to handle a timeslot extension. */
+#define NRF_RADIO_MAX_EXTENSION_PROCESSING_TIME_US           (20)
+
+/**@brief The latest time before the end of a timeslot the timeslot can be extended. */
+#define NRF_RADIO_MIN_EXTENSION_MARGIN_US                    (82)
+
+#define SOC_ECB_KEY_LENGTH                (16)                       /**< ECB key length. */
+#define SOC_ECB_CLEARTEXT_LENGTH          (16)                       /**< ECB cleartext length. */
+#define SOC_ECB_CIPHERTEXT_LENGTH         (SOC_ECB_CLEARTEXT_LENGTH) /**< ECB ciphertext length. */
+
+#define SD_EVT_IRQn                       (SWI2_IRQn)        /**< SoftDevice Event IRQ number. Used for both protocol events and SoC events. */
+#define SD_EVT_IRQHandler                 (SWI2_IRQHandler)  /**< SoftDevice Event IRQ handler. Used for both protocol events and SoC events.
+                                                                       The default interrupt priority for this handler is set to 6 */
+#define RADIO_NOTIFICATION_IRQn           (SWI1_IRQn)        /**< The radio notification IRQ number. */
+#define RADIO_NOTIFICATION_IRQHandler     (SWI1_IRQHandler)  /**< The radio notification IRQ handler.
+                                                                       The default interrupt priority for this handler is set to 6 */
+#define NRF_RADIO_LENGTH_MIN_US           (100)               /**< The shortest allowed radio timeslot, in microseconds. */
+#define NRF_RADIO_LENGTH_MAX_US           (100000)            /**< The longest allowed radio timeslot, in microseconds. */
+
+#define NRF_RADIO_DISTANCE_MAX_US         (128000000UL - 1UL) /**< The longest timeslot distance, in microseconds, allowed for the distance parameter (see @ref nrf_radio_request_normal_t) in the request. */
+
+#define NRF_RADIO_EARLIEST_TIMEOUT_MAX_US (128000000UL - 1UL) /**< The longest timeout, in microseconds, allowed when requesting the earliest possible timeslot. */
+
+#define NRF_RADIO_START_JITTER_US         (2)                 /**< The maximum jitter in @ref NRF_RADIO_CALLBACK_SIGNAL_TYPE_START relative to the requested start time. */
+
+/**@brief Mask of PPI channels reserved by the SoftDevice when the SoftDevice is disabled. */
+#define NRF_SOC_SD_PPI_CHANNELS_SD_DISABLED_MSK ((uint32_t)(0))
+
+/**@brief Mask of PPI channels reserved by the SoftDevice when the SoftDevice is enabled. */
+#define NRF_SOC_SD_PPI_CHANNELS_SD_ENABLED_MSK  ((uint32_t)( \
+      (1U << 17) \
+    | (1U << 18) \
+    | (1U << 19) \
+    | (1U << 20) \
+    | (1U << 21) \
+    | (1U << 22) \
+    | (1U << 23) \
+    | (1U << 24) \
+    | (1U << 25) \
+    | (1U << 26) \
+    | (1U << 27) \
+    | (1U << 28) \
+    | (1U << 29) \
+    | (1U << 30) \
+    | (1U << 31) \
+  ))
+
+/**@brief Mask of PPI groups reserved by the SoftDevice when the SoftDevice is disabled. */
+#define NRF_SOC_SD_PPI_GROUPS_SD_DISABLED_MSK    ((uint32_t)(0))
+
+/**@brief Mask of PPI groups reserved by the SoftDevice when the SoftDevice is enabled. */
+#define NRF_SOC_SD_PPI_GROUPS_SD_ENABLED_MSK     ((uint32_t)( \
+      (1U << 4) \
+    | (1U << 5) \
+  ))
+
+/**@} */
+
+/**@addtogroup NRF_SOC_ENUMS Enumerations
+ * @{ */
+
+/**@brief The SVC numbers used by the SVC functions in the SoC library. */
+enum NRF_SOC_SVCS
+{
+  SD_PPI_CHANNEL_ENABLE_GET   = SOC_SVC_BASE,
+  SD_PPI_CHANNEL_ENABLE_SET   = SOC_SVC_BASE + 1,
+  SD_PPI_CHANNEL_ENABLE_CLR   = SOC_SVC_BASE + 2,
+  SD_PPI_CHANNEL_ASSIGN       = SOC_SVC_BASE + 3,
+  SD_PPI_GROUP_TASK_ENABLE    = SOC_SVC_BASE + 4,
+  SD_PPI_GROUP_TASK_DISABLE   = SOC_SVC_BASE + 5,
+  SD_PPI_GROUP_ASSIGN         = SOC_SVC_BASE + 6,
+  SD_PPI_GROUP_GET            = SOC_SVC_BASE + 7,
+  SD_FLASH_PAGE_ERASE         = SOC_SVC_BASE + 8,
+  SD_FLASH_WRITE              = SOC_SVC_BASE + 9,
+  SD_PROTECTED_REGISTER_WRITE = SOC_SVC_BASE + 11,
+  SD_MUTEX_NEW                            = SOC_SVC_BASE_NOT_AVAILABLE,
+  SD_MUTEX_ACQUIRE                        = SOC_SVC_BASE_NOT_AVAILABLE + 1,
+  SD_MUTEX_RELEASE                        = SOC_SVC_BASE_NOT_AVAILABLE + 2,
+  SD_RAND_APPLICATION_POOL_CAPACITY_GET   = SOC_SVC_BASE_NOT_AVAILABLE + 3,
+  SD_RAND_APPLICATION_BYTES_AVAILABLE_GET = SOC_SVC_BASE_NOT_AVAILABLE + 4,
+  SD_RAND_APPLICATION_VECTOR_GET          = SOC_SVC_BASE_NOT_AVAILABLE + 5,
+  SD_POWER_MODE_SET                       = SOC_SVC_BASE_NOT_AVAILABLE + 6,
+  SD_POWER_SYSTEM_OFF                     = SOC_SVC_BASE_NOT_AVAILABLE + 7,
+  SD_POWER_RESET_REASON_GET               = SOC_SVC_BASE_NOT_AVAILABLE + 8,
+  SD_POWER_RESET_REASON_CLR               = SOC_SVC_BASE_NOT_AVAILABLE + 9,
+  SD_POWER_POF_ENABLE                     = SOC_SVC_BASE_NOT_AVAILABLE + 10,
+  SD_POWER_POF_THRESHOLD_SET              = SOC_SVC_BASE_NOT_AVAILABLE + 11,
+  SD_POWER_POF_THRESHOLDVDDH_SET          = SOC_SVC_BASE_NOT_AVAILABLE + 12,
+  SD_POWER_RAM_POWER_SET                  = SOC_SVC_BASE_NOT_AVAILABLE + 13,
+  SD_POWER_RAM_POWER_CLR                  = SOC_SVC_BASE_NOT_AVAILABLE + 14,
+  SD_POWER_RAM_POWER_GET                  = SOC_SVC_BASE_NOT_AVAILABLE + 15,
+  SD_POWER_GPREGRET_SET                   = SOC_SVC_BASE_NOT_AVAILABLE + 16,
+  SD_POWER_GPREGRET_CLR                   = SOC_SVC_BASE_NOT_AVAILABLE + 17,
+  SD_POWER_GPREGRET_GET                   = SOC_SVC_BASE_NOT_AVAILABLE + 18,
+  SD_POWER_DCDC_MODE_SET                  = SOC_SVC_BASE_NOT_AVAILABLE + 19,
+  SD_POWER_DCDC0_MODE_SET                 = SOC_SVC_BASE_NOT_AVAILABLE + 20,
+  SD_APP_EVT_WAIT                         = SOC_SVC_BASE_NOT_AVAILABLE + 21,
+  SD_CLOCK_HFCLK_REQUEST                  = SOC_SVC_BASE_NOT_AVAILABLE + 22,
+  SD_CLOCK_HFCLK_RELEASE                  = SOC_SVC_BASE_NOT_AVAILABLE + 23,
+  SD_CLOCK_HFCLK_IS_RUNNING               = SOC_SVC_BASE_NOT_AVAILABLE + 24,
+  SD_RADIO_NOTIFICATION_CFG_SET           = SOC_SVC_BASE_NOT_AVAILABLE + 25,
+  SD_ECB_BLOCK_ENCRYPT                    = SOC_SVC_BASE_NOT_AVAILABLE + 26,
+  SD_ECB_BLOCKS_ENCRYPT                   = SOC_SVC_BASE_NOT_AVAILABLE + 27,
+  SD_RADIO_SESSION_OPEN                   = SOC_SVC_BASE_NOT_AVAILABLE + 28,
+  SD_RADIO_SESSION_CLOSE                  = SOC_SVC_BASE_NOT_AVAILABLE + 29,
+  SD_RADIO_REQUEST                        = SOC_SVC_BASE_NOT_AVAILABLE + 30,
+  SD_EVT_GET                              = SOC_SVC_BASE_NOT_AVAILABLE + 31,
+  SD_TEMP_GET                             = SOC_SVC_BASE_NOT_AVAILABLE + 32,
+  SD_POWER_USBPWRRDY_ENABLE               = SOC_SVC_BASE_NOT_AVAILABLE + 33,
+  SD_POWER_USBDETECTED_ENABLE             = SOC_SVC_BASE_NOT_AVAILABLE + 34,
+  SD_POWER_USBREMOVED_ENABLE              = SOC_SVC_BASE_NOT_AVAILABLE + 35,
+  SD_POWER_USBREGSTATUS_GET               = SOC_SVC_BASE_NOT_AVAILABLE + 36,
+  SVC_SOC_LAST                            = SOC_SVC_BASE_NOT_AVAILABLE + 37
+};
+
+/**@brief Possible values of a ::nrf_mutex_t. */
+enum NRF_MUTEX_VALUES
+{
+  NRF_MUTEX_FREE,
+  NRF_MUTEX_TAKEN
+};
+
+/**@brief Power modes. */
+enum NRF_POWER_MODES
+{
+  NRF_POWER_MODE_CONSTLAT,  /**< Constant latency mode. See power management in the reference manual. */
+  NRF_POWER_MODE_LOWPWR     /**< Low power mode. See power management in the reference manual. */
+};
+
+
+/**@brief Power failure thresholds */
+enum NRF_POWER_THRESHOLDS
+{
+  NRF_POWER_THRESHOLD_V17 = 4UL, /**< 1.7 Volts power failure threshold. */
+  NRF_POWER_THRESHOLD_V18,       /**< 1.8 Volts power failure threshold. */
+  NRF_POWER_THRESHOLD_V19,       /**< 1.9 Volts power failure threshold. */
+  NRF_POWER_THRESHOLD_V20,       /**< 2.0 Volts power failure threshold. */
+  NRF_POWER_THRESHOLD_V21,       /**< 2.1 Volts power failure threshold. */
+  NRF_POWER_THRESHOLD_V22,       /**< 2.2 Volts power failure threshold. */
+  NRF_POWER_THRESHOLD_V23,       /**< 2.3 Volts power failure threshold. */
+  NRF_POWER_THRESHOLD_V24,       /**< 2.4 Volts power failure threshold. */
+  NRF_POWER_THRESHOLD_V25,       /**< 2.5 Volts power failure threshold. */
+  NRF_POWER_THRESHOLD_V26,       /**< 2.6 Volts power failure threshold. */
+  NRF_POWER_THRESHOLD_V27,       /**< 2.7 Volts power failure threshold. */
+  NRF_POWER_THRESHOLD_V28        /**< 2.8 Volts power failure threshold. */
+};
+
+/**@brief Power failure thresholds for high voltage */
+enum NRF_POWER_THRESHOLDVDDHS
+{
+  NRF_POWER_THRESHOLDVDDH_V27,       /**< 2.7 Volts power failure threshold. */
+  NRF_POWER_THRESHOLDVDDH_V28,       /**< 2.8 Volts power failure threshold. */
+  NRF_POWER_THRESHOLDVDDH_V29,       /**< 2.9 Volts power failure threshold. */
+  NRF_POWER_THRESHOLDVDDH_V30,       /**< 3.0 Volts power failure threshold. */
+  NRF_POWER_THRESHOLDVDDH_V31,       /**< 3.1 Volts power failure threshold. */
+  NRF_POWER_THRESHOLDVDDH_V32,       /**< 3.2 Volts power failure threshold. */
+  NRF_POWER_THRESHOLDVDDH_V33,       /**< 3.3 Volts power failure threshold. */
+  NRF_POWER_THRESHOLDVDDH_V34,       /**< 3.4 Volts power failure threshold. */
+  NRF_POWER_THRESHOLDVDDH_V35,       /**< 3.5 Volts power failure threshold. */
+  NRF_POWER_THRESHOLDVDDH_V36,       /**< 3.6 Volts power failure threshold. */
+  NRF_POWER_THRESHOLDVDDH_V37,       /**< 3.7 Volts power failure threshold. */
+  NRF_POWER_THRESHOLDVDDH_V38,       /**< 3.8 Volts power failure threshold. */
+  NRF_POWER_THRESHOLDVDDH_V39,       /**< 3.9 Volts power failure threshold. */
+  NRF_POWER_THRESHOLDVDDH_V40,       /**< 4.0 Volts power failure threshold. */
+  NRF_POWER_THRESHOLDVDDH_V41,       /**< 4.1 Volts power failure threshold. */
+  NRF_POWER_THRESHOLDVDDH_V42        /**< 4.2 Volts power failure threshold. */
+};
+
+
+/**@brief DC/DC converter modes. */
+enum NRF_POWER_DCDC_MODES
+{
+  NRF_POWER_DCDC_DISABLE,          /**< The DCDC is disabled. */
+  NRF_POWER_DCDC_ENABLE            /**< The DCDC is enabled.  */
+};
+
+/**@brief Radio notification distances. */
+enum NRF_RADIO_NOTIFICATION_DISTANCES
+{
+  NRF_RADIO_NOTIFICATION_DISTANCE_NONE = 0, /**< The event does not have a notification. */
+  NRF_RADIO_NOTIFICATION_DISTANCE_800US,    /**< The distance from the active notification to start of radio activity. */
+  NRF_RADIO_NOTIFICATION_DISTANCE_1740US,   /**< The distance from the active notification to start of radio activity. */
+  NRF_RADIO_NOTIFICATION_DISTANCE_2680US,   /**< The distance from the active notification to start of radio activity. */
+  NRF_RADIO_NOTIFICATION_DISTANCE_3620US,   /**< The distance from the active notification to start of radio activity. */
+  NRF_RADIO_NOTIFICATION_DISTANCE_4560US,   /**< The distance from the active notification to start of radio activity. */
+  NRF_RADIO_NOTIFICATION_DISTANCE_5500US    /**< The distance from the active notification to start of radio activity. */
+};
+
+
+/**@brief Radio notification types. */
+enum NRF_RADIO_NOTIFICATION_TYPES
+{
+  NRF_RADIO_NOTIFICATION_TYPE_NONE = 0,        /**< The event does not have a radio notification signal. */
+  NRF_RADIO_NOTIFICATION_TYPE_INT_ON_ACTIVE,   /**< Using interrupt for notification when the radio will be enabled. */
+  NRF_RADIO_NOTIFICATION_TYPE_INT_ON_INACTIVE, /**< Using interrupt for notification when the radio has been disabled. */
+  NRF_RADIO_NOTIFICATION_TYPE_INT_ON_BOTH,     /**< Using interrupt for notification both when the radio will be enabled and disabled. */
+};
+
+/**@brief The Radio signal callback types. */
+enum NRF_RADIO_CALLBACK_SIGNAL_TYPE
+{
+  NRF_RADIO_CALLBACK_SIGNAL_TYPE_START,             /**< This signal indicates the start of the radio timeslot. */
+  NRF_RADIO_CALLBACK_SIGNAL_TYPE_TIMER0,            /**< This signal indicates the NRF_TIMER0 interrupt. */
+  NRF_RADIO_CALLBACK_SIGNAL_TYPE_RADIO,             /**< This signal indicates the NRF_RADIO interrupt. */
+  NRF_RADIO_CALLBACK_SIGNAL_TYPE_EXTEND_FAILED,     /**< This signal indicates extend action failed. */
+  NRF_RADIO_CALLBACK_SIGNAL_TYPE_EXTEND_SUCCEEDED   /**< This signal indicates extend action succeeded. */
+};
+
+/**@brief The actions requested by the signal callback.
+ *
+ *  This code gives the SOC instructions about what action to take when the signal callback has
+ *  returned.
+ */
+enum NRF_RADIO_SIGNAL_CALLBACK_ACTION
+{
+  NRF_RADIO_SIGNAL_CALLBACK_ACTION_NONE,            /**< Return without action. */
+  NRF_RADIO_SIGNAL_CALLBACK_ACTION_EXTEND,          /**< Request an extension of the current
+                                                         timeslot. Maximum execution time for this action:
+                                                         @ref NRF_RADIO_MAX_EXTENSION_PROCESSING_TIME_US.
+                                                         This action must be started at least
+                                                         @ref NRF_RADIO_MIN_EXTENSION_MARGIN_US before
+                                                         the end of the timeslot. */
+  NRF_RADIO_SIGNAL_CALLBACK_ACTION_END,             /**< End the current radio timeslot. */
+  NRF_RADIO_SIGNAL_CALLBACK_ACTION_REQUEST_AND_END  /**< Request a new radio timeslot and end the current timeslot. */
+};
+
+/**@brief Radio timeslot high frequency clock source configuration. */
+enum NRF_RADIO_HFCLK_CFG
+{
+  NRF_RADIO_HFCLK_CFG_XTAL_GUARANTEED, /**< The SoftDevice will guarantee that the high frequency clock source is the
+                                           external crystal for the whole duration of the timeslot. This should be the
+                                           preferred option for events that use the radio or require high timing accuracy.
+                                           @note The SoftDevice will automatically turn on and off the external crystal,
+                                           at the beginning and end of the timeslot, respectively. The crystal may also
+                                           intentionally be left running after the timeslot, in cases where it is needed
+                                           by the SoftDevice shortly after the end of the timeslot. */
+  NRF_RADIO_HFCLK_CFG_NO_GUARANTEE    /**< This configuration allows for earlier and tighter scheduling of timeslots.
+                                           The RC oscillator may be the clock source in part or for the whole duration of the timeslot.
+                                           The RC oscillator's accuracy must therefore be taken into consideration.
+                                           @note If the application will use the radio peripheral in timeslots with this configuration,
+                                           it must make sure that the crystal is running and stable before starting the radio. */
+};
+
+/**@brief Radio timeslot priorities. */
+enum NRF_RADIO_PRIORITY
+{
+  NRF_RADIO_PRIORITY_HIGH,                          /**< High (equal priority as the normal connection priority of the SoftDevice stack(s)). */
+  NRF_RADIO_PRIORITY_NORMAL,                        /**< Normal (equal priority as the priority of secondary activities of the SoftDevice stack(s)). */
+};
+
+/**@brief Radio timeslot request type. */
+enum NRF_RADIO_REQUEST_TYPE
+{
+  NRF_RADIO_REQ_TYPE_EARLIEST,                      /**< Request radio timeslot as early as possible. This should always be used for the first request in a session. */
+  NRF_RADIO_REQ_TYPE_NORMAL                         /**< Normal radio timeslot request. */
+};
+
+/**@brief SoC Events. */
+enum NRF_SOC_EVTS
+{
+  NRF_EVT_HFCLKSTARTED,                         /**< Event indicating that the HFCLK has started. */
+  NRF_EVT_POWER_FAILURE_WARNING,                /**< Event indicating that a power failure warning has occurred. */
+  NRF_EVT_FLASH_OPERATION_SUCCESS,              /**< Event indicating that the ongoing flash operation has completed successfully. */
+  NRF_EVT_FLASH_OPERATION_ERROR,                /**< Event indicating that the ongoing flash operation has timed out with an error. */
+  NRF_EVT_RADIO_BLOCKED,                        /**< Event indicating that a radio timeslot was blocked. */
+  NRF_EVT_RADIO_CANCELED,                       /**< Event indicating that a radio timeslot was canceled by SoftDevice. */
+  NRF_EVT_RADIO_SIGNAL_CALLBACK_INVALID_RETURN, /**< Event indicating that a radio timeslot signal callback handler return was invalid. */
+  NRF_EVT_RADIO_SESSION_IDLE,                   /**< Event indicating that a radio timeslot session is idle. */
+  NRF_EVT_RADIO_SESSION_CLOSED,                 /**< Event indicating that a radio timeslot session is closed. */
+  NRF_EVT_POWER_USB_POWER_READY,                /**< Event indicating that a USB 3.3 V supply is ready. */
+  NRF_EVT_POWER_USB_DETECTED,                   /**< Event indicating that voltage supply is detected on VBUS. */
+  NRF_EVT_POWER_USB_REMOVED,                    /**< Event indicating that voltage supply is removed from VBUS. */
+  NRF_EVT_NUMBER_OF_EVTS
+};
+
+/**@} */
+
+
+/**@addtogroup NRF_SOC_STRUCTURES Structures
+ * @{ */
+
+/**@brief Represents a mutex for use with the nrf_mutex functions.
+ * @note Accessing the value directly is not safe, use the mutex functions!
+ */
+typedef volatile uint8_t nrf_mutex_t;
+
+/**@brief Parameters for a request for a timeslot as early as possible. */
+typedef struct
+{
+  uint8_t       hfclk;                              /**< High frequency clock source, see @ref NRF_RADIO_HFCLK_CFG. */
+  uint8_t       priority;                           /**< The radio timeslot priority, see @ref NRF_RADIO_PRIORITY. */
+  uint32_t      length_us;                          /**< The radio timeslot length (in the range 100 to 100,000] microseconds). */
+  uint32_t      timeout_us;                         /**< Longest acceptable delay until the start of the requested timeslot (up to @ref NRF_RADIO_EARLIEST_TIMEOUT_MAX_US microseconds). */
+} nrf_radio_request_earliest_t;
+
+/**@brief Parameters for a normal radio timeslot request. */
+typedef struct
+{
+  uint8_t       hfclk;                              /**< High frequency clock source, see @ref NRF_RADIO_HFCLK_CFG. */
+  uint8_t       priority;                           /**< The radio timeslot priority, see @ref NRF_RADIO_PRIORITY. */
+  uint32_t      distance_us;                        /**< Distance from the start of the previous radio timeslot (up to @ref NRF_RADIO_DISTANCE_MAX_US microseconds). */
+  uint32_t      length_us;                          /**< The radio timeslot length (in the range [100..100,000] microseconds). */
+} nrf_radio_request_normal_t;
+
+/**@brief Radio timeslot request parameters. */
+typedef struct
+{
+  uint8_t                         request_type;     /**< Type of request, see @ref NRF_RADIO_REQUEST_TYPE. */
+  union
+  {
+    nrf_radio_request_earliest_t  earliest;         /**< Parameters for requesting a radio timeslot as early as possible. */
+    nrf_radio_request_normal_t    normal;           /**< Parameters for requesting a normal radio timeslot. */
+  } params;                                         /**< Parameter union. */
+} nrf_radio_request_t;
+
+/**@brief Return parameters of the radio timeslot signal callback. */
+typedef struct
+{
+  uint8_t               callback_action;            /**< The action requested by the application when returning from the signal callback, see @ref NRF_RADIO_SIGNAL_CALLBACK_ACTION. */
+  union
+  {
+    struct
+    {
+      nrf_radio_request_t * p_next;                 /**< The request parameters for the next radio timeslot. */
+    } request;                                      /**< Additional parameters for return_code @ref NRF_RADIO_SIGNAL_CALLBACK_ACTION_REQUEST_AND_END. */
+    struct
+    {
+      uint32_t              length_us;              /**< Requested extension of the radio timeslot duration (microseconds) (for minimum time see @ref NRF_RADIO_MINIMUM_TIMESLOT_LENGTH_EXTENSION_TIME_US). */
+    } extend;                                       /**< Additional parameters for return_code @ref NRF_RADIO_SIGNAL_CALLBACK_ACTION_EXTEND. */
+  } params;                                         /**< Parameter union. */
+} nrf_radio_signal_callback_return_param_t;
+
+/**@brief The radio timeslot signal callback type.
+ *
+ * @note In case of invalid return parameters, the radio timeslot will automatically end
+ *       immediately after returning from the signal callback and the
+ *       @ref NRF_EVT_RADIO_SIGNAL_CALLBACK_INVALID_RETURN event will be sent.
+ * @note The returned struct pointer must remain valid after the signal callback
+ *       function returns. For instance, this means that it must not point to a stack variable.
+ *
+ * @param[in] signal_type Type of signal, see @ref NRF_RADIO_CALLBACK_SIGNAL_TYPE.
+ *
+ * @return Pointer to structure containing action requested by the application.
+ */
+typedef nrf_radio_signal_callback_return_param_t * (*nrf_radio_signal_callback_t) (uint8_t signal_type);
+
+/**@brief AES ECB parameter typedefs */
+typedef uint8_t soc_ecb_key_t[SOC_ECB_KEY_LENGTH];                /**< Encryption key type. */
+typedef uint8_t soc_ecb_cleartext_t[SOC_ECB_CLEARTEXT_LENGTH];    /**< Cleartext data type. */
+typedef uint8_t soc_ecb_ciphertext_t[SOC_ECB_CIPHERTEXT_LENGTH];  /**< Ciphertext data type. */
+
+/**@brief AES ECB data structure */
+typedef struct
+{
+  soc_ecb_key_t        key;            /**< Encryption key. */
+  soc_ecb_cleartext_t  cleartext;      /**< Cleartext data. */
+  soc_ecb_ciphertext_t ciphertext;     /**< Ciphertext data. */
+} nrf_ecb_hal_data_t;
+
+/**@brief AES ECB block. Used to provide multiple blocks in a single call
+          to @ref sd_ecb_blocks_encrypt.*/
+typedef struct
+{
+  soc_ecb_key_t const *       p_key;           /**< Pointer to the Encryption key. */
+  soc_ecb_cleartext_t const * p_cleartext;     /**< Pointer to the Cleartext data. */
+  soc_ecb_ciphertext_t *      p_ciphertext;    /**< Pointer to the Ciphertext data. */
+} nrf_ecb_hal_data_block_t;
+
+/**@} */
+
+/**@addtogroup NRF_SOC_FUNCTIONS Functions
+ * @{ */
+
+/**@brief Initialize a mutex.
+ *
+ * @param[in] p_mutex Pointer to the mutex to initialize.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_MUTEX_NEW, uint32_t, sd_mutex_new(nrf_mutex_t * p_mutex));
+
+/**@brief Attempt to acquire a mutex.
+ *
+ * @param[in] p_mutex Pointer to the mutex to acquire.
+ *
+ * @retval ::NRF_SUCCESS The mutex was successfully acquired.
+ * @retval ::NRF_ERROR_SOC_MUTEX_ALREADY_TAKEN The mutex could not be acquired.
+ */
+SVCALL(SD_MUTEX_ACQUIRE, uint32_t, sd_mutex_acquire(nrf_mutex_t * p_mutex));
+
+/**@brief Release a mutex.
+ *
+ * @param[in] p_mutex Pointer to the mutex to release.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_MUTEX_RELEASE, uint32_t, sd_mutex_release(nrf_mutex_t * p_mutex));
+
+/**@brief Query the capacity of the application random pool.
+ *
+ * @param[out] p_pool_capacity The capacity of the pool.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_RAND_APPLICATION_POOL_CAPACITY_GET, uint32_t, sd_rand_application_pool_capacity_get(uint8_t * p_pool_capacity));
+
+/**@brief Get number of random bytes available to the application.
+ *
+ * @param[out] p_bytes_available The number of bytes currently available in the pool.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_RAND_APPLICATION_BYTES_AVAILABLE_GET, uint32_t, sd_rand_application_bytes_available_get(uint8_t * p_bytes_available));
+
+/**@brief Get random bytes from the application pool.
+ *
+ * @param[out]  p_buff  Pointer to unit8_t buffer for storing the bytes.
+ * @param[in]   length  Number of bytes to take from pool and place in p_buff.
+ *
+ * @retval ::NRF_SUCCESS The requested bytes were written to p_buff.
+ * @retval ::NRF_ERROR_SOC_RAND_NOT_ENOUGH_VALUES No bytes were written to the buffer, because there were not enough bytes available.
+*/
+SVCALL(SD_RAND_APPLICATION_VECTOR_GET, uint32_t, sd_rand_application_vector_get(uint8_t * p_buff, uint8_t length));
+
+/**@brief Gets the reset reason register.
+ *
+ * @param[out]  p_reset_reason  Contents of the NRF_POWER->RESETREAS register.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_POWER_RESET_REASON_GET, uint32_t, sd_power_reset_reason_get(uint32_t * p_reset_reason));
+
+/**@brief Clears the bits of the reset reason register.
+ *
+ * @param[in] reset_reason_clr_msk Contains the bits to clear from the reset reason register.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_POWER_RESET_REASON_CLR, uint32_t, sd_power_reset_reason_clr(uint32_t reset_reason_clr_msk));
+
+/**@brief Sets the power mode when in CPU sleep.
+ *
+ * @param[in] power_mode The power mode to use when in CPU sleep, see @ref NRF_POWER_MODES. @sa sd_app_evt_wait
+ *
+ * @retval ::NRF_SUCCESS The power mode was set.
+ * @retval ::NRF_ERROR_SOC_POWER_MODE_UNKNOWN The power mode was unknown.
+ */
+SVCALL(SD_POWER_MODE_SET, uint32_t, sd_power_mode_set(uint8_t power_mode));
+
+/**@brief Puts the chip in System OFF mode.
+ *
+ * @retval ::NRF_ERROR_SOC_POWER_OFF_SHOULD_NOT_RETURN
+ */
+SVCALL(SD_POWER_SYSTEM_OFF, uint32_t, sd_power_system_off(void));
+
+/**@brief Enables or disables the power-fail comparator.
+ *
+ * Enabling this will give a SoftDevice event (NRF_EVT_POWER_FAILURE_WARNING) when the power failure warning occurs.
+ * The event can be retrieved with sd_evt_get();
+ *
+ * @param[in] pof_enable    True if the power-fail comparator should be enabled, false if it should be disabled.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_POWER_POF_ENABLE, uint32_t, sd_power_pof_enable(uint8_t pof_enable));
+
+/**@brief Enables or disables the USB power ready event.
+ *
+ * Enabling this will give a SoftDevice event (NRF_EVT_POWER_USB_POWER_READY) when a USB 3.3 V supply is ready.
+ * The event can be retrieved with sd_evt_get();
+ *
+ * @param[in] usbpwrrdy_enable    True if the power ready event should be enabled, false if it should be disabled.
+ *
+ * @note Calling this function on a chip without USBD peripheral will result in undefined behaviour.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_POWER_USBPWRRDY_ENABLE, uint32_t, sd_power_usbpwrrdy_enable(uint8_t usbpwrrdy_enable));
+
+/**@brief Enables or disables the power USB-detected event.
+ *
+ * Enabling this will give a SoftDevice event (NRF_EVT_POWER_USB_DETECTED) when a voltage supply is detected on VBUS.
+ * The event can be retrieved with sd_evt_get();
+ *
+ * @param[in] usbdetected_enable    True if the power ready event should be enabled, false if it should be disabled.
+ *
+ * @note Calling this function on a chip without USBD peripheral will result in undefined behaviour.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_POWER_USBDETECTED_ENABLE, uint32_t, sd_power_usbdetected_enable(uint8_t usbdetected_enable));
+
+/**@brief Enables or disables the power USB-removed event.
+ *
+ * Enabling this will give a SoftDevice event (NRF_EVT_POWER_USB_REMOVED) when a voltage supply is removed from VBUS.
+ * The event can be retrieved with sd_evt_get();
+ *
+ * @param[in] usbremoved_enable    True if the power ready event should be enabled, false if it should be disabled.
+ *
+ * @note Calling this function on a chip without USBD peripheral will result in undefined behaviour.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_POWER_USBREMOVED_ENABLE, uint32_t, sd_power_usbremoved_enable(uint8_t usbremoved_enable));
+
+/**@brief Get USB supply status register content.
+ *
+ * @param[out] usbregstatus    The content of USBREGSTATUS register.
+ *
+ * @note Calling this function on a chip without USBD peripheral will result in undefined behaviour.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_POWER_USBREGSTATUS_GET, uint32_t, sd_power_usbregstatus_get(uint32_t * usbregstatus));
+
+/**@brief Sets the power failure comparator threshold value.
+ *
+ * @note: Power failure comparator threshold setting. This setting applies both for normal voltage
+ *        mode (supply connected to both VDD and VDDH) and high voltage mode (supply connected to
+ *        VDDH only).
+ *
+ * @param[in] threshold The power-fail threshold value to use, see @ref NRF_POWER_THRESHOLDS.
+ *
+ * @retval ::NRF_SUCCESS The power failure threshold was set.
+ * @retval ::NRF_ERROR_SOC_POWER_POF_THRESHOLD_UNKNOWN The power failure threshold is unknown.
+ */
+SVCALL(SD_POWER_POF_THRESHOLD_SET, uint32_t, sd_power_pof_threshold_set(uint8_t threshold));
+
+/**@brief Sets the power failure comparator threshold value for high voltage.
+ *
+ * @note: Power failure comparator threshold setting for high voltage mode (supply connected to
+ *        VDDH only). This setting does not apply for normal voltage mode (supply connected to both
+ *        VDD and VDDH).
+ *
+ * @param[in] threshold The power-fail threshold value to use, see @ref NRF_POWER_THRESHOLDVDDHS.
+ *
+ * @retval ::NRF_SUCCESS The power failure threshold was set.
+ * @retval ::NRF_ERROR_SOC_POWER_POF_THRESHOLD_UNKNOWN The power failure threshold is unknown.
+ */
+SVCALL(SD_POWER_POF_THRESHOLDVDDH_SET, uint32_t, sd_power_pof_thresholdvddh_set(uint8_t threshold));
+
+/**@brief Writes the NRF_POWER->RAM[index].POWERSET register.
+ *
+ * @param[in] index Contains the index in the NRF_POWER->RAM[index].POWERSET register to write to.
+ * @param[in] ram_powerset Contains the word to write to the NRF_POWER->RAM[index].POWERSET register.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_POWER_RAM_POWER_SET, uint32_t, sd_power_ram_power_set(uint8_t index, uint32_t ram_powerset));
+
+/**@brief Writes the NRF_POWER->RAM[index].POWERCLR register.
+ *
+ * @param[in] index Contains the index in the NRF_POWER->RAM[index].POWERCLR register to write to.
+ * @param[in] ram_powerclr Contains the word to write to the NRF_POWER->RAM[index].POWERCLR register.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_POWER_RAM_POWER_CLR, uint32_t, sd_power_ram_power_clr(uint8_t index, uint32_t ram_powerclr));
+
+/**@brief Get contents of NRF_POWER->RAM[index].POWER register, indicates power status of RAM[index] blocks.
+ *
+ * @param[in] index Contains the index in the NRF_POWER->RAM[index].POWER register to read from.
+ * @param[out] p_ram_power Content of NRF_POWER->RAM[index].POWER register.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_POWER_RAM_POWER_GET, uint32_t, sd_power_ram_power_get(uint8_t index, uint32_t * p_ram_power));
+
+/**@brief Set bits in the general purpose retention registers (NRF_POWER->GPREGRET*).
+ *
+ * @param[in] gpregret_id 0 for GPREGRET, 1 for GPREGRET2.
+ * @param[in] gpregret_msk Bits to be set in the GPREGRET register.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_POWER_GPREGRET_SET, uint32_t, sd_power_gpregret_set(uint32_t gpregret_id, uint32_t gpregret_msk));
+
+/**@brief Clear bits in the general purpose retention registers (NRF_POWER->GPREGRET*).
+ *
+ * @param[in] gpregret_id 0 for GPREGRET, 1 for GPREGRET2.
+ * @param[in] gpregret_msk Bits to be clear in the GPREGRET register.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_POWER_GPREGRET_CLR, uint32_t, sd_power_gpregret_clr(uint32_t gpregret_id, uint32_t gpregret_msk));
+
+/**@brief Get contents of the general purpose retention registers (NRF_POWER->GPREGRET*).
+ *
+ * @param[in] gpregret_id 0 for GPREGRET, 1 for GPREGRET2.
+ * @param[out] p_gpregret Contents of the GPREGRET register.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_POWER_GPREGRET_GET, uint32_t, sd_power_gpregret_get(uint32_t gpregret_id, uint32_t *p_gpregret));
+
+/**@brief Enable or disable the DC/DC regulator for the regulator stage 1 (REG1).
+ *
+ * @param[in] dcdc_mode The mode of the DCDC, see @ref NRF_POWER_DCDC_MODES.
+ *
+ * @retval ::NRF_SUCCESS
+ * @retval ::NRF_ERROR_INVALID_PARAM The DCDC mode is invalid.
+ */
+SVCALL(SD_POWER_DCDC_MODE_SET, uint32_t, sd_power_dcdc_mode_set(uint8_t dcdc_mode));
+
+/**@brief Enable or disable the DC/DC regulator for the regulator stage 0 (REG0).
+ *
+ * For more details on the REG0 stage, please see product specification.
+ *
+ * @param[in] dcdc_mode The mode of the DCDC0, see @ref NRF_POWER_DCDC_MODES.
+ *
+ * @retval ::NRF_SUCCESS
+ * @retval ::NRF_ERROR_INVALID_PARAM The dcdc_mode is invalid.
+ */
+SVCALL(SD_POWER_DCDC0_MODE_SET, uint32_t, sd_power_dcdc0_mode_set(uint8_t dcdc_mode));
+
+/**@brief Request the high frequency crystal oscillator.
+ *
+ * Will start the high frequency crystal oscillator, the startup time of the crystal varies
+ * and the ::sd_clock_hfclk_is_running function can be polled to check if it has started.
+ *
+ * @see sd_clock_hfclk_is_running
+ * @see sd_clock_hfclk_release
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_CLOCK_HFCLK_REQUEST, uint32_t, sd_clock_hfclk_request(void));
+
+/**@brief Releases the high frequency crystal oscillator.
+ *
+ * Will stop the high frequency crystal oscillator, this happens immediately.
+ *
+ * @see sd_clock_hfclk_is_running
+ * @see sd_clock_hfclk_request
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_CLOCK_HFCLK_RELEASE, uint32_t, sd_clock_hfclk_release(void));
+
+/**@brief Checks if the high frequency crystal oscillator is running.
+ *
+ * @see sd_clock_hfclk_request
+ * @see sd_clock_hfclk_release
+ *
+ * @param[out] p_is_running 1 if the external crystal oscillator is running, 0 if not.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_CLOCK_HFCLK_IS_RUNNING, uint32_t, sd_clock_hfclk_is_running(uint32_t * p_is_running));
+
+/**@brief Waits for an application event.
+ *
+ * An application event is either an application interrupt or a pended interrupt when the interrupt
+ * is disabled.
+ *
+ * When the application waits for an application event by calling this function, an interrupt that
+ * is enabled will be taken immediately on pending since this function will wait in thread mode,
+ * then the execution will return in the application's main thread.
+ *
+ * In order to wake up from disabled interrupts, the SEVONPEND flag has to be set in the Cortex-M
+ * MCU's System Control Register (SCR), CMSIS_SCB. In that case, when a disabled interrupt gets
+ * pended, this function will return to the application's main thread.
+ *
+ * @note The application must ensure that the pended flag is cleared using ::sd_nvic_ClearPendingIRQ
+ *       in order to sleep using this function. This is only necessary for disabled interrupts, as
+ *       the interrupt handler will clear the pending flag automatically for enabled interrupts.
+ *
+ * @note If an application interrupt has happened since the last time sd_app_evt_wait was
+ *       called this function will return immediately and not go to sleep. This is to avoid race
+ *       conditions that can occur when a flag is updated in the interrupt handler and processed
+ *       in the main loop.
+ *
+ * @post An application interrupt has happened or a interrupt pending flag is set.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_APP_EVT_WAIT, uint32_t, sd_app_evt_wait(void));
+
+/**@brief Get PPI channel enable register contents.
+ *
+ * @param[out] p_channel_enable The contents of the PPI CHEN register.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_PPI_CHANNEL_ENABLE_GET, uint32_t, sd_ppi_channel_enable_get(uint32_t * p_channel_enable));
+
+/**@brief Set PPI channel enable register.
+ *
+ * @param[in] channel_enable_set_msk Mask containing the bits to set in the PPI CHEN register.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_PPI_CHANNEL_ENABLE_SET, uint32_t, sd_ppi_channel_enable_set(uint32_t channel_enable_set_msk));
+
+/**@brief Clear PPI channel enable register.
+ *
+ * @param[in] channel_enable_clr_msk Mask containing the bits to clear in the PPI CHEN register.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_PPI_CHANNEL_ENABLE_CLR, uint32_t, sd_ppi_channel_enable_clr(uint32_t channel_enable_clr_msk));
+
+/**@brief Assign endpoints to a PPI channel.
+ *
+ * @param[in] channel_num Number of the PPI channel to assign.
+ * @param[in] evt_endpoint Event endpoint of the PPI channel.
+ * @param[in] task_endpoint Task endpoint of the PPI channel.
+ *
+ * @retval ::NRF_ERROR_SOC_PPI_INVALID_CHANNEL The channel number is invalid.
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_PPI_CHANNEL_ASSIGN, uint32_t, sd_ppi_channel_assign(uint8_t channel_num, const volatile void * evt_endpoint, const volatile void * task_endpoint));
+
+/**@brief Task to enable a channel group.
+ *
+ * @param[in] group_num Number of the channel group.
+ *
+ * @retval ::NRF_ERROR_SOC_PPI_INVALID_GROUP The group number is invalid
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_PPI_GROUP_TASK_ENABLE, uint32_t, sd_ppi_group_task_enable(uint8_t group_num));
+
+/**@brief Task to disable a channel group.
+ *
+ * @param[in] group_num Number of the PPI group.
+ *
+ * @retval ::NRF_ERROR_SOC_PPI_INVALID_GROUP The group number is invalid.
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_PPI_GROUP_TASK_DISABLE, uint32_t, sd_ppi_group_task_disable(uint8_t group_num));
+
+/**@brief Assign PPI channels to a channel group.
+ *
+ * @param[in] group_num Number of the channel group.
+ * @param[in] channel_msk Mask of the channels to assign to the group.
+ *
+ * @retval ::NRF_ERROR_SOC_PPI_INVALID_GROUP The group number is invalid.
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_PPI_GROUP_ASSIGN, uint32_t, sd_ppi_group_assign(uint8_t group_num, uint32_t channel_msk));
+
+/**@brief Gets the PPI channels of a channel group.
+ *
+ * @param[in]   group_num Number of the channel group.
+ * @param[out]  p_channel_msk Mask of the channels assigned to the group.
+ *
+ * @retval ::NRF_ERROR_SOC_PPI_INVALID_GROUP The group number is invalid.
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_PPI_GROUP_GET, uint32_t, sd_ppi_group_get(uint8_t group_num, uint32_t * p_channel_msk));
+
+/**@brief Configures the Radio Notification signal.
+ *
+ * @note
+ *      - The notification signal latency depends on the interrupt priority settings of SWI used
+ *        for notification signal.
+ *      - To ensure that the radio notification signal behaves in a consistent way, the radio
+ *        notifications must be configured when there is no protocol stack or other SoftDevice
+ *        activity in progress. It is recommended that the radio notification signal is
+ *        configured directly after the SoftDevice has been enabled.
+ *      - In the period between the ACTIVE signal and the start of the Radio Event, the SoftDevice
+ *        will interrupt the application to do Radio Event preparation.
+ *      - Using the Radio Notification feature may limit the bandwidth, as the SoftDevice may have
+ *        to shorten the connection events to have time for the Radio Notification signals.
+ *
+ * @param[in]  type      Type of notification signal, see @ref NRF_RADIO_NOTIFICATION_TYPES.
+ *                       @ref NRF_RADIO_NOTIFICATION_TYPE_NONE shall be used to turn off radio
+ *                       notification. Using @ref NRF_RADIO_NOTIFICATION_DISTANCE_NONE is
+ *                       recommended (but not required) to be used with
+ *                       @ref NRF_RADIO_NOTIFICATION_TYPE_NONE.
+ *
+ * @param[in]  distance  Distance between the notification signal and start of radio activity, see @ref NRF_RADIO_NOTIFICATION_DISTANCES.
+ *                       This parameter is ignored when @ref NRF_RADIO_NOTIFICATION_TYPE_NONE or
+ *                       @ref NRF_RADIO_NOTIFICATION_TYPE_INT_ON_INACTIVE is used.
+ *
+ * @retval ::NRF_ERROR_INVALID_PARAM The group number is invalid.
+ * @retval ::NRF_ERROR_INVALID_STATE A protocol stack or other SoftDevice is running. Stop all
+ *                                   running activities and retry.
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_RADIO_NOTIFICATION_CFG_SET, uint32_t, sd_radio_notification_cfg_set(uint8_t type, uint8_t distance));
+
+/**@brief Encrypts a block according to the specified parameters.
+ *
+ * 128-bit AES encryption.
+ *
+ * @note:
+ *    - The application may set the SEVONPEND bit in the SCR to 1 to make the SoftDevice sleep while
+ *      the ECB is running. The SEVONPEND bit should only be cleared (set to 0) from application
+ *      main or low interrupt level.
+ *
+ * @param[in, out] p_ecb_data Pointer to the ECB parameters' struct (two input
+ *                            parameters and one output parameter).
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_ECB_BLOCK_ENCRYPT, uint32_t, sd_ecb_block_encrypt(nrf_ecb_hal_data_t * p_ecb_data));
+
+/**@brief Encrypts multiple data blocks provided as an array of data block structures.
+ *
+ * @details: Performs 128-bit AES encryption on multiple data blocks
+ *
+ * @note:
+ *    - The application may set the SEVONPEND bit in the SCR to 1 to make the SoftDevice sleep while
+ *      the ECB is running. The SEVONPEND bit should only be cleared (set to 0) from application
+ *      main or low interrupt level.
+ *
+ * @param[in]     block_count     Count of blocks in the p_data_blocks array.
+ * @param[in,out] p_data_blocks   Pointer to the first entry in a contiguous array of
+ *                                @ref nrf_ecb_hal_data_block_t structures.
+ *
+ * @retval ::NRF_SUCCESS
+ */
+SVCALL(SD_ECB_BLOCKS_ENCRYPT, uint32_t, sd_ecb_blocks_encrypt(uint8_t block_count, nrf_ecb_hal_data_block_t * p_data_blocks));
+
+/**@brief Gets any pending events generated by the SoC API.
+ *
+ * The application should keep calling this function to get events, until ::NRF_ERROR_NOT_FOUND is returned.
+ *
+ * @param[out] p_evt_id Set to one of the values in @ref NRF_SOC_EVTS, if any events are pending.
+ *
+ * @retval ::NRF_SUCCESS An event was pending. The event id is written in the p_evt_id parameter.
+ * @retval ::NRF_ERROR_NOT_FOUND No pending events.
+ */
+SVCALL(SD_EVT_GET, uint32_t, sd_evt_get(uint32_t * p_evt_id));
+
+/**@brief Get the temperature measured on the chip
+ *
+ * This function will block until the temperature measurement is done.
+ * It takes around 50 us from call to return.
+ *
+ * @param[out] p_temp Result of temperature measurement. Die temperature in 0.25 degrees Celsius.
+ *
+ * @retval ::NRF_SUCCESS A temperature measurement was done, and the temperature was written to temp
+ */
+SVCALL(SD_TEMP_GET, uint32_t, sd_temp_get(int32_t * p_temp));
+
+/**@brief Flash Write
+*
+* Commands to write a buffer to flash
+*
+* If the SoftDevice is enabled:
+*  This call initiates the flash access command, and its completion will be communicated to the
+*  application with exactly one of the following events:
+*      - @ref NRF_EVT_FLASH_OPERATION_SUCCESS - The command was successfully completed.
+*      - @ref NRF_EVT_FLASH_OPERATION_ERROR   - The command could not be started.
+*
+* If the SoftDevice is not enabled no event will be generated, and this call will return @ref NRF_SUCCESS when the
+ * write has been completed
+*
+* @note
+*      - This call takes control over the radio and the CPU during flash erase and write to make sure that
+*        they will not interfere with the flash access. This means that all interrupts will be blocked
+*        for a predictable time (depending on the NVMC specification in the device's Product Specification
+*        and the command parameters).
+*      - The data in the p_src buffer should not be modified before the @ref NRF_EVT_FLASH_OPERATION_SUCCESS
+*        or the @ref NRF_EVT_FLASH_OPERATION_ERROR have been received if the SoftDevice is enabled.
+*      - This call will make the SoftDevice trigger a hardfault when the page is written, if it is
+*        protected.
+*
+*
+* @param[in]  p_dst Pointer to start of flash location to be written.
+* @param[in]  p_src Pointer to buffer with data to be written.
+* @param[in]  size  Number of 32-bit words to write. Maximum size is the number of words in one
+*                   flash page. See the device's Product Specification for details.
+*
+* @retval ::NRF_ERROR_INVALID_ADDR   Tried to write to a non existing flash address, or p_dst or p_src was unaligned.
+* @retval ::NRF_ERROR_BUSY           The previous command has not yet completed.
+* @retval ::NRF_ERROR_INVALID_LENGTH Size was 0, or higher than the maximum allowed size.
+* @retval ::NRF_ERROR_FORBIDDEN      Tried to write to an address outside the application flash area.
+* @retval ::NRF_SUCCESS              The command was accepted.
+*/
+SVCALL(SD_FLASH_WRITE, uint32_t, sd_flash_write(uint32_t * p_dst, uint32_t const * p_src, uint32_t size));
+
+
+/**@brief Flash Erase page
+*
+* Commands to erase a flash page
+* If the SoftDevice is enabled:
+*  This call initiates the flash access command, and its completion will be communicated to the
+*  application with exactly one of the following events:
+*      - @ref NRF_EVT_FLASH_OPERATION_SUCCESS - The command was successfully completed.
+*      - @ref NRF_EVT_FLASH_OPERATION_ERROR   - The command could not be started.
+*
+* If the SoftDevice is not enabled no event will be generated, and this call will return @ref NRF_SUCCESS when the
+* erase has been completed
+*
+* @note
+*      - This call takes control over the radio and the CPU during flash erase and write to make sure that
+*        they will not interfere with the flash access. This means that all interrupts will be blocked
+*        for a predictable time (depending on the NVMC specification in the device's Product Specification
+*        and the command parameters).
+*      - This call will make the SoftDevice trigger a hardfault when the page is erased, if it is
+*        protected.
+*
+*
+* @param[in]  page_number           Page number of the page to erase
+*
+* @retval ::NRF_ERROR_INTERNAL      If a new session could not be opened due to an internal error.
+* @retval ::NRF_ERROR_INVALID_ADDR  Tried to erase to a non existing flash page.
+* @retval ::NRF_ERROR_BUSY          The previous command has not yet completed.
+* @retval ::NRF_ERROR_FORBIDDEN     Tried to erase a page outside the application flash area.
+* @retval ::NRF_SUCCESS             The command was accepted.
+*/
+SVCALL(SD_FLASH_PAGE_ERASE, uint32_t, sd_flash_page_erase(uint32_t page_number));
+
+
+
+/**@brief Opens a session for radio timeslot requests.
+ *
+ * @note Only one session can be open at a time.
+ * @note p_radio_signal_callback(@ref NRF_RADIO_CALLBACK_SIGNAL_TYPE_START) will be called when the radio timeslot
+ *       starts. From this point the NRF_RADIO and NRF_TIMER0 peripherals can be freely accessed
+ *       by the application.
+ * @note p_radio_signal_callback(@ref NRF_RADIO_CALLBACK_SIGNAL_TYPE_TIMER0) is called whenever the NRF_TIMER0
+ *       interrupt occurs.
+ * @note p_radio_signal_callback(@ref NRF_RADIO_CALLBACK_SIGNAL_TYPE_RADIO) is called whenever the NRF_RADIO
+ *       interrupt occurs.
+ * @note p_radio_signal_callback() will be called at ARM interrupt priority level 0. This
+ *       implies that none of the sd_* API calls can be used from p_radio_signal_callback().
+ *
+ * @param[in] p_radio_signal_callback The signal callback.
+ *
+ * @retval ::NRF_ERROR_INVALID_ADDR p_radio_signal_callback is an invalid function pointer.
+ * @retval ::NRF_ERROR_BUSY If session cannot be opened.
+ * @retval ::NRF_ERROR_INTERNAL If a new session could not be opened due to an internal error.
+ * @retval ::NRF_SUCCESS Otherwise.
+ */
+ SVCALL(SD_RADIO_SESSION_OPEN, uint32_t, sd_radio_session_open(nrf_radio_signal_callback_t p_radio_signal_callback));
+
+/**@brief Closes a session for radio timeslot requests.
+ *
+ * @note Any current radio timeslot will be finished before the session is closed.
+ * @note If a radio timeslot is scheduled when the session is closed, it will be canceled.
+ * @note The application cannot consider the session closed until the @ref NRF_EVT_RADIO_SESSION_CLOSED
+ *       event is received.
+ *
+ * @retval ::NRF_ERROR_FORBIDDEN If session not opened.
+ * @retval ::NRF_ERROR_BUSY If session is currently being closed.
+ * @retval ::NRF_SUCCESS Otherwise.
+ */
+ SVCALL(SD_RADIO_SESSION_CLOSE, uint32_t, sd_radio_session_close(void));
+
+/**@brief Requests a radio timeslot.
+ *
+ * @note The request type is determined by p_request->request_type, and can be one of @ref NRF_RADIO_REQ_TYPE_EARLIEST
+ *       and @ref NRF_RADIO_REQ_TYPE_NORMAL. The first request in a session must always be of type @ref NRF_RADIO_REQ_TYPE_EARLIEST.
+ * @note For a normal request (@ref NRF_RADIO_REQ_TYPE_NORMAL), the start time of a radio timeslot is specified by
+ *       p_request->distance_us and is given relative to the start of the previous timeslot.
+ * @note A too small p_request->distance_us will lead to a @ref NRF_EVT_RADIO_BLOCKED event.
+ * @note Timeslots scheduled too close will lead to a @ref NRF_EVT_RADIO_BLOCKED event.
+ * @note See the SoftDevice Specification for more on radio timeslot scheduling, distances and lengths.
+ * @note If an opportunity for the first radio timeslot is not found before 100 ms after the call to this
+ *       function, it is not scheduled, and instead a @ref NRF_EVT_RADIO_BLOCKED event is sent.
+ *       The application may then try to schedule the first radio timeslot again.
+ * @note Successful requests will result in nrf_radio_signal_callback_t(@ref NRF_RADIO_CALLBACK_SIGNAL_TYPE_START).
+ *       Unsuccessful requests will result in a @ref NRF_EVT_RADIO_BLOCKED event, see @ref NRF_SOC_EVTS.
+ * @note The jitter in the start time of the radio timeslots is +/- @ref NRF_RADIO_START_JITTER_US us.
+ * @note The nrf_radio_signal_callback_t(@ref NRF_RADIO_CALLBACK_SIGNAL_TYPE_START) call has a latency relative to the
+ *       specified radio timeslot start, but this does not affect the actual start time of the timeslot.
+ * @note NRF_TIMER0 is reset at the start of the radio timeslot, and is clocked at 1MHz from the high frequency
+ *       (16 MHz) clock source. If p_request->hfclk_force_xtal is true, the high frequency clock is
+ *       guaranteed to be clocked from the external crystal.
+ * @note The SoftDevice will neither access the NRF_RADIO peripheral nor the NRF_TIMER0 peripheral
+ *       during the radio timeslot.
+ *
+ * @param[in] p_request Pointer to the request parameters.
+ *
+ * @retval ::NRF_ERROR_FORBIDDEN Either:
+ *                                - The session is not open.
+ *                                - The session is not IDLE.
+ *                                - This is the first request and its type is not @ref NRF_RADIO_REQ_TYPE_EARLIEST.
+ *                                - The request type was set to @ref NRF_RADIO_REQ_TYPE_NORMAL after a
+ *                                  @ref NRF_RADIO_REQ_TYPE_EARLIEST request was blocked.
+ * @retval ::NRF_ERROR_INVALID_ADDR If the p_request pointer is invalid.
+ * @retval ::NRF_ERROR_INVALID_PARAM If the parameters of p_request are not valid.
+ * @retval ::NRF_SUCCESS Otherwise.
+ */
+ SVCALL(SD_RADIO_REQUEST, uint32_t, sd_radio_request(nrf_radio_request_t const * p_request));
+
+/**@brief Write register protected by the SoftDevice
+ *
+ * This function writes to a register that is write-protected by the SoftDevice. Please refer to your
+ * SoftDevice Specification for more details about which registers that are protected by SoftDevice.
+ * This function can write to the following protected peripheral:
+ *  - ACL
+ *
+ * @note Protected registers may be read directly.
+ * @note Register that are write-once will return @ref NRF_SUCCESS on second set, even the value in
+ *       the register has not changed. See the Product Specification for more details about register
+ *       properties.
+ *
+ * @param[in]  p_register Pointer to register to be written.
+ * @param[in]  value Value to be written to the register.
+ *
+ * @retval ::NRF_ERROR_INVALID_ADDR This function can not write to the reguested register.
+ * @retval ::NRF_SUCCESS Value successfully written to register.
+ *
+ */
+SVCALL(SD_PROTECTED_REGISTER_WRITE, uint32_t, sd_protected_register_write(volatile uint32_t * p_register, uint32_t value));
+
+/**@} */
+
+#ifdef __cplusplus
+}
+#endif
+#endif // NRF_SOC_H__
+
+/**@} */

--- a/variants/t1000-e/s140_nrf52_7.3.0_API/include/nrf_svc.h
+++ b/variants/t1000-e/s140_nrf52_7.3.0_API/include/nrf_svc.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRF_SVC__
+#define NRF_SVC__
+
+#include "stdint.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Supervisor call declaration.
+ *
+ * A call to a function marked with @ref SVCALL, will trigger a Supervisor Call (SVC) Exception.
+ * The SVCs with SVC numbers 0x00-0x0F are forwared to the application. All other SVCs are handled by the SoftDevice.
+ *
+ * @param[in] number      The SVC number to be used.
+ * @param[in] return_type The return type of the SVC function.
+ * @param[in] signature   Function signature. The function can have at most four arguments.
+ */
+
+#ifdef SVCALL_AS_NORMAL_FUNCTION
+#define SVCALL(number, return_type, signature) return_type signature
+#else
+
+#ifndef SVCALL
+#if defined (__CC_ARM)
+#define SVCALL(number, return_type, signature) return_type __svc(number) signature
+#elif defined (__GNUC__)
+#ifdef __cplusplus
+#define GCC_CAST_CPP (uint16_t)
+#else
+#define GCC_CAST_CPP
+#endif
+#define SVCALL(number, return_type, signature)          \
+  _Pragma("GCC diagnostic push")                        \
+  _Pragma("GCC diagnostic ignored \"-Wreturn-type\"")   \
+  __attribute__((naked))                                \
+  __attribute__((unused))                               \
+  static return_type signature                          \
+  {                                                     \
+    __asm(                                              \
+        "svc %0\n"                                      \
+        "bx r14" : : "I" (GCC_CAST_CPP number) : "r0"   \
+    );                                                  \
+  }                                                     \
+  _Pragma("GCC diagnostic pop")
+
+#elif defined (__ICCARM__)
+#define PRAGMA(x) _Pragma(#x)
+#define SVCALL(number, return_type, signature)          \
+PRAGMA(swi_number = (number))                           \
+ __swi return_type signature;
+#else
+#define SVCALL(number, return_type, signature) return_type signature
+#endif
+#endif  // SVCALL
+
+#endif  // SVCALL_AS_NORMAL_FUNCTION
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // NRF_SVC__


### PR DESCRIPTION
This PR adds the nRF52 S140 SoftDevice header files, so we can compile the T1000-E firmware from a fresh clone.

The header files have been sourced directly from the Nordic Semiconductor website.
https://www.nordicsemi.com/Products/Development-software/S140/Download

It's probably the easiest approach to keep these files in the repo, otherwise we'd need an extra script to pull them in from another source at build time.