### PR TITLE
Promicro: add INA219 current sensor support

### DIFF
--- a/variants/promicro/platformio.ini
+++ b/variants/promicro/platformio.ini
@@ -37,7 +37,8 @@ build_flags =
 lib_deps = ${Faketec.lib_deps}
   adafruit/RTClib @ ^2.1.3
   robtillaart/INA3221 @ ^0.4.1
-  
+  robtillaart/INA219 @ ^0.4.1
+
 [env:Faketec_room_server]
 extends = Faketec
 build_src_filter = ${Faketec.build_src_filter}
@@ -53,7 +54,8 @@ build_flags = ${Faketec.build_flags}
 ;  -D MESH_DEBUG=1
 lib_deps = ${Faketec.lib_deps}
   adafruit/RTClib @ ^2.1.3
-  robtillaart/INA3221 @ ^0.4.1  
+  robtillaart/INA3221 @ ^0.4.1
+  robtillaart/INA219 @ ^0.4.1
 
 [env:Faketec_terminal_chat]
 extends = Faketec
@@ -68,6 +70,7 @@ lib_deps = ${Faketec.lib_deps}
   densaugeo/base64 @ ~1.4.0
   adafruit/RTClib @ ^2.1.3
   robtillaart/INA3221 @ ^0.4.1  
+  robtillaart/INA219 @ ^0.4.1  
 
 [env:Faketec_companion_radio_usb]
 extends = Faketec
@@ -82,7 +85,8 @@ build_src_filter = ${Faketec.build_src_filter}
 lib_deps = ${Faketec.lib_deps}
   adafruit/RTClib @ ^2.1.3
   densaugeo/base64 @ ~1.4.0
-  robtillaart/INA3221 @ ^0.4.1  
+  robtillaart/INA3221 @ ^0.4.1
+  robtillaart/INA219 @ ^0.4.1    
 
 [env:Faketec_companion_radio_ble]
 extends = Faketec
@@ -104,6 +108,7 @@ lib_deps = ${Faketec.lib_deps}
   adafruit/RTClib @ ^2.1.3
   densaugeo/base64 @ ~1.4.0
   robtillaart/INA3221 @ ^0.4.1
+  robtillaart/INA219 @ ^0.4.1  
 
 [ProMicroLLCC68]
 extends = nrf52840_base
@@ -134,6 +139,7 @@ build_flags = ${ProMicroLLCC68.build_flags}
 lib_deps = ${ProMicroLLCC68.lib_deps}
   adafruit/RTClib @ ^2.1.3
   robtillaart/INA3221 @ ^0.4.1  
+  robtillaart/INA219 @ ^0.4.1  
 
 [env:ProMicroLLCC68_room_server]
 extends = ProMicroLLCC68
@@ -148,6 +154,7 @@ build_flags = ${ProMicroLLCC68.build_flags}
 lib_deps = ${ProMicroLLCC68.lib_deps}
   adafruit/RTClib @ ^2.1.3
   robtillaart/INA3221 @ ^0.4.1  
+  robtillaart/INA219 @ ^0.4.1
 
 [env:ProMicroLLCC68_terminal_chat]
 extends = ProMicroLLCC68
@@ -162,6 +169,7 @@ lib_deps = ${ProMicroLLCC68.lib_deps}
   densaugeo/base64 @ ~1.4.0
   adafruit/RTClib @ ^2.1.3
   robtillaart/INA3221 @ ^0.4.1  
+  robtillaart/INA219 @ ^0.4.1
 
 [env:ProMicroLLCC68_companion_radio_usb]
 extends = ProMicroLLCC68
@@ -176,6 +184,7 @@ lib_deps = ${ProMicroLLCC68.lib_deps}
   adafruit/RTClib @ ^2.1.3
   densaugeo/base64 @ ~1.4.0
   robtillaart/INA3221 @ ^0.4.1  
+  robtillaart/INA219 @ ^0.4.1
 
 [env:ProMicroLLCC68_companion_radio_ble]
 extends = ProMicroLLCC68
@@ -196,3 +205,4 @@ lib_deps = ${ProMicroLLCC68.lib_deps}
   adafruit/RTClib @ ^2.1.3
   densaugeo/base64 @ ~1.4.0
   robtillaart/INA3221 @ ^0.4.1  
