### PR TITLE
tx_power can be raised to 22dBm on LR1110

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -648,6 +648,7 @@ build_flags = ${nrf52840_t1000e.build_flags}
   -D PIN_USER_BTN=6
   -D RADIO_CLASS=CustomLR1110
   -D WRAPPER_CLASS=CustomLR1110Wrapper
+  -D MAX_LORA_TX_POWER=22
 build_src_filter = ${nrf52840_t1000e.build_src_filter}
   +<helpers/*.cpp>
   +<helpers/nrf52/T1000eBoard.cpp>


### PR DESCRIPTION
Current tx power is limited to 20dBm (default value)

RadioLib let us raise the outputPower up to 22dBm

see : https://github.com/jgromes/RadioLib/blob/15745bbd1d02db51ee6433ad300f172bcf37a2d5/src/modules/LR11x0/LR1110.cpp#L102

any value over that is discarded