### PR TITLE
Remove rtc auto-detect on t1000

### DIFF
--- a/variants/t1000-e/target.cpp
+++ b/variants/t1000-e/target.cpp
@@ -1,6 +1,5 @@
 #include <Arduino.h>
 #include "target.h"
-#include <helpers/ArduinoHelpers.h>
 
 T1000eBoard board;
 
@@ -8,8 +7,7 @@ RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BU
 
 WRAPPER_CLASS radio_driver(radio, board);
 
-VolatileRTCClock fallback_clock;
-AutoDiscoverRTCClock rtc_clock(fallback_clock);
+VolatileRTCClock rtc_clock;
 
 #ifndef LORA_CR
   #define LORA_CR      5
@@ -38,7 +36,7 @@ static const Module::RfSwitchMode_t rfswitch_table[] = {
 #endif
 
 bool radio_init() {
-  rtc_clock.begin(Wire);
+  //rtc_clock.begin(Wire);
   
 #ifdef LR11X0_DIO3_TCXO_VOLTAGE
   float tcxo = LR11X0_DIO3_TCXO_VOLTAGE;

--- a/variants/t1000-e/target.h
+++ b/variants/t1000-e/target.h
@@ -5,11 +5,11 @@
 #include <helpers/RadioLibWrappers.h>
 #include <helpers/nrf52/T1000eBoard.h>
 #include <helpers/CustomLR1110Wrapper.h>
-#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/ArduinoHelpers.h>
 
 extern T1000eBoard board;
 extern WRAPPER_CLASS radio_driver;
-extern AutoDiscoverRTCClock rtc_clock;
+extern VolatileRTCClock rtc_clock;
 
 bool radio_init();
 uint32_t radio_get_rng_seed();


### PR DESCRIPTION
The RTC autodetection was blocking the boot on t1000e

Removed it (nothing to detect here) and works like a charm

I've based this PR on dev, but you might want to apply it to main as quick as possible ;)

I should probably check i2c bus initialization ... 