### PR TITLE
t-beam supreme: PMU and i2c fixes

### DIFF
--- a/src/helpers/TBeamS3SupremeBoard.h
+++ b/src/helpers/TBeamS3SupremeBoard.h
@@ -15,8 +15,8 @@
 #define  P_LORA_MISO    13  //SX1262 MISO pin
 #define  P_LORA_MOSI    11  //SX1262 MOSI pin
 
-#define PIN_BOARD_SDA 17  //SDA for OLED, BME280, and QMC6310U (0x1C)
-#define PIN_BOARD_SCL 18  //SCL for OLED, BME280, and QMC6310U (0x1C)
+//#define PIN_BOARD_SDA 17  //SDA for OLED, BME280, and QMC6310U (0x1C)
+//#define PIN_BOARD_SCL 18  //SCL for OLED, BME280, and QMC6310U (0x1C)
 
 #define PIN_BOARD_SDA1 42  //SDA for PMU and PFC8563 (RTC)
 #define PIN_BOARD_SCL1 41  //SCL for PMU and PFC8563 (RTC)
@@ -58,6 +58,7 @@ public:
   void printPMU();
 #endif
   bool power_init();
+
   void begin() {
 
     power_init();

--- a/variants/lilygo_tbeam_supreme_SX1262/platformio.ini
+++ b/variants/lilygo_tbeam_supreme_SX1262/platformio.ini
@@ -6,6 +6,8 @@ build_flags =
   -I variants/lilygo_tbeam_supreme_SX1262
   -D LORA_TX_POWER=22
   -D P_LORA_TX_LED=6
+  -D PIN_BOARD_SDA=17
+  -D PIN_BOARD_SCL=18
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper
   ;-D DISPLAY_CLASS=SSD1306Display      ;Needs to be modified for SH1106

--- a/variants/lilygo_tbeam_supreme_SX1262/target.cpp
+++ b/variants/lilygo_tbeam_supreme_SX1262/target.cpp
@@ -27,6 +27,69 @@ TbeamSupSensorManager sensors = TbeamSupSensorManager(nmea);
 static void setPMUIntFlag(){
   pmuIntFlag = true;
 }
+
+uint32_t deviceOnline = 0x00;
+
+void scanDevices(TwoWire *w)
+{
+    uint8_t err, addr;
+    int nDevices = 0;
+    uint32_t start = 0;
+
+    Serial.println("Scanning I2C for Devices");
+    for (addr = 1; addr < 127; addr++) {
+        start = millis();
+        w->beginTransmission(addr); delay(2);
+        err = w->endTransmission();
+        if (err == 0) {
+            nDevices++;
+            switch (addr) {
+            case 0x77:
+            case 0x76:
+                Serial.println("\tFound BMX280 Sensor");
+                deviceOnline |= BME280_ONLINE;
+                break;
+            case 0x34:
+                Serial.println("\tFound AXP192/AXP2101 PMU");
+                deviceOnline |= POWERMANAGE_ONLINE;
+                break;
+            case 0x3C:
+                Serial.println("\tFound SSD1306/SH1106 dispaly");
+                deviceOnline |= DISPLAY_ONLINE;
+                break;
+            case 0x51:
+                Serial.println("\tFound PCF8563 RTC");
+                deviceOnline |= PCF8563_ONLINE;
+                break;
+            case 0x1C:
+                Serial.println("\tFound QMC6310 MAG Sensor");
+                deviceOnline |= QMC6310_ONLINE;
+                break;
+            default:
+                Serial.print("\tI2C device found at address 0x");
+                if (addr < 16) {
+                    Serial.print("0");
+                }
+                Serial.print(addr, HEX);
+                Serial.println(" !");
+                break;
+            }
+
+        } else if (err == 4) {
+            Serial.print("Unknow error at address 0x");
+            if (addr < 16) {
+                Serial.print("0");
+            }
+            Serial.println(addr, HEX);
+        }
+    }
+    if (nDevices == 0)
+        Serial.println("No I2C devices found\n");
+
+    Serial.println("Scan for devices is complete.");
+    Serial.println("\n");
+}
+
 #ifdef MESH_DEBUG
 void TBeamS3SupremeBoard::printPMU()
 {
@@ -58,9 +121,9 @@ bool TBeamS3SupremeBoard::power_init()
   PMU.setChargingLedMode(XPOWERS_CHG_LED_CTRL_CHG);
 
   // Set up PMU interrupts
-  MESH_DEBUG_PRINTLN("Setting up PMU interrupts");
-  pinMode(PIN_PMU_IRQ, INPUT_PULLUP);
-  attachInterrupt(PIN_PMU_IRQ, setPMUIntFlag, FALLING);
+  // MESH_DEBUG_PRINTLN("Setting up PMU interrupts");
+  // pinMode(PIN_PMU_IRQ, INPUT_PULLUP);
+  // attachInterrupt(PIN_PMU_IRQ, setPMUIntFlag, FALLING);
 
   // GPS
   MESH_DEBUG_PRINTLN("Setting and enabling a-ldo4 for GPS");
@@ -73,24 +136,29 @@ bool TBeamS3SupremeBoard::power_init()
   PMU.enableALDO3();
 
   // To avoid SPI bus issues during power up, reset OLED, sensor, and SD card supplies
-  MESH_DEBUG_PRINTLN("Reset a-ldo1&2 and b-ldo1");
-  if (ESP_SLEEP_WAKEUP_UNDEFINED == esp_sleep_get_wakeup_cause())
-  {
-    PMU.disableALDO1();
-    PMU.disableALDO2();
-    PMU.disableBLDO1();
-    delay(250);
-  }
+  // MESH_DEBUG_PRINTLN("Reset a-ldo1&2 and b-ldo1");
+  // if (ESP_SLEEP_WAKEUP_UNDEFINED == esp_sleep_get_wakeup_cause())
+  // {
+  //   PMU.disableALDO1();
+  //   PMU.disableALDO2();
+  //   PMU.disableBLDO1();
+  //   delay(250);
+  // }
 
-  // BME280 and OLED
-  MESH_DEBUG_PRINTLN("Setting and enabling a-ldo1 for oled");
-  PMU.setALDO1Voltage(3300);
-  PMU.enableALDO1();
+  // m.2 interface
+  MESH_DEBUG_PRINTLN("Setting and enabling dcdc3 for m.2 interface");
+  PMU.setDC3Voltage(3300); // doesn't go anywhere in the schematic??
+  PMU.enableDC3();
 
   // QMC6310U
   MESH_DEBUG_PRINTLN("Setting and enabling a-ldo2 for QMC");
   PMU.setALDO2Voltage(3300);
   PMU.enableALDO2(); // disable to save power
+
+  // BME280 and OLED
+  MESH_DEBUG_PRINTLN("Setting and enabling a-ldo1 for oled");
+  PMU.setALDO1Voltage(3300);
+  PMU.enableALDO1();
 
   // SD card
   MESH_DEBUG_PRINTLN("Setting and enabling b-ldo2 for SD card");
@@ -98,49 +166,53 @@ bool TBeamS3SupremeBoard::power_init()
   PMU.enableBLDO1();
 
   // Out to header pins
-  MESH_DEBUG_PRINTLN("Setting and enabling b-ldo2 for output to header");
-  PMU.setBLDO2Voltage(3300);
-  PMU.enableBLDO2();
+  // MESH_DEBUG_PRINTLN("Setting and enabling b-ldo2 for output to header");
+  // PMU.setBLDO2Voltage(3300);
+  // PMU.enableBLDO2();
 
-  MESH_DEBUG_PRINTLN("Setting and enabling dcdc4 for output to header");
-  PMU.setDC4Voltage(XPOWERS_AXP2101_DCDC4_VOL2_MAX); // 1.8V
-  PMU.enableDC4();
+  // MESH_DEBUG_PRINTLN("Setting and enabling dcdc4 for output to header");
+  // PMU.setDC4Voltage(XPOWERS_AXP2101_DCDC4_VOL2_MAX); // 1.8V
+  // PMU.enableDC4();
 
-  MESH_DEBUG_PRINTLN("Setting and enabling dcdc5 for output to header");
-  PMU.setDC5Voltage(3300);
-  PMU.enableDC5();
-
-  // Other power rails
-  MESH_DEBUG_PRINTLN("Setting and enabling dcdc3 for ?");
-  PMU.setDC3Voltage(3300); // doesn't go anywhere in the schematic??
-  PMU.enableDC3();
+  // MESH_DEBUG_PRINTLN("Setting and enabling dcdc5 for output to header");
+  // PMU.setDC5Voltage(3300);
+  // PMU.enableDC5();
 
   // Unused power rails
   MESH_DEBUG_PRINTLN("Disabling unused supplies dcdc2, dldo1 and dldo2");
   PMU.disableDC2();
+  PMU.disableDC5();
   PMU.disableDLDO1();
   PMU.disableDLDO2();
 
-  // Set charge current to 300mA
+  PMU.disableIRQ(XPOWERS_AXP2101_ALL_IRQ);
+
+  // Set charge current to 500mA
   MESH_DEBUG_PRINTLN("Setting battery charge current limit and voltage");
   PMU.setChargerConstantCurr(XPOWERS_AXP2101_CHG_CUR_500MA);
   PMU.setChargeTargetVoltage(XPOWERS_AXP2101_CHG_VOL_4V2);
 
+  PMU.clearIrqStatus();
+  PMU.disableTSPinMeasure();
+
   // enable battery voltage measurement
   MESH_DEBUG_PRINTLN("Enabling battery measurement");
   PMU.enableBattVoltageMeasure();
+  PMU.enableVbusVoltageMeasure();
 
   // Reset and re-enable PMU interrupts
-  MESH_DEBUG_PRINTLN("Re-enable interrupts");
-  PMU.disableIRQ(XPOWERS_AXP2101_ALL_IRQ);
-  PMU.clearIrqStatus();
-  PMU.enableIRQ(
-      XPOWERS_AXP2101_BAT_INSERT_IRQ | XPOWERS_AXP2101_BAT_REMOVE_IRQ |    // Battery interrupts
-      XPOWERS_AXP2101_VBUS_INSERT_IRQ | XPOWERS_AXP2101_VBUS_REMOVE_IRQ |  // VBUS interrupts
-      XPOWERS_AXP2101_PKEY_SHORT_IRQ | XPOWERS_AXP2101_PKEY_LONG_IRQ |     // Power Key interrupts
-      XPOWERS_AXP2101_BAT_CHG_DONE_IRQ | XPOWERS_AXP2101_BAT_CHG_START_IRQ // Charging interrupts
-  );
+  // MESH_DEBUG_PRINTLN("Re-enable interrupts");
+  // PMU.disableIRQ(XPOWERS_AXP2101_ALL_IRQ);
+  // PMU.clearIrqStatus();
+  // PMU.enableIRQ(
+  //     XPOWERS_AXP2101_BAT_INSERT_IRQ | XPOWERS_AXP2101_BAT_REMOVE_IRQ |    // Battery interrupts
+  //     XPOWERS_AXP2101_VBUS_INSERT_IRQ | XPOWERS_AXP2101_VBUS_REMOVE_IRQ |  // VBUS interrupts
+  //     XPOWERS_AXP2101_PKEY_SHORT_IRQ | XPOWERS_AXP2101_PKEY_LONG_IRQ |     // Power Key interrupts
+  //     XPOWERS_AXP2101_BAT_CHG_DONE_IRQ | XPOWERS_AXP2101_BAT_CHG_START_IRQ // Charging interrupts
+  // );
 #ifdef MESH_DEBUG
+  // scanDevices(&Wire);
+  // scanDevices(&Wire1);
   printPMU();
 #endif
 
@@ -217,7 +289,7 @@ static bool l76kProbe()
 
 bool radio_init() {
   fallback_clock.begin();
-  Wire1.begin(PIN_BOARD_SDA1,PIN_BOARD_SCL1);
+
   rtc_clock.begin(Wire1);
   
 #ifdef SX126X_DIO3_TCXO_VOLTAGE

--- a/variants/lilygo_tbeam_supreme_SX1262/target.cpp
+++ b/variants/lilygo_tbeam_supreme_SX1262/target.cpp
@@ -28,8 +28,8 @@ static void setPMUIntFlag(){
   pmuIntFlag = true;
 }
 
+#ifdef MESH_DEBUG
 uint32_t deviceOnline = 0x00;
-
 void scanDevices(TwoWire *w)
 {
     uint8_t err, addr;
@@ -89,8 +89,6 @@ void scanDevices(TwoWire *w)
     Serial.println("Scan for devices is complete.");
     Serial.println("\n");
 }
-
-#ifdef MESH_DEBUG
 void TBeamS3SupremeBoard::printPMU()
 {
     Serial.print("isCharging:"); Serial.println(PMU.isCharging() ? "YES" : "NO");


### PR DESCRIPTION
Fixed i2c (Wire) init issue by defining pins in platformio 
Added an i2c scanning function for debug
Corrected the pmu power up sequence