### PR TITLE
Fixes to the TBeam Supreme PMU calls

### DIFF
--- a/src/helpers/TBeamS3SupremeBoard.h
+++ b/src/helpers/TBeamS3SupremeBoard.h
@@ -47,15 +47,17 @@
 #define I2C_RTC_ADD       0x51  //RTC I2C address on Wire1
 #define I2C_PMU_ADD       0x34  //AXP2101 I2C address on Wire1
 
-
+#define PMU_WIRE_PORT               Wire1
+#define XPOWERS_CHIP_AXP2101
 
 class TBeamS3SupremeBoard : public ESP32Board {
-
+  XPowersAXP2101 PMU;
 public:
+#ifdef MESH_DEBUG
+  void printPMU();
+#endif
+  bool power_init();
   void begin() {
-    
-    bool power_init();
-    
     ESP32Board::begin();
 
     esp_reset_reason_t reason = esp_reset_reason();
@@ -68,6 +70,7 @@ public:
       rtc_gpio_hold_dis((gpio_num_t)P_LORA_NSS);
       rtc_gpio_deinit((gpio_num_t)P_LORA_DIO_1);
     }
+    power_init();
   }
 
   void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1) {
@@ -94,12 +97,14 @@ public:
   }
 
   uint16_t getBattMilliVolts() override {
-
-    return 0;
+    return PMU.getBattVoltage();
   }
 
-  uint16_t getBattPercent();
-
+  uint16_t getBattPercent() {
+    //Read the PMU fuel guage for battery %
+    uint16_t battPercent = PMU.getBatteryPercent();
+    return battPercent;
+  }
   const char* getManufacturerName() const override {
     return "LilyGo T-Beam S3 Supreme SX1262";
   }

--- a/variants/lilygo_tbeam_supreme_SX1262/platformio.ini
+++ b/variants/lilygo_tbeam_supreme_SX1262/platformio.ini
@@ -63,8 +63,8 @@ build_flags =
   -D BLE_DEBUG_LOGGING=1
 ;  -D ENABLE_PRIVATE_KEY_IMPORT=1
 ;  -D ENABLE_PRIVATE_KEY_EXPORT=1
