### PR TITLE
ble pin must be zero or a valid 6 digit pin

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -1490,9 +1490,20 @@ public:
         writeErrFrame(ERR_CODE_TABLE_FULL);
       }
     } else if (cmd_frame[0] == CMD_SET_DEVICE_PIN && len >= 5) {
-      memcpy(&_prefs.ble_pin, &cmd_frame[1], 4);
-      savePrefs();
-      writeOKFrame();
+
+      // get pin from command frame
+      uint32_t pin;
+      memcpy(&pin, &cmd_frame[1], 4);
+
+      // ensure pin is zero, or a valid 6 digit pin
+      if(pin == 0 || (pin >= 100000 && pin <= 999999)){
+        _prefs.ble_pin = pin;
+        savePrefs();
+        writeOKFrame();
+      } else {
+        writeErrFrame(ERR_CODE_ILLEGAL_ARG);
+      }
+      
     } else if (cmd_frame[0] == CMD_GET_CUSTOM_VARS) {
       out_frame[0] = RESP_CODE_CUSTOM_VARS;
       char* dp = (char *) &out_frame[1];


### PR DESCRIPTION
This PR enforces that the BLE pin provided by the user is valid before saving to preferences.

If a user provides a pin such as `000123`, the BLE stack will treat this as `123`.
BLE requires a 6 digit pin, and unfortunately a pin less than `100000` breaks the BLE pairing process and doesn't prompt the user to input a pin on the client side. Without erasing flash, or flashing the USB firmware, the user will be unable to pair again.

Allows BLE pin to be:

- `0`
- `100000` to `999999`

Anything else will return `ERR_CODE_ILLEGAL_ARG`.

The next mobile app update will check user input before sending to firmware, but will be good to have this validation for any other clients that may be created in the future.