### PR TITLE
build.sh: detect if we have nrf52 by probing for *.zip and *.hex output files

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -58,7 +58,7 @@ build_firmware() {
   fi
 
   # build .uf2 for nrf52 boards
-  if [[ $1 == *"RAK_4631"* || $1 == *"t1000e"* || $1 == *"t114"* || $1 == *"T-Echo"* || $1 == *"Faketec"* || $1 == *"ProMicro"* ]]; then
+  if [[ -f .pio/build/$1/firmware.zip && -f .pio/build/$1/firmware.hex ]]; then
     python bin/uf2conv/uf2conv.py .pio/build/$1/firmware.hex -c -o .pio/build/$1/firmware.uf2 -f 0xADA52840
   fi
 


### PR DESCRIPTION
as we are adding nrf52 targets often and always forget to update build.sh uf2 generation to match the target, this should fix that for good.