### PR TITLE
companion_radio: greatly reduce the status LED usage

### DIFF
--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -4,6 +4,12 @@
 
 #define AUTO_OFF_MILLIS   15000   // 15 seconds
 
+#ifdef PIN_STATUS_LED
+#define LED_ON_MILLIS     20
+#define LED_ON_MSG_MILLIS 200
+#define LED_CYCLE_MILLIS  4000
+#endif
+
 #ifndef USER_BTN_PRESSED
 #define USER_BTN_PRESSED LOW
 #endif
@@ -135,22 +141,21 @@ void UITask::userLedHandler() {
 #ifdef PIN_STATUS_LED
   static int state = 0;
   static int next_change = 0;
+  static int last_increment = 0;
+
   int cur_time = millis();
   if (cur_time > next_change) {
     if (state == 0) {
-      state = 1; // led on, short = unread msg
+      state = 1;
       if (_msgcount > 0) {
-        next_change = cur_time + 500;
+        last_increment = LED_ON_MSG_MILLIS;
       } else {
-        next_change = cur_time + 2000;
+        last_increment = LED_ON_MILLIS;
       }
+      next_change = cur_time + last_increment;
     } else {
       state = 0;
-      if (_board->getBattMilliVolts() > 3800) {
-        next_change = cur_time + 2000;
-      } else {
-        next_change = cur_time + 4000; // 4s blank if bat level low
-      }
+      next_change = cur_time + LED_CYCLE_MILLIS - last_increment;
     }
     digitalWrite(PIN_STATUS_LED, state);
   }


### PR DESCRIPTION
If the companion device has a status LED it typically stays on for 2s and then off for 2s.

This PR greatly reduces the LED activity, by implementing the following pattern:

```
// No messages
|++|--------|++|--------|++|--------|...
0s 0.02s    4s 4.02s    8s 8.02s    12s
```

```
// With messages
|++++|------|++++|------|++++|------|...
0s   0.2s   4s   4.2s   8s   8.2s   12s
```

## Advantages over current implementation:
- The LED is typically ON 0.5% of the time instead of 50% of the time
- The LED cycle is always exactly 4 seconds, while previously it was variable at 4 seconds (no messages) or 2.5 seconds (messages)
- Since the cycle is slower, and the LED is ON for a very short time, we avoid polling the battery status each cycle

Tested on T1000-E

Fixes #200 