### PR TITLE
Show please wait message on boot

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -1442,7 +1442,9 @@ void setup() {
  #ifdef DISPLAY_CLASS
   if (display.begin()) {
     disp = &display;
-    disp->clear();
+    disp->startFrame();
+    disp->print("Please wait...");
+    disp->endFrame();
   }
  #endif
 #endif

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -1433,10 +1433,6 @@ void setup() {
 
   board.begin();
 
-  if (!radio_init()) { halt(); }
-
-  fast_rng.begin(radio_get_rng_seed());
-
 #ifdef HAS_UI
   DisplayDriver* disp = NULL;
  #ifdef DISPLAY_CLASS
@@ -1448,6 +1444,10 @@ void setup() {
   }
  #endif
 #endif
+
+  if (!radio_init()) { halt(); }
+
+  fast_rng.begin(radio_get_rng_seed());
 
 #if defined(NRF52_PLATFORM)
   InternalFS.begin();

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -616,6 +616,14 @@ void setup() {
 
   board.begin();
 
+#ifdef DISPLAY_CLASS
+  if(display.begin()){
+    display.startFrame();
+    display.print("Please wait...");
+    display.endFrame();
+  }
+#endif
+
   if (!radio_init()) { halt(); }
 
   fast_rng.begin(radio_get_rng_seed());
@@ -646,7 +654,6 @@ void setup() {
   the_mesh.begin(fs);
 
 #ifdef DISPLAY_CLASS
-  display.begin();
   ui_task.begin(the_mesh.getNodeName(), FIRMWARE_BUILD_DATE);
 #endif
 

--- a/examples/simple_room_server/main.cpp
+++ b/examples/simple_room_server/main.cpp
@@ -846,6 +846,14 @@ void setup() {
 
   board.begin();
 
+#ifdef DISPLAY_CLASS
+  if(display.begin()){
+    display.startFrame();
+    display.print("Please wait...");
+    display.endFrame();
+  }
+#endif
+
   if (!radio_init()) { halt(); }
 
   fast_rng.begin(radio_get_rng_seed());
@@ -875,7 +883,6 @@ void setup() {
   the_mesh.begin(fs);
 
 #ifdef DISPLAY_CLASS
-  display.begin();
   ui_task.begin(the_mesh.getNodeName(), FIRMWARE_BUILD_DATE);
 #endif
 


### PR DESCRIPTION
This PR displays the text `Please wait...` on the display as soon as the companion, repeater and room server firmwares start up.

When flashing firmware for the first time on a fresh device, the file system formatting can take about 15 seconds. During this time, the display is blank and users assume the device is not working.

I have moved the display init above the radio init, with the intention of us possibly displaying a "radio init failed" message in the `halt` section in a future update.