### PR TITLE
add defines for RAK OLED pins

### DIFF
--- a/src/helpers/nrf52/RAK4631Board.cpp
+++ b/src/helpers/nrf52/RAK4631Board.cpp
@@ -27,7 +27,7 @@ void RAK4631Board::begin() {
 #endif
 
 #if defined(PIN_BOARD_SDA) && defined(PIN_BOARD_SCL)
-  Wire.setPins(PIN_BOARD_SDA, PIN_BOARD_SCL)
+  Wire.setPins(PIN_BOARD_SDA, PIN_BOARD_SCL);
 #endif
 
   Wire.begin();

--- a/src/helpers/nrf52/T1000eBoard.cpp
+++ b/src/helpers/nrf52/T1000eBoard.cpp
@@ -18,7 +18,7 @@ void T1000eBoard::begin() {
 #endif
 
 #if defined(PIN_BOARD_SDA) && defined(PIN_BOARD_SCL)
-  Wire.setPins(PIN_BOARD_SDA, PIN_BOARD_SCL)
+  Wire.setPins(PIN_BOARD_SDA, PIN_BOARD_SCL);
 #endif
 
   Wire.begin();

--- a/src/helpers/nrf52/T114Board.cpp
+++ b/src/helpers/nrf52/T114Board.cpp
@@ -27,7 +27,7 @@ void T114Board::begin() {
   pinMode(PIN_VBAT_READ, INPUT);
 
 #if defined(PIN_BOARD_SDA) && defined(PIN_BOARD_SCL)
-  Wire.setPins(PIN_BOARD_SDA, PIN_BOARD_SCL)
+  Wire.setPins(PIN_BOARD_SDA, PIN_BOARD_SCL);
 #endif
 
   Wire.begin();

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -7,6 +7,9 @@ build_flags = ${nrf52840_base.build_flags}
   -I variants/rak4631
   -D RAK_4631
   -D PIN_USER_BTN=9
+  -D PIN_BOARD_SCL=14
+  -D PIN_BOARD_SDA=13
+  -D PIN_OLED_RESET=-1
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper
   -D LORA_TX_POWER=22


### PR DESCRIPTION
Added PIN_OLED_RESET pin.

Added PIN_BOARD_SDA and SCL and although they aren't strictly necessary it's maybe not a bad idea just for clarity's sake?