### PR TITLE
Fix RAK4631 builds after addition of Xio nRF52 board

### DIFF
--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -16,7 +16,7 @@ build_flags = ${nrf52840_base.build_flags}
   -D SX126X_CURRENT_LIMIT=130
   -D SX126X_RX_BOOSTED_GAIN=1
 build_src_filter = ${nrf52840_base.build_src_filter}
-  +<helpers/nrf52/*.cpp>
+  +<helpers/nrf52/RAK4631Board.cpp>
   +<../variants/rak4631>
 lib_deps =
   ${nrf52840_base.lib_deps}
@@ -86,7 +86,7 @@ build_flags =
 ;  -D MESH_DEBUG=1
 build_src_filter = ${rak4631.build_src_filter}
   +<helpers/ui/*.cpp>
-  +<helpers/nrf52/*.cpp>
+  +<helpers/nrf52/SerialBLEInterface.cpp>
   +<../examples/companion_radio>
 lib_deps =
   ${rak4631.lib_deps}


### PR DESCRIPTION
This PR fixes RAK4631 builds, which were broken after the Xiao nRF52 board support was merged in from #185.

Builds failed due to the wildcard include `+<helpers/nrf52/*.cpp>`, including the `helpers/nrf52/XiaoNrf52Board.cpp`.

Have tested building all RAK4631 variants, and they're now compiling :)