### PR TITLE
Show version in build info for devices with a screen

### DIFF
--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -30,8 +30,6 @@ void UITask::begin(DisplayDriver* display, const char* node_name, const char* bu
   _auto_off = millis() + AUTO_OFF_MILLIS;
   clearMsgPreview();
   _node_name = node_name;
-  _build_date = build_date;
-  _firmware_version = firmware_version;
   _pin_code = pin_code;
   if (_display != NULL) {
     _display->turnOn();
@@ -39,14 +37,14 @@ void UITask::begin(DisplayDriver* display, const char* node_name, const char* bu
 
   // strip off dash and commit hash by changing dash to null terminator
   // e.g: v1.2.3-abcdef -> v1.2.3
-  char *version = strdup(_firmware_version);
+  char *version = strdup(firmware_version);
   char *dash = strchr(version, '-');
   if(dash){
     *dash = 0;
   }
 
   // v1.2.3 (1 Jan 2025)
-  sprintf(_version_info, "%s (%s)", version, _build_date);
+  sprintf(_version_info, "%s (%s)", version, build_date);
 }
 
 void UITask::msgRead(int msgcount) {

--- a/examples/companion_radio/UITask.h
+++ b/examples/companion_radio/UITask.h
@@ -11,8 +11,6 @@ class UITask {
   bool _connected;
   uint32_t _pin_code;
   const char* _node_name;
-  const char* _build_date;
-  const char* _firmware_version;
   char _version_info[32];
   char _origin[62];
   char _msg[80];

--- a/examples/companion_radio/UITask.h
+++ b/examples/companion_radio/UITask.h
@@ -12,6 +12,8 @@ class UITask {
   uint32_t _pin_code;
   const char* _node_name;
   const char* _build_date;
+  const char* _firmware_version;
+  char _version_info[32];
   char _origin[62];
   char _msg[80];
   int _msgcount;
@@ -26,7 +28,7 @@ public:
       _next_refresh = 0; 
       _connected = false;
   }
-  void begin(DisplayDriver* display, const char* node_name, const char* build_date, uint32_t pin_code);
+  void begin(DisplayDriver* display, const char* node_name, const char* build_date, const char* firmware_version, uint32_t pin_code);
 
   void setHasConnection(bool connected) { _connected = connected; }
   bool hasDisplay() const { return _display != NULL; }

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -1505,7 +1505,7 @@ void setup() {
 #endif
 
 #ifdef HAS_UI
-  ui_task.begin(disp, the_mesh.getNodeName(), FIRMWARE_BUILD_DATE, the_mesh.getBLEPin());
+  ui_task.begin(disp, the_mesh.getNodeName(), FIRMWARE_BUILD_DATE, FIRMWARE_VERSION, the_mesh.getBLEPin());
 #endif
 }
 

--- a/examples/simple_repeater/UITask.cpp
+++ b/examples/simple_repeater/UITask.cpp
@@ -20,25 +20,34 @@ static const uint8_t meshcore_logo [] PROGMEM = {
     0xe3, 0xe3, 0x8f, 0xff, 0x1f, 0xfc, 0x3c, 0x0e, 0x1f, 0xf8, 0xff, 0xf8, 0x70, 0x3c, 0x7f, 0xf8, 
 };
 
-void UITask::begin(const char* node_name, const char* build_date) {
+void UITask::begin(const char* node_name, const char* build_date, const char* firmware_version) {
   _prevBtnState = HIGH;
   _auto_off = millis() + AUTO_OFF_MILLIS;
   _node_name = node_name;
   _build_date = build_date;
   _display->turnOn();
+
+  // strip off dash and commit hash by changing dash to null terminator
+  // e.g: v1.2.3-abcdef -> v1.2.3
+  char *version = strdup(firmware_version);
+  char *dash = strchr(version, '-');
+  if(dash){
+    *dash = 0;
+  }
+
+  // v1.2.3 (1 Jan 2025)
+  sprintf(_version_info, "%s (%s)", version, _build_date);
 }
 
 void UITask::renderCurrScreen() {
-  char tmp[80];
   // render 'home' screen
   _display->drawXbm(0, 0, meshcore_logo, 128, 13);
   _display->setCursor(0, 20);
   _display->setTextSize(1);
   _display->print(_node_name);
 
-  sprintf(tmp, "Build: %s", _build_date);
   _display->setCursor(0, 32);
-  _display->print(tmp);
+  _display->print(_version_info);
   _display->setCursor(0, 43);
   _display->print("< Repeater >");
   //_display->printf("freq : %03.2f sf %d\n", _prefs.freq, _prefs.sf);

--- a/examples/simple_repeater/UITask.cpp
+++ b/examples/simple_repeater/UITask.cpp
@@ -24,7 +24,6 @@ void UITask::begin(const char* node_name, const char* build_date, const char* fi
   _prevBtnState = HIGH;
   _auto_off = millis() + AUTO_OFF_MILLIS;
   _node_name = node_name;
-  _build_date = build_date;
   _display->turnOn();
 
   // strip off dash and commit hash by changing dash to null terminator
@@ -36,7 +35,7 @@ void UITask::begin(const char* node_name, const char* build_date, const char* fi
   }
 
   // v1.2.3 (1 Jan 2025)
-  sprintf(_version_info, "%s (%s)", version, _build_date);
+  sprintf(_version_info, "%s (%s)", version, build_date);
 }
 
 void UITask::renderCurrScreen() {

--- a/examples/simple_repeater/UITask.h
+++ b/examples/simple_repeater/UITask.h
@@ -7,7 +7,6 @@ class UITask {
   unsigned long _next_read, _next_refresh, _auto_off;
   int _prevBtnState;
   const char* _node_name;
-  const char* _build_date;
   char _version_info[32];
 
   void renderCurrScreen();

--- a/examples/simple_repeater/UITask.h
+++ b/examples/simple_repeater/UITask.h
@@ -8,11 +8,12 @@ class UITask {
   int _prevBtnState;
   const char* _node_name;
   const char* _build_date;
+  char _version_info[32];
 
   void renderCurrScreen();
 public:
   UITask(DisplayDriver& display) : _display(&display) { _next_read = _next_refresh = 0; }
-  void begin(const char* node_name, const char* build_date);
+  void begin(const char* node_name, const char* build_date, const char* firmware_version);
 
   void loop();
 };

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -658,7 +658,7 @@ void setup() {
   the_mesh.begin(fs);
 
 #ifdef DISPLAY_CLASS
-  ui_task.begin(the_mesh.getNodeName(), FIRMWARE_BUILD_DATE);
+  ui_task.begin(the_mesh.getNodeName(), FIRMWARE_BUILD_DATE, FIRMWARE_VERSION);
 #endif
 
   // send out initial Advertisement to the mesh

--- a/examples/simple_room_server/UITask.cpp
+++ b/examples/simple_room_server/UITask.cpp
@@ -20,25 +20,34 @@ static const uint8_t meshcore_logo [] PROGMEM = {
     0xe3, 0xe3, 0x8f, 0xff, 0x1f, 0xfc, 0x3c, 0x0e, 0x1f, 0xf8, 0xff, 0xf8, 0x70, 0x3c, 0x7f, 0xf8, 
 };
 
-void UITask::begin(const char* node_name, const char* build_date) {
+void UITask::begin(const char* node_name, const char* build_date, const char* firmware_version) {
   _prevBtnState = HIGH;
   _auto_off = millis() + AUTO_OFF_MILLIS;
   _node_name = node_name;
   _build_date = build_date;
   _display->turnOn();
+
+  // strip off dash and commit hash by changing dash to null terminator
+  // e.g: v1.2.3-abcdef -> v1.2.3
+  char *version = strdup(firmware_version);
+  char *dash = strchr(version, '-');
+  if(dash){
+    *dash = 0;
+  }
+
+  // v1.2.3 (1 Jan 2025)
+  sprintf(_version_info, "%s (%s)", version, _build_date);
 }
 
 void UITask::renderCurrScreen() {
-  char tmp[80];
   // render 'home' screen
   _display->drawXbm(0, 0, meshcore_logo, 128, 13);
   _display->setCursor(0, 20);
   _display->setTextSize(1);
   _display->print(_node_name);
 
-  sprintf(tmp, "Build: %s", _build_date);
   _display->setCursor(0, 32);
-  _display->print(tmp);
+  _display->print(_version_info);
   _display->setCursor(0, 43);
   _display->print("< Room Server >");
   //_display->printf("freq : %03.2f sf %d\n", _prefs.freq, _prefs.sf);

--- a/examples/simple_room_server/UITask.cpp
+++ b/examples/simple_room_server/UITask.cpp
@@ -24,7 +24,6 @@ void UITask::begin(const char* node_name, const char* build_date, const char* fi
   _prevBtnState = HIGH;
   _auto_off = millis() + AUTO_OFF_MILLIS;
   _node_name = node_name;
-  _build_date = build_date;
   _display->turnOn();
 
   // strip off dash and commit hash by changing dash to null terminator
@@ -36,7 +35,7 @@ void UITask::begin(const char* node_name, const char* build_date, const char* fi
   }
 
   // v1.2.3 (1 Jan 2025)
-  sprintf(_version_info, "%s (%s)", version, _build_date);
+  sprintf(_version_info, "%s (%s)", version, build_date);
 }
 
 void UITask::renderCurrScreen() {

--- a/examples/simple_room_server/UITask.h
+++ b/examples/simple_room_server/UITask.h
@@ -7,7 +7,6 @@ class UITask {
   unsigned long _next_read, _next_refresh, _auto_off;
   int _prevBtnState;
   const char* _node_name;
-  const char* _build_date;
   char _version_info[32];
 
   void renderCurrScreen();

--- a/examples/simple_room_server/UITask.h
+++ b/examples/simple_room_server/UITask.h
@@ -8,11 +8,12 @@ class UITask {
   int _prevBtnState;
   const char* _node_name;
   const char* _build_date;
+  char _version_info[32];
 
   void renderCurrScreen();
 public:
   UITask(DisplayDriver& display) : _display(&display) { _next_read = _next_refresh = 0; }
-  void begin(const char* node_name, const char* build_date);
+  void begin(const char* node_name, const char* build_date, const char* firmware_version);
 
   void loop();
 };

--- a/examples/simple_room_server/main.cpp
+++ b/examples/simple_room_server/main.cpp
@@ -887,7 +887,7 @@ void setup() {
   the_mesh.begin(fs);
 
 #ifdef DISPLAY_CLASS
-  ui_task.begin(the_mesh.getNodeName(), FIRMWARE_BUILD_DATE);
+  ui_task.begin(the_mesh.getNodeName(), FIRMWARE_BUILD_DATE, FIRMWARE_VERSION);
 #endif
 
   // send out initial Advertisement to the mesh


### PR DESCRIPTION
This PR changes the build info shown on screen from `Build: 1 Jan 2025` to `v1.2.3 (1 Jan 2025)`.

The firmware version string can either be `v1.2.3` when built locally, or `v1.2.3-hash` when built from GitHub Actions.

I've opted to strip off the commit hash when shown on screen, as in my opinion it looks better with both the version and build date. (Users can see the commit hash from the app settings screen)

Before:

![Snapchat-1957752689](https://github.com/user-attachments/assets/bf49ed4f-ad14-4412-9fb4-1849d9c3dc9a)

After:

![Snapchat-831659645](https://github.com/user-attachments/assets/7208516e-35b0-4f3e-97c5-c80862085c9a)

I have tested on the following firmware types:

- Companion BLE
- Repeater
- Room Server

We could probably refactor the version info dash stripper thing into it's own helper class, but I've left this for now.

This closes #181