### PR TITLE
xiao-nrf keep vbat_en to low to prevent issues ...

### DIFF
--- a/src/helpers/nrf52/XiaoNrf52Board.h
+++ b/src/helpers/nrf52/XiaoNrf52Board.h
@@ -49,20 +49,16 @@ public:
     // Please read befor going further ;)
     // https://wiki.seeedstudio.com/XIAO_BLE#q3-what-are-the-considerations-when-using-xiao-nrf52840-sense-for-battery-charging
 
-    pinMode(BAT_NOT_CHARGING, INPUT);
-    if (digitalRead(BAT_NOT_CHARGING) == HIGH) {
-      int adcvalue = 0;
-      analogReadResolution(12);
-      analogReference(AR_INTERNAL_3_0);  
-      digitalWrite(VBAT_ENABLE, LOW);
-      delay(10);
-      adcvalue = analogRead(PIN_VBAT);
-      digitalWrite(VBAT_ENABLE, HIGH);
-      return (adcvalue * ADC_MULTIPLIER * AREF_VOLTAGE) / 4.096;
-    } else {
-      digitalWrite(VBAT_ENABLE, HIGH); // ensures high !
-      return 4200; // charging value
-    }
+    // We can't drive VBAT_ENABLE to HIGH as long 
+    // as we don't know wether we are charging or not ...
+    // this is a 3mA loss (4/1500)
+    digitalWrite(VBAT_ENABLE, LOW);
+    int adcvalue = 0;
+    analogReadResolution(12);
+    analogReference(AR_INTERNAL_3_0);  
+    delay(10);
+    adcvalue = analogRead(PIN_VBAT);
+    return (adcvalue * ADC_MULTIPLIER * AREF_VOLTAGE) / 4.096;
   }
 
   const char* getManufacturerName() const override {

--- a/variants/xiao_nrf52/variant.cpp
+++ b/variants/xiao_nrf52/variant.cpp
@@ -60,11 +60,19 @@ void initVariant()
     // Disable reading of the BAT voltage.
     // https://wiki.seeedstudio.com/XIAO_BLE#q3-what-are-the-considerations-when-using-xiao-nrf52840-sense-for-battery-charging
     pinMode(VBAT_ENABLE, OUTPUT);
-    digitalWrite(VBAT_ENABLE, HIGH);
+    //digitalWrite(VBAT_ENABLE, HIGH); 
+    // This was taken from Seeed github butis not coherent with the doc, 
+    // VBAT_ENABLE should be kept to LOW to protect P0.14, (1500/500)*(4.2-3.3)+3.3 = 3.9V > 3.6V
+    // This induces a 3mA current in the resistors :( but it's better than burning the nrf
+    digitalWrite(VBAT_ENABLE, LOW);
 
-    // Low charging current.
+    // Low charging current (50mA)
     // https://wiki.seeedstudio.com/XIAO_BLE#battery-charging-current
-    pinMode(PIN_CHARGING_CURRENT, INPUT);
+    //pinMode(PIN_CHARGING_CURRENT, INPUT);
+
+    // High charging current (100mA)
+    pinMode(PIN_CHARGING_CURRENT, OUTPUT);
+    digitalWrite(PIN_CHARGING_CURRENT, LOW);
 
     pinMode(PIN_QSPI_CS, OUTPUT);
     digitalWrite(PIN_QSPI_CS, HIGH);


### PR DESCRIPTION
This is about reading the battery monitoring on xiao-nrfs ...

Following https://wiki.seeedstudio.com/XIAO_BLE/#q3-what-are-the-considerations-when-using-xiao-nrf52840-sense-for-battery-charging, in order to be cautious, I did follow what was in the ```variant.cpp``` file proposed by seeed (see : https://github.com/Seeed-Studio/Adafruit_nRF52_Arduino/blob/557f68f23259b8e1756dbfd99cc322d678dbc063/variants/Seeed_XIAO_nRF52840/variant.cpp#L60-L63). But I was puzzled by what was done, because it was in contradiction with the doc.

I took time to study the cases ... it appears that, with a VBAT of 4.2V
 - if READ_BAT is set to high, voltage at P0.31 will be at 3.9V (assuming a divider of 2/3)
 - if READ_BAT is set to low, voltage will be kept at 1/3 of VBAT, so it is ok
I think that they have swaped the two resistors, because in this case, figures are much better ...

So it appears, we shouldn't keep READ_BAT at an high level, as it would be complicated to check for levels and state of the charger (specifically for a port, I mean ...), to then put it at low. But it seems, by default, it is what designs based on seeed files do, so maybe it is ok.

I propose to keep READ_BAT at a low level all the time ... it will generate a current loss of 3mA (max), which is not negligible, but we can live with it ...

The biggest issue would be not to drive READ_BAT at all ! and that won't happen ...

I've also set the charging current to 100mA (it was kept at 50mA) I don't see the problem ...