### PR TITLE
UI Text Width - minor improvement

### DIFF
--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -144,7 +144,7 @@ void UITask::renderCurrScreen() {
     // version info
     _display->setColor(DisplayDriver::LIGHT);
     _display->setTextSize(1);
-    int textWidth = strlen(_version_info) * 5; // Assuming each character is 5 pixels wide
+    uint16_t textWidth = _display->getTextWidth(_version_info);
     _display->setCursor((_display->width() - textWidth) / 2, 22);
     _display->print(_version_info);
   } else {  // home screen

--- a/examples/simple_repeater/UITask.cpp
+++ b/examples/simple_repeater/UITask.cpp
@@ -51,14 +51,14 @@ void UITask::renderCurrScreen() {
     // version info
     _display->setColor(DisplayDriver::LIGHT);
     _display->setTextSize(1);
-    int versionWidth = strlen(_version_info) * 6;
+    uint16_t versionWidth = _display->getTextWidth(_version_info);
     _display->setCursor((_display->width() - versionWidth) / 2, 22);
     _display->print(_version_info);
 
     // node type
     const char* node_type = "< Repeater >";
-    int nodeTypeWidth = strlen(node_type) * 6;
-    _display->setCursor((_display->width() - nodeTypeWidth) / 2, 35);
+    uint16_t typeWidth = _display->getTextWidth(node_type);
+    _display->setCursor((_display->width() - typeWidth) / 2, 35);
     _display->print(node_type);
   } else {  // home screen
     // node name

--- a/examples/simple_room_server/UITask.cpp
+++ b/examples/simple_room_server/UITask.cpp
@@ -51,14 +51,14 @@ void UITask::renderCurrScreen() {
     // version info
     _display->setColor(DisplayDriver::LIGHT);
     _display->setTextSize(1);
-    int versionWidth = strlen(_version_info) * 6;
+    uint16_t versionWidth = _display->getTextWidth(_version_info);
     _display->setCursor((_display->width() - versionWidth) / 2, 22);
     _display->print(_version_info);
 
     // node type
-    const char* node_type = "< Room Server >";
-    int nodeTypeWidth = strlen(node_type) * 6;
-    _display->setCursor((_display->width() - nodeTypeWidth) / 2, 35);
+    const char* node_type = "< Repeater >";
+    uint16_t typeWidth = _display->getTextWidth(node_type);
+    _display->setCursor((_display->width() - typeWidth) / 2, 35);
     _display->print(node_type);
   } else {  // home screen
     // node name

--- a/src/helpers/ui/DisplayDriver.h
+++ b/src/helpers/ui/DisplayDriver.h
@@ -24,5 +24,6 @@ public:
   virtual void fillRect(int x, int y, int w, int h) = 0;
   virtual void drawRect(int x, int y, int w, int h) = 0;
   virtual void drawXbm(int x, int y, const uint8_t* bits, int w, int h) = 0;
+  virtual uint16_t getTextWidth(const char* str) = 0;
   virtual void endFrame() = 0;
 };

--- a/src/helpers/ui/GxEPDDisplay.cpp
+++ b/src/helpers/ui/GxEPDDisplay.cpp
@@ -94,6 +94,13 @@ void GxEPDDisplay::drawXbm(int x, int y, const uint8_t* bits, int w, int h) {
   display.drawBitmap(x*1.5, (y*1.5) + 10, bits, w, h, GxEPD_BLACK);
 }
 
+uint16_t GxEPDDisplay::getTextWidth(const char* str) {
+  int16_t x1, y1;
+  uint16_t w, h;
+  display.getTextBounds(str, 0, 0, &x1, &y1, &w, &h);
+  return w;
+}
+
 void GxEPDDisplay::endFrame() {
   display.display(true);
 }

--- a/src/helpers/ui/GxEPDDisplay.h
+++ b/src/helpers/ui/GxEPDDisplay.h
@@ -47,5 +47,6 @@ public:
   void fillRect(int x, int y, int w, int h) override;
   void drawRect(int x, int y, int w, int h) override;
   void drawXbm(int x, int y, const uint8_t* bits, int w, int h) override;
+  uint16_t getTextWidth(const char* str) override;
   void endFrame() override;
 };

--- a/src/helpers/ui/SSD1306Display.cpp
+++ b/src/helpers/ui/SSD1306Display.cpp
@@ -62,6 +62,13 @@ void SSD1306Display::drawXbm(int x, int y, const uint8_t* bits, int w, int h) {
   display.drawBitmap(x, y, bits, w, h, SSD1306_WHITE);
 }
 
+uint16_t SSD1306Display::getTextWidth(const char* str) {
+  int16_t x1, y1;
+  uint16_t w, h;
+  display.getTextBounds(str, 0, 0, &x1, &y1, &w, &h);
+  return w;
+}
+
 void SSD1306Display::endFrame() {
   display.display();
 }

--- a/src/helpers/ui/SSD1306Display.h
+++ b/src/helpers/ui/SSD1306Display.h
@@ -36,5 +36,6 @@ public:
   void fillRect(int x, int y, int w, int h) override;
   void drawRect(int x, int y, int w, int h) override;
   void drawXbm(int x, int y, const uint8_t* bits, int w, int h) override;
+  uint16_t getTextWidth(const char* str) override;
   void endFrame() override;
 };

