### PR TITLE
Telemetry: add support of AHT10/AHT20 temp/humidity sensor to Promicro

### DIFF
--- a/variants/promicro/platformio.ini
+++ b/variants/promicro/platformio.ini
@@ -19,6 +19,9 @@ build_src_filter = ${nrf52840_base.build_src_filter}
   +<../variants/promicro>
 lib_deps= ${nrf52840_base.lib_deps}
 	adafruit/Adafruit SSD1306 @ ^2.5.13
+  robtillaart/INA3221 @ ^0.4.1
+  robtillaart/INA219 @ ^0.4.1
+  adafruit/Adafruit AHTX0@^2.0.5
 
 [env:Faketec_Repeater]
 extends = Faketec
@@ -36,8 +39,6 @@ build_flags =
 ;  -D MESH_DEBUG=1
 lib_deps = ${Faketec.lib_deps}
   adafruit/RTClib @ ^2.1.3
-  robtillaart/INA3221 @ ^0.4.1
-  robtillaart/INA219 @ ^0.4.1
 
 [env:Faketec_room_server]
 extends = Faketec
@@ -54,8 +55,6 @@ build_flags = ${Faketec.build_flags}
 ;  -D MESH_DEBUG=1
 lib_deps = ${Faketec.lib_deps}
   adafruit/RTClib @ ^2.1.3
-  robtillaart/INA3221 @ ^0.4.1
-  robtillaart/INA219 @ ^0.4.1
 
 [env:Faketec_terminal_chat]
 extends = Faketec
@@ -69,8 +68,6 @@ build_src_filter = ${Faketec.build_src_filter}
 lib_deps = ${Faketec.lib_deps}
   densaugeo/base64 @ ~1.4.0
   adafruit/RTClib @ ^2.1.3
-  robtillaart/INA3221 @ ^0.4.1  
-  robtillaart/INA219 @ ^0.4.1  
 
 [env:Faketec_companion_radio_usb]
 extends = Faketec
@@ -85,8 +82,6 @@ build_src_filter = ${Faketec.build_src_filter}
 lib_deps = ${Faketec.lib_deps}
   adafruit/RTClib @ ^2.1.3
   densaugeo/base64 @ ~1.4.0
-  robtillaart/INA3221 @ ^0.4.1
-  robtillaart/INA219 @ ^0.4.1    
 
 [env:Faketec_companion_radio_ble]
 extends = Faketec
@@ -107,8 +102,6 @@ build_src_filter = ${Faketec.build_src_filter}
 lib_deps = ${Faketec.lib_deps}
   adafruit/RTClib @ ^2.1.3
   densaugeo/base64 @ ~1.4.0
-  robtillaart/INA3221 @ ^0.4.1
-  robtillaart/INA219 @ ^0.4.1  
 
 [ProMicroLLCC68]
 extends = nrf52840_base
@@ -125,6 +118,10 @@ build_src_filter =
   ${nrf52840_base.build_src_filter}
   +<helpers/nrf52/PromicroBoard.cpp>
   +<../variants/promicro>
+lib_deps= ${nrf52840_base.lib_deps}
+  robtillaart/INA3221 @ ^0.4.1
+  robtillaart/INA219 @ ^0.4.1
+  adafruit/Adafruit AHTX0@^2.0.5
 
 [env:ProMicroLLCC68_Repeater]
 extends = ProMicroLLCC68
@@ -138,8 +135,6 @@ build_flags = ${ProMicroLLCC68.build_flags}
 ;  -D MESH_DEBUG=1
 lib_deps = ${ProMicroLLCC68.lib_deps}
   adafruit/RTClib @ ^2.1.3
-  robtillaart/INA3221 @ ^0.4.1  
-  robtillaart/INA219 @ ^0.4.1  
 
 [env:ProMicroLLCC68_room_server]
 extends = ProMicroLLCC68
@@ -153,8 +148,6 @@ build_flags = ${ProMicroLLCC68.build_flags}
 ;  -D MESH_DEBUG=1
 lib_deps = ${ProMicroLLCC68.lib_deps}
   adafruit/RTClib @ ^2.1.3
