### PR TITLE
Use identity key as default node name

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -847,6 +847,13 @@ public:
 
     loadMainIdentity();
 
+    // use hex of first 4 bytes of identity public key as default node name
+    if(strcmp(_prefs.node_name, "NONAME") == 0){
+      char pub_key_hex[10];
+      mesh::Utils::toHex(pub_key_hex, self_id.pub_key, 4);
+      strcpy(_prefs.node_name, pub_key_hex);
+    }
+
     // load persisted prefs
     if (_fs->exists("/new_prefs")) {
       loadPrefsInt("/new_prefs");   // new filename

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -848,11 +848,9 @@ public:
     loadMainIdentity();
 
     // use hex of first 4 bytes of identity public key as default node name
-    if(strcmp(_prefs.node_name, "NONAME") == 0){
-      char pub_key_hex[10];
-      mesh::Utils::toHex(pub_key_hex, self_id.pub_key, 4);
-      strcpy(_prefs.node_name, pub_key_hex);
-    }
+    char pub_key_hex[10];
+    mesh::Utils::toHex(pub_key_hex, self_id.pub_key, 4);
+    strcpy(_prefs.node_name, pub_key_hex);
 
     // load persisted prefs
     if (_fs->exists("/new_prefs")) {


### PR DESCRIPTION
This PR changes the default node name in companion firmware from `NONAME` to use the first 4 bytes of the generated identity public key.

Currently, when powering on multiple MeshCore companion nodes in the same area, users don't know which node they are connecting to as they all show the same name.

Displaying a short version of the identity public key on the devices screen, as well as in the BLE device name will make it easier to determine which node to connect to.

Once the user sets a new name, that value will be used instead.

<img src="https://github.com/user-attachments/assets/29656eba-4c19-4a93-96da-980722e0e2a5" height="500">
<img src="https://github.com/user-attachments/assets/122cef97-fd0c-4943-b86a-3f1acf812ea8" height="500">