-  -D MESH_PACKET_LOGGING=8
-  -D MESH_DEBUG=1
+;  -D MESH_PACKET_LOGGING=8
+;  -D MESH_DEBUG=1
 build_src_filter = ${T_Beam_S3_Supreme_SX1262.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio>

--- a/variants/lilygo_tbeam_supreme_SX1262/target.cpp
+++ b/variants/lilygo_tbeam_supreme_SX1262/target.cpp
@@ -3,9 +3,6 @@
 
 TBeamS3SupremeBoard board;
 
-// Using PMU AXP2102
-XPowersAXP2101 PMU;
-
 bool pmuIntFlag;
 
 #ifndef LORA_CR
@@ -28,103 +25,125 @@ SensorManager sensors;
 static void setPMUIntFlag(){
   pmuIntFlag = true;
 }
+#ifdef MESH_DEBUG
+void TBeamS3SupremeBoard::printPMU()
+{
+    Serial.print("isCharging:"); Serial.println(PMU.isCharging() ? "YES" : "NO");
+    Serial.print("isDischarge:"); Serial.println(PMU.isDischarge() ? "YES" : "NO");
+    Serial.print("isVbusIn:"); Serial.println(PMU.isVbusIn() ? "YES" : "NO");
+    Serial.print("getBattVoltage:"); Serial.print(PMU.getBattVoltage()); Serial.println("mV");
+    Serial.print("getVbusVoltage:"); Serial.print(PMU.getVbusVoltage()); Serial.println("mV");
+    Serial.print("getSystemVoltage:"); Serial.print(PMU.getSystemVoltage()); Serial.println("mV");
 
-bool power_init() {
-  //Start up Wire1 with PMU address
-  //Serial.println("Starting Wire1 for PMU");
-  //Wire1.begin(I2C_PMU_ADD);
-  //Wire1.begin(PIN_BOARD_SDA1,PIN_BOARD_SCL1);
-  
-  //Set LED to indicate charge state
-  Serial.println("Setting charge led");
-  PMU.setChargingLedMode(XPOWERS_CHG_LED_CTRL_CHG);  
-  
-  //Set up PMU interrupts
-  Serial.println("Setting up PMU interrupts");
-  pinMode(PIN_PMU_IRQ,INPUT_PULLUP);
-  attachInterrupt(PIN_PMU_IRQ,setPMUIntFlag,FALLING);
+    // The battery percentage may be inaccurate at first use, the PMU will automatically
+    // learn the battery curve and will automatically calibrate the battery percentage
+    // after a charge and discharge cycle
+    if (PMU.isBatteryConnect()) {
+        Serial.print("getBatteryPercent:"); Serial.print(PMU.getBatteryPercent()); Serial.println("%");
+    }
 
-  //GPS
-  Serial.println("Setting and enabling a-ldo4 for GPS");
-  PMU.setALDO4Voltage(3300);  
-  PMU.enableALDO4();          //disable to save power
-  
-  //Lora
-  Serial.println("Setting and enabling a-ldo3 for LoRa");
-  PMU.setALDO3Voltage(3300);  
-  PMU.enableALDO3();   
+    Serial.println();
+}
+#endif
 
-  //To avoid SPI bus issues during power up, reset OLED, sensor, and SD card supplies
-  Serial.println("Reset a-ldo1&2 and b-ldo1");
-  if(ESP_SLEEP_WAKEUP_UNDEFINED == esp_sleep_get_wakeup_cause()){
+bool TBeamS3SupremeBoard::power_init()
+{
+  bool result = PMU.begin(PMU_WIRE_PORT, I2C_PMU_ADD, PIN_BOARD_SDA1, PIN_BOARD_SCL1);
+  if (result == false) {
+    MESH_DEBUG_PRINTLN("power is not online..."); while (1)delay(50);
+  }
+  MESH_DEBUG_PRINTLN("Setting charge led");
+  PMU.setChargingLedMode(XPOWERS_CHG_LED_CTRL_CHG);
+
+  // Set up PMU interrupts
+  MESH_DEBUG_PRINTLN("Setting up PMU interrupts");
+  pinMode(PIN_PMU_IRQ, INPUT_PULLUP);
+  attachInterrupt(PIN_PMU_IRQ, setPMUIntFlag, FALLING);
+
+  // GPS
+  MESH_DEBUG_PRINTLN("Setting and enabling a-ldo4 for GPS");
+  PMU.setALDO4Voltage(3300);
+  PMU.enableALDO4(); // disable to save power
+
+  // Lora
+  MESH_DEBUG_PRINTLN("Setting and enabling a-ldo3 for LoRa");
+  PMU.setALDO3Voltage(3300);
+  PMU.enableALDO3();
+
+  // To avoid SPI bus issues during power up, reset OLED, sensor, and SD card supplies
+  MESH_DEBUG_PRINTLN("Reset a-ldo1&2 and b-ldo1");
+  if (ESP_SLEEP_WAKEUP_UNDEFINED == esp_sleep_get_wakeup_cause())
+  {
     PMU.enableALDO1();
     PMU.enableALDO2();
     PMU.enableBLDO1();
     delay(250);
   }
- 
-  //BME280 and OLED
-  Serial.println("Setting and enabling a-ldo1 for oled");
+
+  // BME280 and OLED
+  MESH_DEBUG_PRINTLN("Setting and enabling a-ldo1 for oled");
   PMU.setALDO1Voltage(3300);
   PMU.enableALDO1();
 
-  //QMC6310U 
-  Serial.println("Setting and enabling a-ldo2 for QMC");
+  // QMC6310U
+  MESH_DEBUG_PRINTLN("Setting and enabling a-ldo2 for QMC");
   PMU.setALDO2Voltage(3300);
-  PMU.enableALDO2();          //disable to save power
+  PMU.enableALDO2(); // disable to save power
 
-  //SD card
-  Serial.println("Setting and enabling b-ldo2 for SD card");
+  // SD card
+  MESH_DEBUG_PRINTLN("Setting and enabling b-ldo2 for SD card");
   PMU.setBLDO1Voltage(3300);
   PMU.enableBLDO1();
 
-  //Out to header pins
-  Serial.println("Setting and enabling b-ldo2 for output to header");
+  // Out to header pins
+  MESH_DEBUG_PRINTLN("Setting and enabling b-ldo2 for output to header");
   PMU.setBLDO2Voltage(3300);
   PMU.enableBLDO2();
 
-  Serial.println("Setting and enabling dcdc4 for output to header");
-  PMU.setDC4Voltage(XPOWERS_AXP2101_DCDC4_VOL2_MAX);    //1.8V
+  MESH_DEBUG_PRINTLN("Setting and enabling dcdc4 for output to header");
+  PMU.setDC4Voltage(XPOWERS_AXP2101_DCDC4_VOL2_MAX); // 1.8V
   PMU.enableDC4();
 
-  Serial.println("Setting and enabling dcdc5 for output to header");
+  MESH_DEBUG_PRINTLN("Setting and enabling dcdc5 for output to header");
   PMU.setDC5Voltage(3300);
   PMU.enableDC5();
 
-  //Other power rails
-  Serial.println("Setting and enabling dcdc3 for ?");
-  PMU.setDC3Voltage(3300);    //doesn't go anywhere in the schematic??
+  // Other power rails
+  MESH_DEBUG_PRINTLN("Setting and enabling dcdc3 for ?");
+  PMU.setDC3Voltage(3300); // doesn't go anywhere in the schematic??
   PMU.enableDC3();
 
-  //Unused power rails
-  Serial.println("Disabling unused supplies dcdc2, dldo1 and dldo2");
+  // Unused power rails
+  MESH_DEBUG_PRINTLN("Disabling unused supplies dcdc2, dldo1 and dldo2");
   PMU.disableDC2();
   PMU.disableDLDO1();
-  PMU.disableDLDO2();  
+  PMU.disableDLDO2();
 
-  //Set charge current to 300mA
-  Serial.println("Setting battery charge current limit and voltage");
+  // Set charge current to 300mA
+  MESH_DEBUG_PRINTLN("Setting battery charge current limit and voltage");
   PMU.setChargerConstantCurr(XPOWERS_AXP2101_CHG_CUR_300MA);
   PMU.setChargeTargetVoltage(XPOWERS_AXP2101_CHG_VOL_4V2);
 
-  //enable battery voltage measurement
-  Serial.println("Enabling battery measurement");
+  // enable battery voltage measurement
+  MESH_DEBUG_PRINTLN("Enabling battery measurement");
   PMU.enableBattVoltageMeasure();
 
-  //Reset and re-enable PMU interrupts
-  Serial.println("Re-enable interrupts");
+  // Reset and re-enable PMU interrupts
+  MESH_DEBUG_PRINTLN("Re-enable interrupts");
   PMU.disableIRQ(XPOWERS_AXP2101_ALL_IRQ);
   PMU.clearIrqStatus();
   PMU.enableIRQ(
-    XPOWERS_AXP2101_BAT_INSERT_IRQ    | XPOWERS_AXP2101_BAT_REMOVE_IRQ      |   //Battery interrupts
-    XPOWERS_AXP2101_VBUS_INSERT_IRQ   | XPOWERS_AXP2101_VBUS_REMOVE_IRQ     |   //VBUS interrupts
-    XPOWERS_AXP2101_PKEY_SHORT_IRQ    | XPOWERS_AXP2101_PKEY_LONG_IRQ       |   //Power Key interrupts
-    XPOWERS_AXP2101_BAT_CHG_DONE_IRQ  | XPOWERS_AXP2101_BAT_CHG_START_IRQ       //Charging interrupts
+      XPOWERS_AXP2101_BAT_INSERT_IRQ | XPOWERS_AXP2101_BAT_REMOVE_IRQ |    // Battery interrupts
+      XPOWERS_AXP2101_VBUS_INSERT_IRQ | XPOWERS_AXP2101_VBUS_REMOVE_IRQ |  // VBUS interrupts
+      XPOWERS_AXP2101_PKEY_SHORT_IRQ | XPOWERS_AXP2101_PKEY_LONG_IRQ |     // Power Key interrupts
+      XPOWERS_AXP2101_BAT_CHG_DONE_IRQ | XPOWERS_AXP2101_BAT_CHG_START_IRQ // Charging interrupts
   );
+#ifdef MESH_DEBUG
+  printPMU();
+#endif
 
-  //Set the power key off press time
+  // Set the power key off press time
   PMU.setPowerKeyPressOffTime(XPOWERS_POWEROFF_4S);
-
   return true;
 }
 
@@ -152,13 +171,6 @@ bool radio_init() {
   radio.setCRC(1);
   
   return true;  // success
-}
-
-uint16_t getBattPercent() {
-  //Read the PMU fuel guage for battery %
-  uint16_t battPercent = PMU.getBatteryPercent();
-
-  return battPercent;
 }
 
 uint32_t radio_get_rng_seed() {


### PR DESCRIPTION
Refactoring and improving PMU code for the TBeam Supreme. Was getting 0% battery level reporting before, which means the PMU wasn't initializing correctly. Also removing MESH_DEBUG from default companion build.

* Rewrote debug prints to only take effect when MESH_DEBUG is on. 
* Fixed PMU initialization
* Moved declaration of PMU and battery functions into TBeam class

Output in debug mode when plugged in:

```
DEBUG: Setting charge led
DEBUG: Setting up PMU interrupts
DEBUG: Setting and enabling a-ldo4 for GPS
DEBUG: Setting and enabling a-ldo3 for LoRa
DEBUG: Reset a-ldo1&2 and b-ldo1
DEBUG: Setting and enabling a-ldo1 for oled
DEBUG: Setting and enabling a-ldo2 for QMC
DEBUG: Setting and enabling b-ldo2 for SD card
DEBUG: Setting and enabling b-ldo2 for output to header
DEBUG: Setting and enabling dcdc4 for output to header
DEBUG: Setting and enabling dcdc5 for output to header
DEBUG: Setting and enabling dcdc3 for ?
DEBUG: Disabling unused supplies dcdc2, dldo1 and dldo2
DEBUG: Setting battery charge current limit and voltage
DEBUG: Enabling battery measurement
DEBUG: Re-enable interrupts
isCharging:NO
isDischarge:NO
isVbusIn:YES
getBattVoltage:4127mV
getVbusVoltage:0mV
getSystemVoltage:0mV
getBatteryPercent:100%

Repeater ID: 65076C0AFD290CF97DE1F16FFF4B6344A7BD25951D7126E962AAB1B911D5B39E
```

Works in release mode too. Checked info reporting in repeater and room server builds, all working.