### PR TITLE
Allow the use companion radio on other serial interfaces

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -1404,6 +1404,10 @@ public:
   #elif defined(BLE_PIN_CODE)
     #include <helpers/esp32/SerialBLEInterface.h>
     SerialBLEInterface serial_interface;
+  #elif defined(SERIAL_RX)
+    #include <helpers/ArduinoSerialInterface.h>
+    ArduinoSerialInterface serial_interface;
+    HardwareSerial companion_serial(1);
   #else
     #include <helpers/ArduinoSerialInterface.h>
     ArduinoSerialInterface serial_interface;
@@ -1481,6 +1485,10 @@ void setup() {
   char dev_name[32+16];
   sprintf(dev_name, "%s%s", BLE_NAME_PREFIX, the_mesh.getNodeName());
   serial_interface.begin(dev_name, the_mesh.getBLEPin());
+#elif defined(SERIAL_RX)
+  companion_serial.setPins(SERIAL_RX, SERIAL_TX);
+  companion_serial.begin(115200);
+  serial_interface.begin(companion_serial);
 #else
   serial_interface.begin(Serial);
 #endif

--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -88,3 +88,21 @@ build_src_filter = ${Xiao_S3_WIO.build_src_filter}
 lib_deps =
   ${Xiao_S3_WIO.lib_deps}
   densaugeo/base64 @ ~1.4.0
+
+[env:Xiao_S3_WIO_companion_radio_serial]
+extends = Xiao_S3_WIO
+build_flags =
+  ${Xiao_S3_WIO.build_flags}
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=8
+  -D SERIAL_TX=D6
+  -D SERIAL_RX=D7
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Xiao_S3_WIO.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<../examples/companion_radio/main.cpp>
+lib_deps =
+  ${Xiao_S3_WIO.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+


### PR DESCRIPTION
want to hook a micropython node there and work on a micropython version of meshcore_py ;)

sorry I already proposed this but was not based on dev :(