### PR TITLE
remove pin mode setup from uitask

### DIFF
--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -43,10 +43,6 @@ void UITask::begin(DisplayDriver* display, const char* node_name, const char* bu
     *dash = 0;
   }
 
-  #ifdef PIN_USER_BTN
-    pinMode(PIN_USER_BTN, INPUT);
-  #endif
-
   // v1.2.3 (1 Jan 2025)
   sprintf(_version_info, "%s (%s)", version, build_date);
 }


### PR DESCRIPTION
This PR removes the `pinMode` call from `UITask.cpp`. Fixes #215, if `INPUT` is needed instead of `INPUT_PULLUP` for a different board type, this should be set in the board file instead of `UITask.cpp`.