### PR TITLE
permit access to rx_boosted_mode at runtime for LR1110 

### DIFF
--- a/src/helpers/CustomLR1110Wrapper.h
+++ b/src/helpers/CustomLR1110Wrapper.h
@@ -27,4 +27,5 @@ public:
 
   float getLastRSSI() const override { return ((CustomLR1110 *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomLR1110 *)_radio)->getSNR(); }
+  int16_t setRxBoostedGainMode(bool en) { return ((CustomLR1110 *)_radio)->setRxBoostedGainMode(en); };
 };


### PR DESCRIPTION
for dpm tests on that setting

The objective is to be able to toggle dynamically this setting. On the T1000, 

I've been able to get significant battery improvements by disabling rx_boost. But this is interesting to get a little more range ...