--- a/src/helpers/ui/ST7789Display.cpp
+++ b/src/helpers/ui/ST7789Display.cpp
@@ -44,7 +44,6 @@ void ST7789Display::startFrame(Color bkg) {
 }
 
 void ST7789Display::setTextSize(int sz) {
-  _textSize = sz; // Store the text size
   switch(sz) {
     case 1 :
       display.setFont(ArialMT_Plain_10);

--- a/src/helpers/ui/ST7789Display.cpp
+++ b/src/helpers/ui/ST7789Display.cpp
@@ -44,6 +44,7 @@ void ST7789Display::startFrame(Color bkg) {
 }
 
 void ST7789Display::setTextSize(int sz) {
+  _textSize = sz; // Store the text size
   switch(sz) {
     case 1 :
       display.setFont(ArialMT_Plain_10);
@@ -105,6 +106,10 @@ void ST7789Display::drawRect(int x, int y, int w, int h) {
 
 void ST7789Display::drawXbm(int x, int y, const uint8_t* bits, int w, int h) {
   display.drawBitmap(x+X_OFFSET, y, w, h, bits);
+}
+
+uint16_t ST7789Display::getTextWidth(const char* str) {
+  return display.getStringWidth(str);
 }
 
 void ST7789Display::endFrame() {

--- a/src/helpers/ui/ST7789Display.h
+++ b/src/helpers/ui/ST7789Display.h
@@ -11,7 +11,6 @@ class ST7789Display : public DisplayDriver {
   bool _isOn;
   uint16_t _color;
   int _x=0, _y=0;
-  int _textSize=1; // Track the current text size
 
   bool i2c_probe(TwoWire& wire, uint8_t addr);
 public:

--- a/src/helpers/ui/ST7789Display.h
+++ b/src/helpers/ui/ST7789Display.h
@@ -11,6 +11,7 @@ class ST7789Display : public DisplayDriver {
   bool _isOn;
   uint16_t _color;
   int _x=0, _y=0;
+  int _textSize=1; // Track the current text size
 
   bool i2c_probe(TwoWire& wire, uint8_t addr);
 public:
@@ -31,5 +32,6 @@ public:
   void fillRect(int x, int y, int w, int h) override;
   void drawRect(int x, int y, int w, int h) override;
   void drawXbm(int x, int y, const uint8_t* bits, int w, int h) override;
+  uint16_t getTextWidth(const char* str) override;
   void endFrame() override;
 };


### PR DESCRIPTION
Small PR to clean up some magic numbers in the UITask. All our display drivers support a native way to get text width based off the current font size. This helps when centering text in the UI (we do this for the boot screen). This should be a lot cleaner.

- Added getTextWidth method to DisplayDriver interface
- Implemented getTextWidth in all display classes
- Updated examples to use getTextWidth directly to center text
- Tested on Heltec V3 and T114

![IMG_5592 2](https://github.com/user-attachments/assets/00cc9d0a-2178-4e29-a43f-076aa1fc441e)