+  robtillaart/INA219 @ ^0.4.1

--- a/variants/promicro/platformio.ini
+++ b/variants/promicro/platformio.ini
@@ -53,6 +53,7 @@ build_flags = ${Faketec.build_flags}
 ;  -D MESH_DEBUG=1
 lib_deps = ${Faketec.lib_deps}
   adafruit/RTClib @ ^2.1.3
+  robtillaart/INA3221 @ ^0.4.1  
 
 [env:Faketec_terminal_chat]
 extends = Faketec
@@ -66,6 +67,7 @@ build_src_filter = ${Faketec.build_src_filter}
 lib_deps = ${Faketec.lib_deps}
   densaugeo/base64 @ ~1.4.0
   adafruit/RTClib @ ^2.1.3
+  robtillaart/INA3221 @ ^0.4.1  
 
 [env:Faketec_companion_radio_usb]
 extends = Faketec
@@ -80,6 +82,7 @@ build_src_filter = ${Faketec.build_src_filter}
 lib_deps = ${Faketec.lib_deps}
   adafruit/RTClib @ ^2.1.3
   densaugeo/base64 @ ~1.4.0
+  robtillaart/INA3221 @ ^0.4.1  
 
 [env:Faketec_companion_radio_ble]
 extends = Faketec
@@ -100,6 +103,7 @@ build_src_filter = ${Faketec.build_src_filter}
 lib_deps = ${Faketec.lib_deps}
   adafruit/RTClib @ ^2.1.3
   densaugeo/base64 @ ~1.4.0
+  robtillaart/INA3221 @ ^0.4.1
 
 [ProMicroLLCC68]
 extends = nrf52840_base
@@ -129,6 +133,7 @@ build_flags = ${ProMicroLLCC68.build_flags}
 ;  -D MESH_DEBUG=1
 lib_deps = ${ProMicroLLCC68.lib_deps}
   adafruit/RTClib @ ^2.1.3
+  robtillaart/INA3221 @ ^0.4.1  
 
 [env:ProMicroLLCC68_room_server]
 extends = ProMicroLLCC68
@@ -142,6 +147,7 @@ build_flags = ${ProMicroLLCC68.build_flags}
 ;  -D MESH_DEBUG=1
 lib_deps = ${ProMicroLLCC68.lib_deps}
   adafruit/RTClib @ ^2.1.3
+  robtillaart/INA3221 @ ^0.4.1  
 
 [env:ProMicroLLCC68_terminal_chat]
 extends = ProMicroLLCC68
@@ -155,6 +161,7 @@ build_src_filter = ${ProMicroLLCC68.build_src_filter}
 lib_deps = ${ProMicroLLCC68.lib_deps}
   densaugeo/base64 @ ~1.4.0
   adafruit/RTClib @ ^2.1.3
+  robtillaart/INA3221 @ ^0.4.1  
 
 [env:ProMicroLLCC68_companion_radio_usb]
 extends = ProMicroLLCC68
@@ -168,6 +175,7 @@ build_src_filter = ${ProMicroLLCC68.build_src_filter}
 lib_deps = ${ProMicroLLCC68.lib_deps}
   adafruit/RTClib @ ^2.1.3
   densaugeo/base64 @ ~1.4.0
+  robtillaart/INA3221 @ ^0.4.1  
 
 [env:ProMicroLLCC68_companion_radio_ble]
 extends = ProMicroLLCC68
@@ -187,3 +195,4 @@ build_src_filter = ${ProMicroLLCC68.build_src_filter}
 lib_deps = ${ProMicroLLCC68.lib_deps}
   adafruit/RTClib @ ^2.1.3
   densaugeo/base64 @ ~1.4.0
+  robtillaart/INA3221 @ ^0.4.1  

--- a/variants/promicro/target.cpp
+++ b/variants/promicro/target.cpp
@@ -76,9 +76,10 @@ mesh::LocalIdentity radio_new_identity() {
 }
 
 static INA3221 INA_3221(TELEM_INA3221_ADDRESS, &Wire);
