### PR TITLE
Build fixes for ProMicro and ProMicroLLCC68

### DIFF
--- a/variants/promicro/platformio.ini
+++ b/variants/promicro/platformio.ini
@@ -19,6 +19,7 @@ build_src_filter = ${nrf52840_base.build_src_filter}
   +<../variants/promicro>
 lib_deps= ${nrf52840_base.lib_deps}
 	adafruit/Adafruit SSD1306 @ ^2.5.13
+  robtillaart/INA3221 @ ^0.4.1
 
 [env:Faketec_Repeater]
 extends = Faketec
@@ -36,7 +37,6 @@ build_flags =
 ;  -D MESH_DEBUG=1
 lib_deps = ${Faketec.lib_deps}
   adafruit/RTClib @ ^2.1.3
-  robtillaart/INA3221 @ ^0.4.1
   
 [env:Faketec_room_server]
 extends = Faketec

--- a/variants/promicro/platformio.ini
+++ b/variants/promicro/platformio.ini
@@ -117,6 +117,7 @@ build_src_filter =
   +<helpers/nrf52/PromicroBoard.cpp>
   +<../variants/promicro>
 
+
 [env:ProMicroLLCC68_Repeater]
 extends = ProMicroLLCC68
 build_src_filter = ${ProMicroLLCC68.build_src_filter}
@@ -129,6 +130,7 @@ build_flags = ${ProMicroLLCC68.build_flags}
 ;  -D MESH_DEBUG=1
 lib_deps = ${ProMicroLLCC68.lib_deps}
   adafruit/RTClib @ ^2.1.3
+  robtillaart/INA3221 @ ^0.4.1
 
 [env:ProMicroLLCC68_room_server]
 extends = ProMicroLLCC68
@@ -142,6 +144,7 @@ build_flags = ${ProMicroLLCC68.build_flags}
 ;  -D MESH_DEBUG=1
 lib_deps = ${ProMicroLLCC68.lib_deps}
   adafruit/RTClib @ ^2.1.3
+  robtillaart/INA3221 @ ^0.4.1
 
 [env:ProMicroLLCC68_terminal_chat]
 extends = ProMicroLLCC68
@@ -155,6 +158,7 @@ build_src_filter = ${ProMicroLLCC68.build_src_filter}
 lib_deps = ${ProMicroLLCC68.lib_deps}
   densaugeo/base64 @ ~1.4.0
   adafruit/RTClib @ ^2.1.3
+  robtillaart/INA3221 @ ^0.4.1
 
 [env:ProMicroLLCC68_companion_radio_usb]
 extends = ProMicroLLCC68
@@ -168,6 +172,7 @@ build_src_filter = ${ProMicroLLCC68.build_src_filter}
 lib_deps = ${ProMicroLLCC68.lib_deps}
   adafruit/RTClib @ ^2.1.3
   densaugeo/base64 @ ~1.4.0
+  robtillaart/INA3221 @ ^0.4.1
 
 [env:ProMicroLLCC68_companion_radio_ble]
 extends = ProMicroLLCC68
@@ -187,3 +192,4 @@ build_src_filter = ${ProMicroLLCC68.build_src_filter}
 lib_deps = ${ProMicroLLCC68.lib_deps}
   adafruit/RTClib @ ^2.1.3
   densaugeo/base64 @ ~1.4.0
+  robtillaart/INA3221 @ ^0.4.1


### PR DESCRIPTION
Moved the INA3221 dependency up to the top level for ProMicro and added it to ProMicroLLCC68 as well.