### PR TITLE
use Stream abstract interface for serial port in ArduinoSerialInterface

### DIFF
--- a/src/helpers/ArduinoSerialInterface.h
+++ b/src/helpers/ArduinoSerialInterface.h
@@ -8,30 +8,18 @@ class ArduinoSerialInterface : public BaseSerialInterface {
   uint8_t _state;
   uint16_t _frame_len;
   uint16_t rx_len;
-#ifdef LILYGO_T3S3
-  HWCDC* _serial;
-#elif defined(NRF52_PLATFORM)
-  Adafruit_USBD_CDC* _serial;
-#else
-  HardwareSerial* _serial;
-#endif
+  Stream* _serial;
   uint8_t rx_buf[MAX_FRAME_SIZE];
 
 public:
   ArduinoSerialInterface() { _isEnabled = false; _state = 0; }
 
-#ifdef LILYGO_T3S3
-  void begin(HWCDC& serial) { _serial = &serial; }
-#elif defined(NRF52_PLATFORM)
-  void begin(Adafruit_USBD_CDC& serial) {
-    _serial = &serial;
+  void begin(Stream& serial) { 
+    _serial = &serial; 
   #ifdef RAK_4631
     pinMode(WB_IO2, OUTPUT);
-  #endif
+  #endif  
   }
-#else
-  void begin(HardwareSerial& serial) { _serial = &serial; }
-#endif
 
   // BaseSerialInterface methods
   void enable() override;


### PR DESCRIPTION
We can get rid of all these ifdefs in ArduinoSerialInterface by using Stream, in the implementation we never use methods from the HardwareSerial interfaces

Found it necessary when trying to switch from uart to internal usb uart of esp-c3 (which uses HWCDC), didn't want to add another condition (and I have the two interfaces on the board)

Tested on T114 (nrf52), HeltecV3 (was using HWSerial) and CT62 (esp32-c3 using HWCDC)