### PR TITLE
Fix Companion Display Noise

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -1442,6 +1442,7 @@ void setup() {
  #ifdef DISPLAY_CLASS
   if (display.begin()) {
     disp = &display;
+    disp->clear();
   }
  #endif
 #endif

--- a/src/helpers/ui/DisplayDriver.h
+++ b/src/helpers/ui/DisplayDriver.h
@@ -15,6 +15,7 @@ public:
   virtual bool isOn() = 0;
   virtual void turnOn() = 0;
   virtual void turnOff() = 0;
+  virtual void clear() = 0;
   virtual void startFrame(Color bkg = DARK) = 0;
   virtual void setTextSize(int sz) = 0;
   virtual void setColor(Color c) = 0;

--- a/src/helpers/ui/SSD1306Display.cpp
+++ b/src/helpers/ui/SSD1306Display.cpp
@@ -20,6 +20,11 @@ void SSD1306Display::turnOff() {
   _isOn = false;
 }
 
+void SSD1306Display::clear() {
+  display.clearDisplay();
+  display.display();
+}
+
 void SSD1306Display::startFrame(Color bkg) {
   display.clearDisplay();  // TODO: apply 'bkg'
   _color = SSD1306_WHITE;

--- a/src/helpers/ui/SSD1306Display.h
+++ b/src/helpers/ui/SSD1306Display.h
@@ -27,6 +27,7 @@ public:
   bool isOn() override { return _isOn; }
   void turnOn() override;
   void turnOff() override;
+  void clear() override;
   void startFrame(Color bkg = DARK) override;
   void setTextSize(int sz) override;
   void setColor(Color c) override;


### PR DESCRIPTION
Currently, when the companion firmware boots up, the display shows static noise.

The display driver is init early during setup, however the UI task isn't started until later on when everything else is done.
Such as setting up the mesh, ble and serial. Due to this, noise is shown on the display.

This PR clears the display as soon as it has been started. This fix is not needed for Repeater/Room firmwares since they start the display and ui task at the same time.