### PR TITLE
Increase the delay to 1500 to allow enough time for T114 GPS to start up successfully.

### DIFF
--- a/variants/t114/target.cpp
+++ b/variants/t114/target.cpp
@@ -97,7 +97,7 @@ bool T114SensorManager::begin() {
   digitalWrite(GPS_EN, HIGH);  // Power on GPS
 
   // Give GPS a moment to power up and send data
-  delay(500);
+  delay(1500);
 
   // We'll consider GPS detected if we see any data on Serial1
   gps_detected = (Serial1.available() > 0);


### PR DESCRIPTION
One of the two T114 boards I have has an issue with the GPS: it seems the initial delay of 500 was too short in some situations.
Increasing the delay to 1500 has fixed the problem.