### PR TITLE
compiles xiao_nrf52 board files only if we compile for xiao_nrf52

### DIFF
--- a/src/helpers/nrf52/XiaoNrf52Board.cpp
+++ b/src/helpers/nrf52/XiaoNrf52Board.cpp
@@ -1,3 +1,5 @@
+#ifdef XIAO_NRF52
+
 #include <Arduino.h>
 #include "XiaoNrf52Board.h"
 
@@ -89,3 +91,5 @@ bool XiaoNrf52Board::startOTAUpdate(const char* id, char reply[]) {
 
   return false;
 }
+
+#endif

--- a/src/helpers/nrf52/XiaoNrf52Board.h
+++ b/src/helpers/nrf52/XiaoNrf52Board.h
@@ -3,6 +3,8 @@
 #include <MeshCore.h>
 #include <Arduino.h>
 
+#ifdef XIAO_NRF52
+
 // LoRa radio module pins for Seeed Xiao-nrf52
 #ifdef SX1262_XIAO_S3_VARIANT
   #define  P_LORA_DIO_1       D0
@@ -73,3 +75,5 @@ public:
 
   bool startOTAUpdate(const char* id, char reply[]) override;
 };
+
+#endif


### PR DESCRIPTION
That is a quick fix, 

Think it should also be done for other nrf52 ports 

And platformio.ini might only compile against good nrf52/helper files (by specifying them explicitely, it would also save memory)