### PR TITLE
Fix Floating Pin on FakeTec/Promicro: Update BUTTON_PIN to INPUT_PULLUP

### DIFF
--- a/src/helpers/nrf52/PromicroBoard.cpp
+++ b/src/helpers/nrf52/PromicroBoard.cpp
@@ -14,7 +14,7 @@ void PromicroBoard::begin() {
     pinMode(PIN_VBAT_READ, INPUT);
 
     #ifdef BUTTON_PIN
-      pinMode(BUTTON_PIN, INPUT);
+      pinMode(BUTTON_PIN, INPUT_PULLUP);
     #endif
 
     #if defined(PIN_BOARD_SDA) && defined(PIN_BOARD_SCL)


### PR DESCRIPTION
This pull request resolves the floating pin issue on the FakeTec/Promicro. The change updates the BUTTON_PIN configuration by switching from INPUT to INPUT_PULLUP, which ensures proper behavior and no floating pins. 

Key Fixes/Updates   
- Changed pinMode(BUTTON_PIN, INPUT); to pinMode(BUTTON_PIN, INPUT_PULLUP); under the BUTTON_PIN conditional compilation block.  
- Resolves potential float-induced glitches or incorrect button readings.

This adjustment has been tested and confirmed to compile and work correctly on a Faketec board.

Please review and merge if everything looks good. 