### PR TITLE
Add support for Faketec with LLCC68 instead of SX1262

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -99,6 +99,7 @@
 #elif defined(FAKETEC)
   #include <helpers/nrf52/faketecBoard.h>
   #include <helpers/CustomSX1262Wrapper.h>
+  #include <helpers/CustomLLCC68Wrapper.h>
   static faketecBoard board;
 #else
   #error "need to provide a 'board' object"

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -99,6 +99,7 @@
 #elif defined(FAKETEC)
   #include <helpers/nrf52/faketecBoard.h>
   #include <helpers/CustomSX1262Wrapper.h>
+  #include <helpers/CustomLLCC68Wrapper.h>
   static faketecBoard board;
 #else
   #error "need to provide a 'board' object"

--- a/examples/simple_room_server/main.cpp
+++ b/examples/simple_room_server/main.cpp
@@ -103,6 +103,7 @@
 #elif defined(FAKETEC)
   #include <helpers/nrf52/faketecBoard.h>
   #include <helpers/CustomSX1262Wrapper.h>
+  #include <helpers/CustomLLCC68Wrapper.h>
   static faketecBoard board;
 #else
   #error "need to provide a 'board' object"

--- a/examples/simple_secure_chat/main.cpp
+++ b/examples/simple_secure_chat/main.cpp
@@ -81,6 +81,7 @@
 #elif defined(FAKETEC)
   #include <helpers/nrf52/faketecBoard.h>
   #include <helpers/CustomSX1262Wrapper.h>
+  #include <helpers/CustomLLCC68Wrapper.h>
   static faketecBoard board;
 #else
   #error "need to provide a 'board' object"

--- a/platformio.ini
+++ b/platformio.ini
@@ -1001,8 +1001,11 @@ board = promicro_nrf52840
 build_src_filter = ${nrf52840_base.build_src_filter}  +<helpers/nrf52/faketecBoard.cpp>
 build_flags = ${nrf52840_base.build_flags}
   -D FAKETEC
-  -D RADIO_CLASS=CustomSX1262
-  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  ; select SX1262 or LLCC68 by commenting/uncommenting the appropriate two lines below
+;  -D RADIO_CLASS=CustomSX1262
+;  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D RADIO_CLASS=CustomLLCC68 
+  -D WRAPPER_CLASS=CustomLLCC68Wrapper
   -D LORA_TX_POWER=22
   -D SX126X_CURRENT_LIMIT=130
   -D SX126X_RX_BOOSTED_GAIN=1

--- a/src/helpers/CustomLLCC68.h
+++ b/src/helpers/CustomLLCC68.h
@@ -9,7 +9,7 @@ class CustomLLCC68 : public LLCC68 {
     CustomLLCC68(Module *mod) : LLCC68(mod) { }
 
     bool isReceiving() {
-      uint16_t irq = getIrqStatus();
+      uint16_t irq = getIrqFlags();
       bool hasPreamble = (irq & SX126X_IRQ_HEADER_VALID);
       return hasPreamble;
     }


### PR DESCRIPTION
base class didn't have getIrqStatus() member