-  robtillaart/INA3221 @ ^0.4.1  
-  robtillaart/INA219 @ ^0.4.1
 
 [env:ProMicroLLCC68_terminal_chat]
 extends = ProMicroLLCC68
@@ -168,8 +161,6 @@ build_src_filter = ${ProMicroLLCC68.build_src_filter}
 lib_deps = ${ProMicroLLCC68.lib_deps}
   densaugeo/base64 @ ~1.4.0
   adafruit/RTClib @ ^2.1.3
-  robtillaart/INA3221 @ ^0.4.1  
-  robtillaart/INA219 @ ^0.4.1
 
 [env:ProMicroLLCC68_companion_radio_usb]
 extends = ProMicroLLCC68
@@ -183,8 +174,6 @@ build_src_filter = ${ProMicroLLCC68.build_src_filter}
 lib_deps = ${ProMicroLLCC68.lib_deps}
   adafruit/RTClib @ ^2.1.3
   densaugeo/base64 @ ~1.4.0
-  robtillaart/INA3221 @ ^0.4.1  
-  robtillaart/INA219 @ ^0.4.1
 
 [env:ProMicroLLCC68_companion_radio_ble]
 extends = ProMicroLLCC68
@@ -204,5 +193,3 @@ build_src_filter = ${ProMicroLLCC68.build_src_filter}
 lib_deps = ${ProMicroLLCC68.lib_deps}
   adafruit/RTClib @ ^2.1.3
   densaugeo/base64 @ ~1.4.0
-  robtillaart/INA3221 @ ^0.4.1  
-  robtillaart/INA219 @ ^0.4.1

--- a/variants/promicro/target.h
+++ b/variants/promicro/target.h
@@ -10,6 +10,7 @@
 #include <helpers/SensorManager.h>
 #include <INA3221.h>
 #include <INA219.h>
+#include <Adafruit_AHTX0.h>
 
 #define NUM_SENSOR_SETTINGS 3
 
@@ -26,6 +27,7 @@ mesh::LocalIdentity radio_new_identity();
 
 #define TELEM_INA3221_ADDRESS 0x42      // INA3221 3 channel current sensor I2C address
 #define TELEM_INA219_ADDRESS  0x40      // INA219 single channel current sensor I2C address
+#define TELEM_AHTX_ADDRESS    0x38      // AHT10, AHT20 temperature and humidity sensor I2C address
 
 #define TELEM_INA3221_SHUNT_VALUE 0.100 // most variants will have a 0.1 ohm shunts
 #define TELEM_INA3221_SETTING_CH1 "INA3221-1"
@@ -38,13 +40,15 @@ mesh::LocalIdentity radio_new_identity();
 class PromicroSensorManager: public SensorManager {
   bool INA3221initialized = false;
   bool INA219initialized = false;
+  bool AHTXinitialized = false;
 
   // INA3221 channels in telemetry
-  int INA3221_CHANNELS[NUM_SENSOR_SETTINGS] = {TELEM_CHANNEL_SELF + 1, TELEM_CHANNEL_SELF + 2, TELEM_CHANNEL_SELF+ 3};
   const char * INA3221_CHANNEL_NAMES[NUM_SENSOR_SETTINGS] = { TELEM_INA3221_SETTING_CH1, TELEM_INA3221_SETTING_CH2, TELEM_INA3221_SETTING_CH3};
   bool INA3221_CHANNEL_ENABLED[NUM_SENSOR_SETTINGS] = {true, true, true};
   
-  int INA219_CHANNEL;
+  void initINA3221();
+  void initINA219();
+  void initAHTX();
 public:
   PromicroSensorManager(){};
   bool begin() override;


### PR DESCRIPTION
1. Added support of Adafruit AHT10/20 temperature and humidity sensor to Promicro based boards
2. Temperature/humidity values are bound to the SELF channel in telemetry response
3. Moved sensor libs to Faketec/LLCC68 libpath instead of having them in each build target. Built them all to make sure that the lib path is good.