### PR TITLE
add display to companion_radio_ble target

### DIFF
--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -79,17 +79,20 @@ build_flags =
   -D MAX_CONTACTS=100
   -D MAX_GROUP_CHANNELS=8
   -D BLE_PIN_CODE=123456
+  -D DISPLAY_CLASS=SSD1306Display
 ;  -D BLE_DEBUG_LOGGING=1
 ;  -D ENABLE_PRIVATE_KEY_IMPORT=1
 ;  -D ENABLE_PRIVATE_KEY_EXPORT=1
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${Xiao_S3_WIO.build_src_filter}
+  +<helpers/ui/SSD1306Display.cpp>
   +<helpers/esp32/*.cpp>
-  +<../examples/companion_radio/main.cpp>
+  +<../examples/companion_radio>
 lib_deps =
   ${Xiao_S3_WIO.lib_deps}
   densaugeo/base64 @ ~1.4.0
+  adafruit/Adafruit SSD1306 @ ^2.5.13
 
 [env:Xiao_S3_WIO_companion_radio_serial]
 extends = Xiao_S3_WIO
@@ -108,24 +111,4 @@ lib_deps =
   ${Xiao_S3_WIO.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
-[env:Xiao_S3_WIO_expansion_companion_radio_ble]
-extends = Xiao_S3_WIO
-build_flags =
-  ${Xiao_S3_WIO.build_flags}
-  -D MAX_CONTACTS=100
-  -D MAX_GROUP_CHANNELS=8
-  -D BLE_PIN_CODE=123456
-  -D DISPLAY_CLASS=SSD1306Display
-;  -D BLE_DEBUG_LOGGING=1
-;  -D ENABLE_PRIVATE_KEY_IMPORT=1
-;  -D ENABLE_PRIVATE_KEY_EXPORT=1
-;  -D MESH_PACKET_LOGGING=1
-;  -D MESH_DEBUG=1
-build_src_filter = ${Xiao_S3_WIO.build_src_filter}
-  +<helpers/ui/SSD1306Display.cpp>
-  +<helpers/esp32/*.cpp>
-  +<../examples/companion_radio>
-lib_deps =
-  ${Xiao_S3_WIO.lib_deps}
-  densaugeo/base64 @ ~1.4.0
-  adafruit/Adafruit SSD1306 @ ^2.5.13
+


### PR DESCRIPTION
Adds the screen of the official expansion board to the companion_radio_ble target

the screen is on default I2C bus and will be autodetected at startup, so no real need for two targets here

An alternative would be to define a new xiao_s3_expansion board but I don't think it is woth it