### PR TITLE
Enable SSD1306 display class for LilyGo_TLora_V2_1_1_6

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -365,10 +365,15 @@ build_flags =
   -D P_LORA_MOSI=27     ; SPI MOSI
   -D P_LORA_TX_LED=2    ; LED pin for TX indication
   -D PIN_VBAT_READ=35   ; Battery voltage reading (analog pin)
+  -D PIN_USER_BTN=0
   -D RADIO_CLASS=CustomSX1276
   -D ARDUINO_LOOP_STACK_SIZE=16384
+  -D DISPLAY_CLASS=SSD1306Display
   -D WRAPPER_CLASS=CustomSX1276Wrapper
   -D LORA_TX_POWER=20
+lib_deps =
+  ${esp32_base.lib_deps}
+  adafruit/Adafruit SSD1306 @ ^2.5.13
 
 ; =============
 [LilyGo_T3S3_sx1262]
@@ -396,7 +401,7 @@ build_flags = ${esp32_base.build_flags}
 ; === LILYGO T-LoRa V2.1-1.6 with SX1276 environments ===
 [env:LilyGo_TLora_V2_1_1_6_Repeater]
 extends = LilyGo_TLora_V2_1_1_6
-build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter} +<../examples/simple_repeater/main.cpp>
+build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter} +<helpers/ui/*.cpp> +<../examples/simple_repeater>
 build_flags =
   ${LilyGo_TLora_V2_1_1_6.build_flags}
   -D ADVERT_NAME="\"TLora-V2.1-1.6 Repeater\""
@@ -415,7 +420,7 @@ build_flags =
   -D MAX_GROUP_CHANNELS=1
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
-build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter} +<../examples/simple_secure_chat/main.cpp>
+build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter} +<helpers/ui/*.cpp> +<../examples/simple_repeater>
 lib_deps =
   ${LilyGo_TLora_V2_1_1_6.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -430,7 +435,7 @@ build_flags =
 ;  -D ENABLE_PRIVATE_KEY_EXPORT=1
 ; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
 ; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
-build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter} +<../examples/companion_radio/main.cpp>
+build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter} +<helpers/ui/*.cpp> +<../examples/companion_radio>
 lib_deps =
   ${LilyGo_TLora_V2_1_1_6.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -447,14 +452,14 @@ build_flags =
 ;  -D ENABLE_PRIVATE_KEY_EXPORT=1
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
-build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter} +<helpers/esp32/*.cpp> +<../examples/companion_radio/main.cpp>
+build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter} +<helpers/ui/*.cpp> +<../examples/companion_radio>
 lib_deps =
   ${LilyGo_TLora_V2_1_1_6.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
 [env:LilyGo_TLora_V2_1_1_6_room_server]
 extends = LilyGo_TLora_V2_1_1_6
-build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter} +<../examples/simple_room_server/main.cpp>
+build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter} +<helpers/ui/*.cpp> +<../examples/simple_room_server>
 build_flags =
   ${LilyGo_TLora_V2_1_1_6.build_flags}
   -D ADVERT_NAME="\"TLora-V2.1-1.6 Room\""


### PR DESCRIPTION
The LilyGo_TLora_V2_1_1_6_Repeater board has a SSD1306Display so enabling it is pretty simple. This should also apply to T3S3 boards, but I don't have on hand to test.

<img width="870" alt="Screenshot 2025-03-07 at 2 36 13 PM" src="https://github.com/user-attachments/assets/7466f9e0-4e67-4283-acab-91290294498e" />
