### PR TITLE
support for xiao expansion board screen

### DIFF
--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -13,6 +13,8 @@ build_flags = ${esp32_base.build_flags}
   -D P_LORA_SCLK=7
   -D P_LORA_MISO=8
   -D P_LORA_MOSI=9
+  -D PIN_USER_BTN=21
+  -D PIN_STATUS_LED=48
   -D SX126X_DIO2_AS_RF_SWITCH=true
   -D SX126X_DIO3_TCXO_VOLTAGE=1.8
   -D SX126X_CURRENT_LIMIT=130
@@ -105,3 +107,25 @@ build_src_filter = ${Xiao_S3_WIO.build_src_filter}
 lib_deps =
   ${Xiao_S3_WIO.lib_deps}
   densaugeo/base64 @ ~1.4.0
+
+[env:Xiao_S3_WIO_expansion_companion_radio_ble]
+extends = Xiao_S3_WIO
+build_flags =
+  ${Xiao_S3_WIO.build_flags}
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=8
+  -D BLE_PIN_CODE=123456
+  -D DISPLAY_CLASS=SSD1306Display
+;  -D BLE_DEBUG_LOGGING=1
+;  -D ENABLE_PRIVATE_KEY_IMPORT=1
+;  -D ENABLE_PRIVATE_KEY_EXPORT=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Xiao_S3_WIO.build_src_filter}
+  +<helpers/ui/SSD1306Display.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/companion_radio>
+lib_deps =
+  ${Xiao_S3_WIO.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+  adafruit/Adafruit SSD1306 @ ^2.5.13

--- a/variants/xiao_s3_wio/target.cpp
+++ b/variants/xiao_s3_wio/target.cpp
@@ -22,7 +22,9 @@ AutoDiscoverRTCClock rtc_clock(fallback_clock);
 bool radio_init() {
   fallback_clock.begin();
   rtc_clock.begin(Wire);
-  
+  pinMode(21, INPUT);
+  pinMode(48, OUTPUT);
+
 #ifdef SX126X_DIO3_TCXO_VOLTAGE
   float tcxo = SX126X_DIO3_TCXO_VOLTAGE;
 #else


### PR DESCRIPTION
Adds support for the xiao expansion board

![image](https://github.com/user-attachments/assets/1174b800-049c-484e-abdf-637d1db38854)

user button and led are used from the sx1262 module ...