+static INA219 INA_219(TELEM_INA219_ADDRESS, &Wire);
 
 bool PromicroSensorManager::begin() {
-  if (INA_3221.begin() ) {
+  if (INA_3221.begin()) {
     MESH_DEBUG_PRINTLN("Found INA3221 at address: %02X", INA_3221.getAddress());
     MESH_DEBUG_PRINTLN("%04X %04X %04X", INA_3221.getDieID(), INA_3221.getManufacturerID(), INA_3221.getConfiguration());
 
@@ -89,6 +90,15 @@ bool PromicroSensorManager::begin() {
   } else {
     INA3221initialized = false;
     MESH_DEBUG_PRINTLN("INA3221 was not found at I2C address %02X", TELEM_INA3221_ADDRESS);
+  }
+  if (INA_219.begin()) {
+    MESH_DEBUG_PRINTLN("Found INA219 at address: %02X", INA_219.getAddress());
+    INA219_CHANNEL = INA3221initialized ? TELEM_CHANNEL_SELF + 4 : TELEM_CHANNEL_SELF + 1;
+    INA_219.setMaxCurrentShunt(TELEM_INA219_MAX_CURRENT, TELEM_INA219_SHUNT_VALUE);
+    INA219initialized = true;
+  } else {
+    INA219initialized = false;
+    MESH_DEBUG_PRINTLN("INA219 was not found at I2C address %02X", TELEM_INA219_ADDRESS);
   }
   return true;
 }
@@ -104,6 +114,11 @@ bool PromicroSensorManager::querySensors(uint8_t requester_permissions, CayenneL
           telemetry.addPower(INA3221_CHANNELS[i], INA_3221.getPower(i));
         }
       }
+    }
+    if(INA219initialized) {
+      telemetry.addVoltage(INA219_CHANNEL, INA_219.getBusVoltage());
+      telemetry.addCurrent(INA219_CHANNEL, INA_219.getCurrent());
+      telemetry.addPower(INA219_CHANNEL, INA_219.getPower());
     }
   }
 

--- a/variants/promicro/target.h
+++ b/variants/promicro/target.h
@@ -9,6 +9,7 @@
 #include <helpers/AutoDiscoverRTCClock.h>
 #include <helpers/SensorManager.h>
 #include <INA3221.h>
+#include <INA219.h>
 
 #define NUM_SENSOR_SETTINGS 3
 
@@ -23,20 +24,27 @@ void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr);
 void radio_set_tx_power(uint8_t dbm);
 mesh::LocalIdentity radio_new_identity();
 
-#define TELEM_INA3221_ADDRESS 0x42      // INA3221 3 channel current, voltage, power sensor I2C address
+#define TELEM_INA3221_ADDRESS 0x42      // INA3221 3 channel current sensor I2C address
+#define TELEM_INA219_ADDRESS  0x40      // INA219 single channel current sensor I2C address
+
 #define TELEM_INA3221_SHUNT_VALUE 0.100 // most variants will have a 0.1 ohm shunts
 #define TELEM_INA3221_SETTING_CH1 "INA3221-1"
 #define TELEM_INA3221_SETTING_CH2 "INA3221-2"
 #define TELEM_INA3221_SETTING_CH3 "INA3221-3"
 
+#define TELEM_INA219_SHUNT_VALUE 0.100  // shunt value in ohms (may differ between manufacturers)
+#define TELEM_INA219_MAX_CURRENT 5
+
 class PromicroSensorManager: public SensorManager {
   bool INA3221initialized = false;
+  bool INA219initialized = false;
 
   // INA3221 channels in telemetry
   int INA3221_CHANNELS[NUM_SENSOR_SETTINGS] = {TELEM_CHANNEL_SELF + 1, TELEM_CHANNEL_SELF + 2, TELEM_CHANNEL_SELF+ 3};
   const char * INA3221_CHANNEL_NAMES[NUM_SENSOR_SETTINGS] = { TELEM_INA3221_SETTING_CH1, TELEM_INA3221_SETTING_CH2, TELEM_INA3221_SETTING_CH3};
   bool INA3221_CHANNEL_ENABLED[NUM_SENSOR_SETTINGS] = {true, true, true};
   
+  int INA219_CHANNEL;
 public:
   PromicroSensorManager(){};
   bool begin() override;


### PR DESCRIPTION
1. Fix broken Promicro build targets (missing library dependency added to all affected configurations)
2. Add support for the inexpensive single channel INA219 current sensor