### PR TITLE
FIX: Set RfSwitch pins properly.

### DIFF
--- a/variants/promicro/target.cpp
+++ b/variants/promicro/target.cpp
@@ -26,6 +26,7 @@ bool radio_init() {
 
   SPI.setPins(P_LORA_MISO, P_LORA_SCLK, P_LORA_MOSI);
   SPI.begin();
+  radio.setRfSwitchPins(SX126X_RXEN, SX126X_TXEN);
   int status = radio.begin(LORA_FREQ, LORA_BW, LORA_SF, LORA_CR, RADIOLIB_SX126X_SYNC_WORD_PRIVATE, LORA_TX_POWER, 8, tcxo);
   if (status == RADIOLIB_ERR_SPI_CMD_FAILED || status == RADIOLIB_ERR_SPI_CMD_INVALID) {
     #define SX126X_DIO3_TCXO_VOLTAGE (0.0f);


### PR DESCRIPTION
We need to set the RfSwitch pins in order to drive RXEN high when in receive mode because it's not automatically switched by hardware when DIO2/TXEN is set low.