### PR TITLE
fixing scaling of bitmaps for 7789 display

### DIFF
--- a/src/helpers/ui/ST7789Display.cpp
+++ b/src/helpers/ui/ST7789Display.cpp
@@ -120,23 +120,27 @@ void ST7789Display::drawXbm(int x, int y, const uint8_t* bits, int w, int h) {
   
   // Process the bitmap row by row
   for (uint16_t by = 0; by < h; by++) {
+    // Calculate the target y-coordinates for this logical row
+    int y1 = startY + (int)(by * SCALE_Y);
+    int y2 = startY + (int)((by + 1) * SCALE_Y);
+    int block_h = y2 - y1;
+    
     // Scan across the row bit by bit
     for (uint16_t bx = 0; bx < w; bx++) {
+      // Calculate the target x-coordinates for this logical column
+      int x1 = startX + (int)(bx * SCALE_X);
+      int x2 = startX + (int)((bx + 1) * SCALE_X);
+      int block_w = x2 - x1;
+      
       // Get the current bit
       uint16_t byteOffset = (by * widthInBytes) + (bx / 8);
       uint8_t bitMask = 0x80 >> (bx & 7);
       bool bitSet = pgm_read_byte(bits + byteOffset) & bitMask;
       
-      // If the bit is set, draw pixels using setPixel with scaling
+      // If the bit is set, draw a block of pixels
       if (bitSet) {
-        // Apply scaling - draw multiple pixels for each original bitmap pixel
-        for (uint16_t scaleY = 0; scaleY <= (uint16_t)SCALE_Y; scaleY++) {
-          for (uint16_t scaleX = 0; scaleX <= (uint16_t)SCALE_X; scaleX++) {
-            uint16_t pixelX = startX + (uint16_t)(bx * SCALE_X) + scaleX;
-            uint16_t pixelY = startY + (uint16_t)(by * SCALE_Y) + scaleY;
-            display.setPixel(pixelX, pixelY);
-          }
-        }
+        // Draw the block as a filled rectangle
+        display.fillRect(x1, y1, block_w, block_h);
       }
     }
   }


### PR DESCRIPTION
Added some basic scaling to the drawXbm method in the ST7789 display code which impacts the T114. All of the other methods in this class account for scaling but bitmaps need to be scaled accordingly. Right now in the dev branch the logo is tucked in the top left corner and smaller after the recent scaling changes. This seems to work well. If I had a T-echo to test on I'd add this to that display class too but might need someone else's help with that.

![IMG_5613](https://github.com/user-attachments/assets/91d3ca4e-fd28-420b-9db7-35af0bd25ed8)
