### PR TITLE
xiao_nrf52-missing_targets

### DIFF
--- a/variants/xiao_nrf52/platformio.ini
+++ b/variants/xiao_nrf52/platformio.ini
@@ -55,6 +55,25 @@ lib_deps =
   ${Xiao_nrf52.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
+[env:Xiao_nrf52_companion_radio_usb]
+extends = Xiao_nrf52
+build_flags =
+  ${Xiao_nrf52.build_flags}
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=8
+;  -D BLE_PIN_CODE=123456
+;  -D BLE_DEBUG_LOGGING=1
+;  -D ENABLE_PRIVATE_KEY_IMPORT=1
+;  -D ENABLE_PRIVATE_KEY_EXPORT=1
+  -D MESH_PACKET_LOGGING=1
+  -D MESH_DEBUG=1
+build_src_filter = ${Xiao_nrf52.build_src_filter}
+  +<helpers/nrf52/SerialBLEInterface.cpp>
+  +<../examples/companion_radio/main.cpp>
+lib_deps =
+  ${Xiao_nrf52.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
 [env:Xiao_nrf52_alt_pinout_companion_radio_ble]
 extends = env:Xiao_nrf52_companion_radio_ble
 build_flags = 
@@ -79,3 +98,16 @@ extends = env:Xiao_nrf52_repeater
 build_flags = 
   ${env:Xiao_nrf52_repeater.build_flags}
   -D SX1262_XIAO_S3_VARIANT
+
+[env:Xiao_nrf52_room_server]
+extends = Xiao_nrf52
+build_flags =
+  ${Xiao_nrf52.build_flags}
+  -D ADVERT_NAME='"Xiao_nrf52 Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Xiao_nrf52.build_src_filter}
+  +<../examples/simple_room_server/main.cpp>


### PR DESCRIPTION
add room_server, and companion_radio_usb targets