### PR TITLE
Disable LED flashing during BLE advertising on T114

### DIFF
--- a/variants/t114/variant.h
+++ b/variants/t114/variant.h
@@ -69,7 +69,7 @@
 #define LED_BUILTIN             (35)
 #define PIN_LED                 LED_BUILTIN
 #define LED_RED                 LED_BUILTIN
-#define LED_BLUE                LED_BUILTIN
+#define LED_BLUE                (-1)            // No blue led, prevents Bluefruit flashing the green LED during advertising
 #define LED_PIN                 LED_BUILTIN
 
 #define LED_STATE_ON            HIGH


### PR DESCRIPTION
Fix #265 and #102

[Bluefruit uses LED_BLUE during advertising](https://github.com/adafruit/Adafruit_nRF52_Arduino/blob/master/libraries/Bluefruit52Lib/src/bluefruit.cpp#L115), meaning that LED will pretty much always flash unless a companion device is paired and it stays on when connected. I agree its a little too much so tossing this up to see if we like the idea of disabling it.

there is also `Bluefruit.autoConnLed(false);` but that would still leave the green LED lit all the time while paired since we set `LED_BLUE` to the green LED pin. I noticed the t1000 variant disables `LED_BLUE` too so I figured this is fine.
