### PR TITLE
RTTTL on message types

### DIFF
--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -59,23 +59,23 @@ void UITask::begin(DisplayDriver* display, NodePrefs* node_prefs, const char* bu
 #endif
 }
 
-void UITask::soundBuzzer(buzzerEventType bet) {
+void UITask::soundBuzzer(UIEventType bet) {
 #if defined(PIN_BUZZER)
 switch(bet){
-  case buzzerEventType::contactMessage:
+  case UIEventType::contactMessage:
     // gemini's pick
     buzzer.play("MsgRcv3:d=4,o=6,b=200:32e,32g,32b,16c7");
     break;
-  case buzzerEventType::channelMessage:
-  case buzzerEventType::roomMessage:
-  case buzzerEventType::newContactMessage:
-  case buzzerEventType::noBuzzer:
+  case UIEventType::channelMessage:
+  case UIEventType::roomMessage:
+  case UIEventType::newContactMessage:
+  case UIEventType::none:
   default:
     break;
 }
 #endif
-  Serial.print("DBG:  Buzzzzzz -> ");
-  Serial.println((int) bet);
+//  Serial.print("DBG:  Buzzzzzz -> ");
+//  Serial.println((int) bet);
 }
 
 void UITask::msgRead(int msgcount) {

--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -59,12 +59,23 @@ void UITask::begin(DisplayDriver* display, NodePrefs* node_prefs, const char* bu
 #endif
 }
 
-void UITask::soundBuzzer() {
+void UITask::soundBuzzer(buzzerEventType bet) {
 #if defined(PIN_BUZZER)
-  // gemini's pick
-  buzzer.play("MsgRcv3:d=4,o=6,b=200:32e,32g,32b,16c7");
-  //Serial.println("DBG:  Buzzzzzz");
+switch(bet){
+  case buzzerEventType::contactMessage:
+    // gemini's pick
+    buzzer.play("MsgRcv3:d=4,o=6,b=200:32e,32g,32b,16c7");
+    break;
+  case buzzerEventType::channelMessage:
+  case buzzerEventType::roomMessage:
+  case buzzerEventType::newContactMessage:
+  case buzzerEventType::noBuzzer:
+  default:
+    break;
+}
 #endif
+  Serial.print("DBG:  Buzzzzzz -> ");
+  Serial.println((int) bet);
 }
 
 void UITask::msgRead(int msgcount) {

--- a/examples/companion_radio/UITask.h
+++ b/examples/companion_radio/UITask.h
@@ -10,6 +10,15 @@
 
 #include "NodePrefs.h"
 
+ enum class UIEventType
+{
+    none,
+    contactMessage,
+    channelMessage,
+    roomMessage,
+    newContactMessage
+};
+
 class UITask {
   DisplayDriver* _display;
   mesh::MainBoard* _board;
@@ -31,6 +40,7 @@ class UITask {
   void userLedHandler();
   void renderBatteryIndicator(uint16_t batteryMilliVolts);
 
+ 
 public:
 
   UITask(mesh::MainBoard* board) : _board(board), _display(NULL) {
@@ -44,6 +54,6 @@ public:
   void clearMsgPreview();
   void msgRead(int msgcount);
   void newMsg(uint8_t path_len, const char* from_name, const char* text, int msgcount);
-  void soundBuzzer(buzzerEventType bet = buzzerEventType::noBuzzer);
+  void soundBuzzer(UIEventType bet = UIEventType::none);
   void loop();
 };

--- a/examples/companion_radio/UITask.h
+++ b/examples/companion_radio/UITask.h
@@ -44,6 +44,6 @@ public:
   void clearMsgPreview();
   void msgRead(int msgcount);
   void newMsg(uint8_t path_len, const char* from_name, const char* text, int msgcount);
-  void soundBuzzer();
+  void soundBuzzer(buzzerEventType bet = buzzerEventType::noBuzzer);
   void loop();
 };

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -520,7 +520,7 @@ protected:
       }
     } else {
     #ifdef DISPLAY_CLASS
-      ui_task.soundBuzzer();
+      ui_task.soundBuzzer(buzzerEventType::newContactMessage);
     #endif
     }
 
@@ -583,7 +583,7 @@ protected:
       _serial->writeFrame(frame, 1);
     } else {
     #ifdef DISPLAY_CLASS
-      ui_task.soundBuzzer();
+      ui_task.soundBuzzer(buzzerEventType::contactMessage);
     #endif
     }
   #ifdef DISPLAY_CLASS

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -520,7 +520,7 @@ protected:
       }
     } else {
     #ifdef DISPLAY_CLASS
-      ui_task.soundBuzzer(buzzerEventType::newContactMessage);
+      ui_task.soundBuzzer(UIEventType::newContactMessage);
     #endif
     }
 
@@ -583,7 +583,7 @@ protected:
       _serial->writeFrame(frame, 1);
     } else {
     #ifdef DISPLAY_CLASS
-      ui_task.soundBuzzer(buzzerEventType::contactMessage);
+      ui_task.soundBuzzer(UIEventType::contactMessage);
     #endif
     }
   #ifdef DISPLAY_CLASS
@@ -636,7 +636,7 @@ protected:
       _serial->writeFrame(frame, 1);
     } else {
     #ifdef DISPLAY_CLASS
-      ui_task.soundBuzzer();
+      ui_task.soundBuzzer(UIEventType::channelMessage);
     #endif
     }
   #ifdef DISPLAY_CLASS

--- a/src/helpers/ui/buzzer.cpp
+++ b/src/helpers/ui/buzzer.cpp
@@ -2,8 +2,8 @@
 #include "buzzer.h"
 
 void genericBuzzer::begin() {
-    Serial.print("DBG: Setting up buzzer on pin ");
-    Serial.println(PIN_BUZZER);
+//    Serial.print("DBG: Setting up buzzer on pin ");
+//    Serial.println(PIN_BUZZER);
     #ifdef PIN_BUZZER_EN
       pinMode(PIN_BUZZER_EN, OUTPUT);
       digitalWrite(PIN_BUZZER_EN, HIGH);

--- a/src/helpers/ui/buzzer.h
+++ b/src/helpers/ui/buzzer.h
@@ -15,6 +15,16 @@
     - make message ring tone configurable
 
 */
+
+enum class buzzerEventType
+{
+    noBuzzer,
+    contactMessage,
+    channelMessage,
+    roomMessage,
+    newContactMessage
+};
+
 class genericBuzzer
 {
     public:

--- a/src/helpers/ui/buzzer.h
+++ b/src/helpers/ui/buzzer.h
@@ -16,15 +16,6 @@
 
 */
 
-enum class buzzerEventType
-{
-    noBuzzer,
-    contactMessage,
-    channelMessage,
-    roomMessage,
-    newContactMessage
-};
-
 class genericBuzzer
 {
     public:


### PR DESCRIPTION
Add enums for message event types

Implemented on contactMessage with hard coded melody.

All other messages types suppressed.  This is just:
newContactMessage
channelMessage