### PR TITLE
change default frequency as mentioned in FAQ

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -23,7 +23,7 @@ lib_deps =
   adafruit/RTClib @ ^2.1.3
   melopero/Melopero RV3028 @ ^1.1.0
 build_flags = -w -DNDEBUG -DRADIOLIB_STATIC_ONLY=1 -DRADIOLIB_GODMODE=1
-  -D LORA_FREQ=867.5
+  -D LORA_FREQ=869.525
   -D LORA_BW=250
   -D LORA_SF=10
 build_src_filter =


### PR DESCRIPTION
The default frequency should be 869.525. This is the dafault for the builds and many nodes will just run with this because operators will not set proper settings. The old value is not even allowed in Germany as 867.5 is limited to 200 kHz bandwidth.