### PR TITLE
Add a way to easily define blinking patterns based on device state

### DIFF
--- a/examples/companion_radio/BlinkPattern.cpp
+++ b/examples/companion_radio/BlinkPattern.cpp
@@ -1,0 +1,39 @@
+#include "BlinkPattern.h"
+
+BlinkPattern::BlinkPattern(bool initial_state, const unsigned long* pattern, size_t size)
+  :_initial_state(initial_state)
+{
+  _pattern_size = size > 8 ? 8 : size;
+
+  for (size_t i = 0; i < _pattern_size; ++i) {
+    _pattern[i] = pattern[i];
+  }
+}
+
+void BlinkPattern::start(unsigned long t0) {
+  _pattern_idx = _pattern_size - 1;
+  _state = !_initial_state;
+  _next_change = t0;
+}
+
+bool BlinkPattern::loop(unsigned long t) {
+  if (t >= _next_change) {
+    size_t next_idx = (_pattern_idx + 1) % _pattern_size;
+    _next_change += _pattern[next_idx];
+
+    if (next_idx != 0) {
+      _next_change -= _pattern[_pattern_idx];
+    }
+
+    _state = !_state;
+    _pattern_idx = next_idx;
+
+    return true;
+  }
+
+  return false;
+}
+
+bool BlinkPattern::state() const {
+  return _state;
+}

--- a/examples/companion_radio/BlinkPattern.h
+++ b/examples/companion_radio/BlinkPattern.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <stddef.h>
+
+class BlinkPattern {
+  bool _initial_state = false; // state of the led at the beginning of the periodic pattern
+  bool _state = false; // current state of the led
+  unsigned long _pattern[8]; // times at which the led state changes [t0, t1, t2, ...]
+  size_t _pattern_size;
+  size_t _pattern_idx = 0;
+
+  int _next_change = 0;
+
+public:
+
+  BlinkPattern(bool initial_state, const unsigned long* pattern, size_t size);
+
+  void start(unsigned long t0);
+  bool loop(unsigned long t);
+  bool state() const;
+};

--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -5,9 +5,11 @@
 #define AUTO_OFF_MILLIS   15000   // 15 seconds
 
 #ifdef PIN_STATUS_LED
-#define LED_ON_MILLIS     20
-#define LED_ON_MSG_MILLIS 200
-#define LED_CYCLE_MILLIS  4000
+#include "BlinkPattern.h"
+BlinkPattern IDLE_BLINK_PATTERN(true, (unsigned long[2]){10, 4000}, 2);
+BlinkPattern MESSAGE_BLINK_PATTERN(true, (unsigned long[2]){400, 4000}, 2);
+BlinkPattern CONNECTED_BLINK_PATTERN(true, (unsigned long[4]){10, 250, 260, 4000}, 4);
+BlinkPattern PAIRING_BLINK_PATTERN(true, (unsigned long[2]){1500, 2000}, 2);
 #endif
 
 #ifndef USER_BTN_PRESSED
@@ -31,8 +33,9 @@ static const uint8_t meshcore_logo [] PROGMEM = {
     0xe3, 0xe3, 0x8f, 0xff, 0x1f, 0xfc, 0x3c, 0x0e, 0x1f, 0xf8, 0xff, 0xf8, 0x70, 0x3c, 0x7f, 0xf8, 
 };
 
