### PR TITLE
T114 display

### DIFF
--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -89,22 +89,29 @@ void UITask::renderCurrScreen() {
     // render message preview
     _display->setCursor(0, 0);
     _display->setTextSize(1);
+    _display->setColor(DisplayDriver::GREEN);
     _display->print(_node_name);
 
     _display->setCursor(0, 12);
+    _display->setColor(DisplayDriver::YELLOW);
     _display->print(_origin);
     _display->setCursor(0, 24);
+    _display->setColor(DisplayDriver::LIGHT);
     _display->print(_msg);
 
     _display->setCursor(100, 9);
     _display->setTextSize(2);
+    _display->setColor(DisplayDriver::ORANGE);
     sprintf(tmp, "%d", _msgcount);
     _display->print(tmp);
   } else {
     // render 'home' screen
+    _display->setColor(DisplayDriver::BLUE);
     _display->drawXbm(0, 0, meshcore_logo, 128, 13);
     _display->setCursor(0, 20);
     _display->setTextSize(1);
+
+    _display->setColor(DisplayDriver::LIGHT);
     _display->print(_node_name);
     
     _display->setCursor(0, 32);
@@ -114,6 +121,7 @@ void UITask::renderCurrScreen() {
       //_display->printf("freq : %03.2f sf %d\n", _prefs.freq, _prefs.sf);
       //_display->printf("bw   : %03.2f cr %d\n", _prefs.bw, _prefs.cr);
     } else if (_pin_code != 0) {
+      _display->setColor(DisplayDriver::RED);
       _display->setTextSize(2);
       _display->setCursor(0, 43);
       sprintf(tmp, "Pin:%d", _pin_code);

--- a/examples/companion_radio/UITask.h
+++ b/examples/companion_radio/UITask.h
@@ -15,6 +15,7 @@ class UITask {
   char _origin[62];
   char _msg[80];
   int _msgcount;
+  bool _need_refresh = true;
 
   void renderCurrScreen();
   void buttonHandler();

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -59,9 +59,12 @@
 
 #ifdef DISPLAY_CLASS
   #include "UITask.h"
-  #include <helpers/ui/SSD1306Display.h>
-
-  static DISPLAY_CLASS  display;
+  #ifdef ST7789
+    #include <helpers/ui/ST7789Display.h>
+  #else
+    #include <helpers/ui/SSD1306Display.h>
+  #endif
+  static DISPLAY_CLASS display;
   #define HAS_UI
 #endif
 

--- a/src/helpers/ui/DisplayDriver.h
+++ b/src/helpers/ui/DisplayDriver.h
@@ -7,7 +7,7 @@ class DisplayDriver {
 protected:
   DisplayDriver(int w, int h) { _w = w; _h = h; }
 public:
-  enum Color { DARK, LIGHT };
+  enum Color { DARK=0, LIGHT, RED, GREEN, BLUE, YELLOW, ORANGE }; // on b/w screen, colors will be !=0 synonym of light
 
   int width() const { return _w; }
   int height() const { return _h; }

--- a/src/helpers/ui/SSD1306Display.cpp
+++ b/src/helpers/ui/SSD1306Display.cpp
@@ -38,7 +38,7 @@ void SSD1306Display::setTextSize(int sz) {
 }
 
 void SSD1306Display::setColor(Color c) {
-  _color = (c == LIGHT) ? SSD1306_WHITE : SSD1306_BLACK;
+  _color = (c != 0) ? SSD1306_WHITE : SSD1306_BLACK;
   display.setTextColor(_color);
 }
 

--- a/src/helpers/ui/ST7789Display.cpp
+++ b/src/helpers/ui/ST7789Display.cpp
@@ -1,0 +1,88 @@
+#include "ST7789Display.h"
+
+bool ST7789Display::i2c_probe(TwoWire& wire, uint8_t addr) {
+  return true;
+/*
+  wire.beginTransmission(addr);
+  uint8_t error = wire.endTransmission();
+  return (error == 0);
+*/
+}
+
+bool ST7789Display::begin() {
+  if(!_isOn) {
+    pinMode(PIN_TFT_VDD_CTL, OUTPUT);
+    pinMode(PIN_TFT_LEDA_CTL, OUTPUT);
+    digitalWrite(PIN_TFT_VDD_CTL, LOW);
+    digitalWrite(PIN_TFT_LEDA_CTL, LOW);
+    digitalWrite(PIN_TFT_RST, HIGH);
+
+    display.init(135, 240);
+    display.setRotation(2);
+    display.setSPISpeed(40000000);
+    display.fillScreen(ST77XX_BLACK);
+    display.setTextColor(ST77XX_WHITE);
+    display.setTextSize(2);
+    display.cp437(true);         // Use full 256 char 'Code Page 437' font
+  
+    _isOn = true;
+  }
+  return true;
+}
+
+void ST7789Display::turnOn() {
+  ST7789Display::begin();
+}
+
+void ST7789Display::turnOff() {
+  digitalWrite(PIN_TFT_VDD_CTL, HIGH);
+  digitalWrite(PIN_TFT_LEDA_CTL, HIGH);
+  digitalWrite(PIN_TFT_RST, LOW);
+  // digitalWrite(PIN_TFT_VDD_CTL, LOW);
+  // digitalWrite(PIN_TFT_LEDA_CTL, LOW);
+  _isOn = false;
+}
+
+void ST7789Display::clear() {
+  display.fillScreen(ST77XX_BLACK);
+}
+
+void ST7789Display::startFrame(Color bkg) {
+  display.fillScreen(0x00);
+  display.setTextColor(ST77XX_WHITE);
+  display.setTextSize(2);
+  display.cp437(true);         // Use full 256 char 'Code Page 437' font
+}
+
+void ST7789Display::setTextSize(int sz) {
+  display.setTextSize(sz);
+}
+
+void ST7789Display::setColor(Color c) {
+  _color = (c == LIGHT) ? ST77XX_WHITE : ST77XX_BLACK;
+  display.setTextColor(_color);
+}
+
+void ST7789Display::setCursor(int x, int y) {
+  display.setCursor(x, y);
+}
+
+void ST7789Display::print(const char* str) {
+  display.print(str);
+}
+
+void ST7789Display::fillRect(int x, int y, int w, int h) {
+  display.fillRect(x, y, w, h, _color);
+}
+
+void ST7789Display::drawRect(int x, int y, int w, int h) {
+  display.drawRect(x, y, w, h, _color);
+}
+
+void ST7789Display::drawXbm(int x, int y, const uint8_t* bits, int w, int h) {
+  display.drawBitmap(x, y, bits, w, h, ST77XX_BLUE);
+}
+
+void ST7789Display::endFrame() {
+  // display.display();
+}

--- a/src/helpers/ui/ST7789Display.cpp
+++ b/src/helpers/ui/ST7789Display.cpp
@@ -1,3 +1,5 @@
+#ifdef ST7789
+
 #include "ST7789Display.h"
 
 bool ST7789Display::i2c_probe(TwoWire& wire, uint8_t addr) {
@@ -59,7 +61,32 @@ void ST7789Display::setTextSize(int sz) {
 }
 
 void ST7789Display::setColor(Color c) {
-  _color = (c == LIGHT) ? ST77XX_WHITE : ST77XX_BLACK;
+  switch (c) {
+    case DisplayDriver::DARK :
+      _color = ST77XX_BLACK;
+      break;
+    case DisplayDriver::LIGHT : 
+      _color = ST77XX_WHITE;
+      break;
+    case DisplayDriver::RED : 
+      _color = ST77XX_RED;
+      break;
+    case DisplayDriver::GREEN : 
+      _color = ST77XX_GREEN;
+      break;
+    case DisplayDriver::BLUE : 
+      _color = ST77XX_BLUE;
+      break;
+    case DisplayDriver::YELLOW : 
+      _color = ST77XX_YELLOW;
+      break;
+    case DisplayDriver::ORANGE : 
+      _color = ST77XX_ORANGE;
+      break;
+    default:
+      _color = ST77XX_WHITE;
+      break;
+  }
   display.setTextColor(_color);
 }
 
@@ -80,9 +107,11 @@ void ST7789Display::drawRect(int x, int y, int w, int h) {
 }
 
 void ST7789Display::drawXbm(int x, int y, const uint8_t* bits, int w, int h) {
-  display.drawBitmap(x, y, bits, w, h, ST77XX_BLUE);
+  display.drawBitmap(x, y, bits, w, h, _color);
 }
 
 void ST7789Display::endFrame() {
   // display.display();
 }
+
+#endif

--- a/src/helpers/ui/ST7789Display.h
+++ b/src/helpers/ui/ST7789Display.h
@@ -9,7 +9,7 @@
 class ST7789Display : public DisplayDriver {
   Adafruit_ST7789 display;
   bool _isOn;
-  uint8_t _color;
+  uint16_t _color;
 
   bool i2c_probe(TwoWire& wire, uint8_t addr);
 public:

--- a/src/helpers/ui/ST7789Display.h
+++ b/src/helpers/ui/ST7789Display.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "DisplayDriver.h"
+#include <Wire.h>
+#include <SPI.h>
+#include <Adafruit_GFX.h>
+#include <Adafruit_ST7789.h>
+
+class ST7789Display : public DisplayDriver {
+  Adafruit_ST7789 display;
+  bool _isOn;
+  uint8_t _color;
+
+  bool i2c_probe(TwoWire& wire, uint8_t addr);
+public:
+  ST7789Display() : DisplayDriver(135, 240), display(&SPI1, PIN_TFT_CS, PIN_TFT_DC, PIN_TFT_RST) { _isOn = false; }
+//  ST7789Display() : DisplayDriver(135, 240), display(PIN_TFT_CS, PIN_TFT_DC, PIN_TFT_SDA, PIN_TFT_SCL, PIN_TFT_RST) { _isOn = false; }
+  bool begin();
+
+  bool isOn() override { return _isOn; }
+  void turnOn() override;
+  void turnOff() override;
+  void clear() override;
+  void startFrame(Color bkg = DARK) override;
+  void setTextSize(int sz) override;
+  void setColor(Color c) override;
+  void setCursor(int x, int y) override;
+  void print(const char* str) override;
+  void fillRect(int x, int y, int w, int h) override;
+  void drawRect(int x, int y, int w, int h) override;
+  void drawXbm(int x, int y, const uint8_t* bits, int w, int h) override;
+  void endFrame() override;
+};

--- a/variants/heltec_v2/platformio.ini
+++ b/variants/heltec_v2/platformio.ini
@@ -32,7 +32,7 @@ build_flags =
 ;  -D MESH_DEBUG=1
 build_src_filter = ${Heltec_lora32_v2.build_src_filter}
   +<../examples/simple_repeater>
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
 lib_deps =
   ${Heltec_lora32_v2.lib_deps}
   ${esp32_ota.lib_deps}
@@ -50,7 +50,7 @@ build_flags =
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${Heltec_lora32_v2.build_src_filter}
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_room_server>
 lib_deps =
   ${Heltec_lora32_v2.lib_deps}
@@ -81,7 +81,7 @@ build_flags =
 ; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
 build_src_filter = ${Heltec_lora32_v2.build_src_filter}
   +<helpers/esp32/*.cpp>
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/companion_radio>
 lib_deps =
   ${Heltec_lora32_v2.lib_deps}
@@ -102,7 +102,7 @@ build_flags =
 ;  -D MESH_DEBUG=1
 build_src_filter = ${Heltec_lora32_v2.build_src_filter}
   +<helpers/esp32/*.cpp>
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/companion_radio>
 lib_deps =
   ${Heltec_lora32_v2.lib_deps}

--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -34,7 +34,7 @@ build_flags =
   -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${Heltec_lora32_v3.build_src_filter}
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_repeater>
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
@@ -53,7 +53,7 @@ build_flags =
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${Heltec_lora32_v3.build_src_filter}
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_room_server>
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
@@ -85,7 +85,7 @@ build_flags =
 ; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
 ; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
 build_src_filter = ${Heltec_lora32_v3.build_src_filter}
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/companion_radio>
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
@@ -105,7 +105,7 @@ build_flags =
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${Heltec_lora32_v3.build_src_filter}
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio>
 lib_deps =
@@ -127,7 +127,7 @@ build_flags =
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${Heltec_lora32_v3.build_src_filter}
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio>
 lib_deps =

--- a/variants/lilygo_t3s3/platformio.ini
+++ b/variants/lilygo_t3s3/platformio.ini
@@ -45,7 +45,7 @@ build_flags =
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${LilyGo_T3S3_sx1262.build_src_filter}
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_repeater>
 lib_deps =
   ${LilyGo_T3S3_sx1262.lib_deps}
@@ -78,7 +78,7 @@ build_flags =
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${LilyGo_T3S3_sx1262.build_src_filter}
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_room_server>
 lib_deps =
   ${LilyGo_T3S3_sx1262.lib_deps}
@@ -96,7 +96,7 @@ build_flags =
 ; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
 ; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
 build_src_filter = ${LilyGo_T3S3_sx1262.build_src_filter}
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/companion_radio>
 lib_deps =
   ${LilyGo_T3S3_sx1262.lib_deps}
@@ -117,7 +117,7 @@ build_flags =
 ;  -D MESH_DEBUG=1
 build_src_filter = ${LilyGo_T3S3_sx1262.build_src_filter}
   +<helpers/esp32/*.cpp>
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/companion_radio>
 lib_deps =
   ${LilyGo_T3S3_sx1262.lib_deps}

--- a/variants/lilygo_tbeam/platformio.ini
+++ b/variants/lilygo_tbeam/platformio.ini
@@ -39,7 +39,7 @@ build_flags =
 ;  -D MESH_DEBUG=1
 build_src_filter = ${LilyGo_TBeam.build_src_filter}
   +<helpers/esp32/*.cpp>
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/companion_radio>
 lib_deps =
   ${LilyGo_TBeam.lib_deps}
@@ -57,7 +57,7 @@ build_flags =
   -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${LilyGo_TBeam.build_src_filter}
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_repeater>
 lib_deps =
   ${LilyGo_TBeam.lib_deps}

--- a/variants/lilygo_tlora_v2_1/platformio.ini
+++ b/variants/lilygo_tlora_v2_1/platformio.ini
@@ -34,7 +34,7 @@ lib_deps =
 [env:LilyGo_TLora_V2_1_1_6_Repeater]
 extends = LilyGo_TLora_V2_1_1_6
 build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter}
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_repeater>
 build_flags =
   ${LilyGo_TLora_V2_1_1_6.build_flags}
@@ -58,7 +58,7 @@ build_flags =
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter}
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_repeater>
 lib_deps =
   ${LilyGo_TLora_V2_1_1_6.lib_deps}
@@ -75,7 +75,7 @@ build_flags =
 ; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
 ; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
 build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter}
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/companion_radio>
 lib_deps =
   ${LilyGo_TLora_V2_1_1_6.lib_deps}
@@ -95,7 +95,7 @@ build_flags =
 ;  -D MESH_DEBUG=1
 build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter}
   +<helpers/esp32/*.cpp>
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/companion_radio>
 lib_deps =
   ${LilyGo_TLora_V2_1_1_6.lib_deps}
@@ -104,7 +104,7 @@ lib_deps =
 [env:LilyGo_TLora_V2_1_1_6_room_server]
 extends = LilyGo_TLora_V2_1_1_6
 build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter}
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_room_server>
 build_flags =
   ${LilyGo_TLora_V2_1_1_6.build_flags}

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -34,7 +34,7 @@ build_flags =
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${rak4631.build_src_filter}
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_repeater>
 
 [env:RAK_4631_room_server]
@@ -50,7 +50,7 @@ build_flags =
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${rak4631.build_src_filter}
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_room_server>
 
 [env:RAK_4631_companion_radio_usb]
@@ -65,7 +65,7 @@ build_flags =
 ; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
 ; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
 build_src_filter = ${rak4631.build_src_filter}
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<../examples/companion_radio>
 lib_deps =
   ${rak4631.lib_deps}
@@ -85,7 +85,7 @@ build_flags =
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${rak4631.build_src_filter}
-  +<helpers/ui/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
   +<helpers/nrf52/*.cpp>
   +<../examples/companion_radio>
 lib_deps =

--- a/variants/t114/platformio.ini
+++ b/variants/t114/platformio.ini
@@ -60,9 +60,6 @@ build_flags =
 extends = Heltec_t114
 build_flags =
   ${Heltec_t114.build_flags}
-  -I src/helpers/ui
-  -D ST7789
-  -D DISPLAY_CLASS=ST7789Display
   -D MAX_CONTACTS=100
   -D MAX_GROUP_CHANNELS=8
   -D BLE_PIN_CODE=123456
@@ -74,11 +71,20 @@ build_flags =
 build_src_filter = ${Heltec_t114.build_src_filter}
   +<helpers/nrf52/*.cpp>
   +<../examples/companion_radio/main.cpp>
-  +<../examples/companion_radio/UITask.cpp>
-  +<helpers/ui/ST7789Display.cpp>
 lib_deps =
   ${Heltec_t114.lib_deps}
   densaugeo/base64 @ ~1.4.0
+
+[env:Heltec_t114_companion_radio_ble_screen]
+extends = env:Heltec_t114_companion_radio_ble
+build_flags = ${env:Heltec_t114_companion_radio_ble.build_flags}
+  -I src/helpers/ui
+  -D ST7789
+  -D DISPLAY_CLASS=ST7789Display
+build_src_filter = ${env:Heltec_t114_companion_radio_ble.build_src_filter}
+  +<../examples/companion_radio/UITask.cpp>
+  +<helpers/ui/ST7789Display.cpp>
+lib_deps = ${env:Heltec_t114_companion_radio_ble.lib_deps}
   adafruit/Adafruit ST7735 and ST7789 Library @ ^1.11.0
 
 [env:Heltec_t114_companion_radio_usb]

--- a/variants/t114/platformio.ini
+++ b/variants/t114/platformio.ini
@@ -60,6 +60,9 @@ build_flags =
 extends = Heltec_t114
 build_flags =
   ${Heltec_t114.build_flags}
+  -I src/helpers/ui
+  -D ST7789
+  -D DISPLAY_CLASS=ST7789Display
   -D MAX_CONTACTS=100
   -D MAX_GROUP_CHANNELS=8
   -D BLE_PIN_CODE=123456
@@ -71,9 +74,12 @@ build_flags =
 build_src_filter = ${Heltec_t114.build_src_filter}
   +<helpers/nrf52/*.cpp>
   +<../examples/companion_radio/main.cpp>
+  +<../examples/companion_radio/UITask.cpp>
+  +<helpers/ui/ST7789Display.cpp>
 lib_deps =
   ${Heltec_t114.lib_deps}
   densaugeo/base64 @ ~1.4.0
+  adafruit/Adafruit ST7735 and ST7789 Library @ ^1.11.0
 
 [env:Heltec_t114_companion_radio_usb]
 extends = Heltec_t114

--- a/variants/t114/variant.h
+++ b/variants/t114/variant.h
@@ -80,11 +80,13 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Builtin buttons
 
-#define PIN_BUTTON1             (5)
+#define PIN_BUTTON1             (42)
 #define BUTTON_PIN              PIN_BUTTON1
 
-#define PIN_BUTTON2             (11)
-#define BUTTON_PIN2             PIN_BUTTON2
+// #define PIN_BUTTON2             (11)
+// #define BUTTON_PIN2             PIN_BUTTON2
+
+#define PIN_USER_BTN            BUTTON_PIN
 
 #define EXTERNAL_FLASH_DEVICES MX25R1635F
 #define EXTERNAL_FLASH_USE_QSPI
@@ -108,3 +110,14 @@
 // Buzzer
 
 #define PIN_BUZZER              (46)
+
+
+////////////////////////////////////////////////////////////////////////////////
+// TFT
+#define PIN_TFT_SCL             (40)
+#define PIN_TFT_SDA             (41)
+#define PIN_TFT_RST             (2)
+#define PIN_TFT_VDD_CTL         (3)
+#define PIN_TFT_LEDA_CTL        (15)
+#define PIN_TFT_CS              (11)
+#define PIN_TFT_DC              (12)


### PR DESCRIPTION
* Added a display class for ST7789 (color TFT screen used on T114)
* Added a target for compiling T114 BLE Companion using the screen (some T114 don't have screen)
* modified ui class so refresh is done only if screen has been modified (ST7789 is slow to refresh and doesn't have double buffer, it will also be necessary for e-ink screens)
* added some colors
* ensure that the new code is not compiled against a SSD1306 based target

Code has been tested on T114, but also on a SSD1306 target (heltec_v3)
