### PR TITLE
t1000 : power bat sensor only when necessary

### DIFF
--- a/src/helpers/nrf52/T1000eBoard.h
+++ b/src/helpers/nrf52/T1000eBoard.h
@@ -29,9 +29,12 @@ public:
 
   uint16_t getBattMilliVolts() override {
   #ifdef BATTERY_PIN
+    digitalWrite(PIN_3V3_EN, HIGH);
     analogReference(AR_INTERNAL_3_0);
     analogReadResolution(12);
+    delay(10);
     float volts = (analogRead(BATTERY_PIN) * ADC_MULTIPLIER * AREF_VOLTAGE) / 4096;
+    digitalWrite(PIN_3V3_EN, LOW);
 
     analogReference(AR_DEFAULT);  // put back to default
     analogReadResolution(10);

--- a/variants/t1000-e/variant.cpp
+++ b/variants/t1000-e/variant.cpp
@@ -83,13 +83,13 @@ void initVariant()
   pinMode(GPS_RTC_INT, OUTPUT);
   pinMode(LED_PIN, OUTPUT);
 
-  digitalWrite(PIN_3V3_EN, HIGH);
+  digitalWrite(PIN_3V3_EN, LOW);
   digitalWrite(PIN_3V3_ACC_EN, LOW);
   digitalWrite(BUZZER_EN, LOW);
   digitalWrite(SENSOR_EN, LOW);
   digitalWrite(GPS_EN, LOW);
   digitalWrite(GPS_RESET, LOW);
-  digitalWrite(GPS_VRTC_EN, HIGH);
+  digitalWrite(GPS_VRTC_EN, LOW);
   digitalWrite(GPS_SLEEP_INT, HIGH);
   digitalWrite(GPS_RTC_INT, LOW);
   digitalWrite(LED_PIN, LOW);


### PR DESCRIPTION
PIN_3V3_EN was always HIGH
It's the pin that enables the bat sensor, so we can drive it to high only when reading bat and save some power