-void UITask::begin(DisplayDriver* display, const char* node_name, const char* build_date, const char* firmware_version, uint32_t pin_code) {
+void UITask::begin(DisplayDriver* display, BaseSerialInterface* serial, const char* node_name, const char* build_date, const char* firmware_version, uint32_t pin_code) {
   _display = display;
+  _serial = serial;
   _auto_off = millis() + AUTO_OFF_MILLIS;
   clearMsgPreview();
   _node_name = node_name;
@@ -135,25 +138,33 @@ void UITask::renderCurrScreen() {
 
 void UITask::userLedHandler() {
 #ifdef PIN_STATUS_LED
-  static int state = 0;
-  static int next_change = 0;
-  static int last_increment = 0;
+  static BlinkPattern* blinker = NULL;
 
   int cur_time = millis();
-  if (cur_time > next_change) {
-    if (state == 0) {
-      state = 1;
-      if (_msgcount > 0) {
-        last_increment = LED_ON_MSG_MILLIS;
-      } else {
-        last_increment = LED_ON_MILLIS;
-      }
-      next_change = cur_time + last_increment;
-    } else {
-      state = 0;
-      next_change = cur_time + LED_CYCLE_MILLIS - last_increment;
+
+  if (_serial && _serial->isConnected()) {
+    // Connected to companion app
+    if (blinker != &CONNECTED_BLINK_PATTERN) {
+      blinker = &CONNECTED_BLINK_PATTERN;
+      blinker->start(cur_time);
     }
-    digitalWrite(PIN_STATUS_LED, state);
+  } else if (_msgcount > 0) {
+    // Pending messages
+    if (blinker != &MESSAGE_BLINK_PATTERN) {
+        blinker = &MESSAGE_BLINK_PATTERN;
+        blinker->start(cur_time);
+    }
+  } else {
+    // Idle
+    if (blinker != &IDLE_BLINK_PATTERN) {
+      blinker = &IDLE_BLINK_PATTERN;
+      blinker->start(cur_time);
+    }
+  }
+
+  bool change = blinker->loop(cur_time);
+  if (change) {
+    digitalWrite(PIN_STATUS_LED, blinker->state());
   }
 #endif
 }

--- a/examples/companion_radio/UITask.h
+++ b/examples/companion_radio/UITask.h
@@ -2,11 +2,13 @@
 
 #include <MeshCore.h>
 #include <helpers/ui/DisplayDriver.h>
+#include <helpers/BaseSerialInterface.h>
 #include <stddef.h>
 
 class UITask {
   DisplayDriver* _display;
   mesh::MainBoard* _board;
+  BaseSerialInterface* _serial;
   unsigned long _next_refresh, _auto_off;
   bool _connected;
   uint32_t _pin_code;
@@ -23,11 +25,11 @@ class UITask {
 
 public:
 
-  UITask(mesh::MainBoard* board) : _board(board), _display(NULL) {
+  UITask(mesh::MainBoard* board) : _board(board), _display(NULL), _serial(NULL) {
       _next_refresh = 0; 
       _connected = false;
   }
-  void begin(DisplayDriver* display, const char* node_name, const char* build_date, const char* firmware_version, uint32_t pin_code);
+  void begin(DisplayDriver* display, BaseSerialInterface* serial, const char* node_name, const char* build_date, const char* firmware_version, uint32_t pin_code);
 
   void setHasConnection(bool connected) { _connected = connected; }
   bool hasDisplay() const { return _display != NULL; }

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -867,6 +867,7 @@ public:
 
   const char* getNodeName() { return _prefs.node_name; }
   uint32_t getBLEPin() { return _active_ble_pin; }
+  BaseSerialInterface* getSerialInterface() { return _serial; }
 
   void startInterface(BaseSerialInterface& serial) {
     _serial = &serial;
@@ -1605,7 +1606,7 @@ void setup() {
 #endif
 
 #ifdef HAS_UI
-  ui_task.begin(disp, the_mesh.getNodeName(), FIRMWARE_BUILD_DATE, FIRMWARE_VERSION, the_mesh.getBLEPin());
+  ui_task.begin(disp, the_mesh.getSerialInterface(), the_mesh.getNodeName(), FIRMWARE_BUILD_DATE, FIRMWARE_VERSION, the_mesh.getBLEPin());
 #endif
 }
 


### PR DESCRIPTION
This PR adds an helper class to easily create blinking patterns.
Depending on the state of the companion device, we swap out the active blinking pattern.

4 patterns implemented so far:
- Idle (blink once for 10ms every 4 seconds)
- Pending messages (blink once for 400ms every 4 seconds)
- Connected to app (quickly blink twice for 10ms every 4 seconds)
- Pairing mode (not used yet, stay on for 1.5s every 2 seconds)

Tested on the t1000e