### PR TITLE
Word wrap node name on home screen, slightly better battery icon and implement user button on RAK4631 using analogue pin 31 (same as MT) 

### DIFF
--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -2,6 +2,7 @@
 #include <Arduino.h>
 #include <helpers/TxtDataHelpers.h>
 #include "NodePrefs.h"
+#include <string>
 
 #define AUTO_OFF_MILLIS     15000   // 15 seconds
 #define BOOT_SCREEN_MILLIS   4000   // 4 seconds
@@ -68,6 +69,14 @@ void UITask::clearMsgPreview() {
   _need_refresh = true;
 }
 
+std::string textWrap(std::string str, int location) {
+  int n = str.rfind(' ', location);
+  if (n != std::string::npos) {
+      str.at(n) = '\n';
+  }
+  return str;
+}
+
 void UITask::newMsg(uint8_t path_len, const char* from_name, const char* text, int msgcount) {
   _msgcount = msgcount;
 
@@ -108,7 +117,7 @@ void renderBatteryIndicator(DisplayDriver* _display, uint16_t batteryMilliVolts)
 
   // fill the battery based on the percentage
   int fillWidth = (batteryPercentage * (iconWidth - 2)) / 100;
-  _display->fillRect(iconX + 1, iconY + 1, fillWidth, iconHeight - 2);
+  _display->fillRect(iconX + 2, iconY + 2, fillWidth, iconHeight - 4);
 }
 
 void UITask::renderCurrScreen() {
@@ -152,7 +161,10 @@ void UITask::renderCurrScreen() {
     _display->setCursor(0, 0);
     _display->setTextSize(1);
     _display->setColor(DisplayDriver::GREEN);
-    _display->print(_node_prefs->node_name);
+    uint16_t textWidth = _display->getTextWidth("H"); // display width of 1 char with this text size
+    int iconX = _display->width() - 24 - 5; //24 = icon width from above
+    int chars = iconX / textWidth;
+    _display->print(textWrap(_node_prefs->node_name, chars).c_str());
 
     // battery voltage
     renderBatteryIndicator(_display, _board->getBattMilliVolts());

--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -221,40 +221,49 @@ void UITask::userLedHandler() {
 }
 
 void UITask::buttonHandler() {
-#ifdef PIN_USER_BTN
-  static int prev_btn_state = !USER_BTN_PRESSED;
-  static unsigned long btn_state_change_time = 0;
-  static unsigned long next_read = 0;
-  int cur_time = millis();
-  if (cur_time >= next_read) {
-    int btn_state = digitalRead(PIN_USER_BTN);
-    if (btn_state != prev_btn_state) {
-      if (btn_state == USER_BTN_PRESSED) {  // pressed?
-        if (_display != NULL) {
-          if (_display->isOn()) {
-            clearMsgPreview();
-          } else {
-            _display->turnOn();
-            _need_refresh = true;
+  #ifdef PIN_USER_BTN || PIN_USER_BTN_ANA
+    static int prev_btn_state = !USER_BTN_PRESSED;
+    static int prev_btn_state_ana = !USER_BTN_PRESSED;
+    static unsigned long btn_state_change_time = 0;
+    static unsigned long next_read = 0;
+    int cur_time = millis();
+    if (cur_time >= next_read) {
+      int btn_state = 0;
+      int btn_state_ana = 0;
+      #ifdef PIN_USER_BTN
+        btn_state = digitalRead(PIN_USER_BTN);
+      #endif
+      #ifdef PIN_USER_BTN_ANA
+        btn_state_ana = (analogRead(PIN_USER_BTN_ANA) < 20); // analogRead returns a value hopefully below 20 when button is pressed. 
+      #endif
+      if (btn_state != prev_btn_state || btn_state_ana != prev_btn_state_ana) { // check for either digital or analogue button change of state
+        if (btn_state == USER_BTN_PRESSED || btn_state_ana == USER_BTN_PRESSED) {  // pressed?
+          if (_display != NULL) {
+            if (_display->isOn()) {
+              clearMsgPreview();
+            } else {
+              _display->turnOn();
+              _need_refresh = true;
+            }
+            _auto_off = cur_time + AUTO_OFF_MILLIS;   // extend auto-off timer
           }
-          _auto_off = cur_time + AUTO_OFF_MILLIS;   // extend auto-off timer
+        } else { // unpressed ? check pressed time ...
+          if ((cur_time - btn_state_change_time) > 5000) {
+          #ifdef PIN_STATUS_LED
+            digitalWrite(PIN_STATUS_LED, LOW);
+            delay(10);
+          #endif
+            _board->powerOff();
+          }
         }
-      } else { // unpressed ? check pressed time ...
-        if ((cur_time - btn_state_change_time) > 5000) {
-        #ifdef PIN_STATUS_LED
-          digitalWrite(PIN_STATUS_LED, LOW);
-          delay(10);
-        #endif
-          _board->powerOff();
-        }
+        btn_state_change_time = millis();
+        prev_btn_state = btn_state;
+        prev_btn_state_ana = btn_state_ana;
       }
-      btn_state_change_time = millis();
-      prev_btn_state = btn_state;
+      next_read = millis() + 100;  // 10 reads per second
     }
-    next_read = millis() + 100;  // 10 reads per second
+  #endif
   }
-#endif
-}
 
 void UITask::loop() {
   buttonHandler();

--- a/src/helpers/nrf52/RAK4631Board.cpp
+++ b/src/helpers/nrf52/RAK4631Board.cpp
@@ -22,8 +22,13 @@ void RAK4631Board::begin() {
   // for future use, sub-classes SHOULD call this from their begin()
   startup_reason = BD_STARTUP_NORMAL;
   pinMode(PIN_VBAT_READ, INPUT);
+
 #ifdef PIN_USER_BTN
   pinMode(PIN_USER_BTN, INPUT_PULLUP);
+#endif
+
+#ifdef PIN_USER_BTN_ANA
+  pinMode(PIN_USER_BTN_ANA, INPUT_PULLUP);
 #endif
 
 #if defined(PIN_BOARD_SDA) && defined(PIN_BOARD_SCL)

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -7,6 +7,7 @@ build_flags = ${nrf52840_base.build_flags}
   -I variants/rak4631
   -D RAK_4631
   -D PIN_USER_BTN=9
+  -D PIN_USER_BTN_ANA=31
   -D PIN_BOARD_SCL=14
   -D PIN_BOARD_SDA=13
   -D PIN_OLED_RESET=-1


### PR DESCRIPTION
For devices with smaller screens (e.g Heltec V3 or RAK Wireless OLED) the node name can be overlaid by the battery icon if the name is too long. This change implements a word wrap function for the node name. 

A slightly better battery icon which makes the inner rectangle slightly smaller to give it a more modern look.

Implemented user button for RAK4631 boards using analogue pin 31 - same as MT 

