### PR TITLE
Set default companion node name via build flags

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -863,6 +863,11 @@ public:
     mesh::Utils::toHex(pub_key_hex, self_id.pub_key, 4);
     strcpy(_prefs.node_name, pub_key_hex);
 
+    // if name is provided as a build flag, use that as default node name instead
+    #ifdef ADVERT_NAME
+    strcpy(_prefs.node_name, ADVERT_NAME);
+    #endif
+
     // load persisted prefs
     if (_fs->exists("/new_prefs")) {
       loadPrefsInt("/new_prefs");   // new filename


### PR DESCRIPTION
This PR allows configuring the default name for a companion node via build flags. I've used the same build flag name as the repeater and room server firmwares.

```
-D ADVERT_NAME='"Custom Device 001"'
 ```