### PR TITLE
ProMicro GPS support

### DIFF
--- a/src/helpers/nrf52/PromicroBoard.h
+++ b/src/helpers/nrf52/PromicroBoard.h
@@ -19,6 +19,11 @@
 #define  PIN_VBAT_READ 17
 #define  ADC_MULTIPLIER   (1.815f) // dependent on voltage divider resistors. TODO: more accurate battery tracking
 
+#define PIN_GPS_EN 5  // P0.24
+#define PIN_GPS_RX 3  // P0.20
+#define PIN_GPS_TX 4  // P0.22
+
+
 class PromicroBoard : public mesh::MainBoard {
 protected:
   uint8_t startup_reason;

--- a/variants/promicro/platformio.ini
+++ b/variants/promicro/platformio.ini
@@ -13,6 +13,10 @@ build_flags = ${nrf52840_base.build_flags}
   -D PIN_BOARD_SDA=8
   -D PIN_OLED_RESET=-1
   -D PIN_USER_BTN=6
+  -D PIN_GPS_TX=4
+  -D PIN_GPS_RX=3
+  -D PIN_GPS_EN=5
+  
 build_src_filter = ${nrf52840_base.build_src_filter}
   +<helpers/nrf52/PromicroBoard.cpp>
   +<../variants/promicro>
@@ -21,6 +25,7 @@ lib_deps= ${nrf52840_base.lib_deps}
   robtillaart/INA3221 @ ^0.4.1
   robtillaart/INA219 @ ^0.4.1
   adafruit/Adafruit AHTX0@^2.0.5
+  stevemarple/MicroNMEA @ ^2.0.6
 
 [env:Faketec_Repeater]
 extends = Faketec
@@ -97,7 +102,7 @@ build_flags = ${Faketec.build_flags}
   -D OFFLINE_QUEUE_SIZE=256
   -D DISPLAY_CLASS=SSD1306Display
 ;  -D MESH_PACKET_LOGGING=1
-;  -D MESH_DEBUG=1
+  -D MESH_DEBUG=1
 build_src_filter = ${Faketec.build_src_filter}
   +<helpers/nrf52/SerialBLEInterface.cpp>
   +<../examples/companion_radio>

--- a/variants/promicro/target.cpp
+++ b/variants/promicro/target.cpp
@@ -128,6 +128,10 @@ bool PromicroSensorManager::querySensors(uint8_t requester_permissions, CayenneL
 }
 
 int PromicroSensorManager::getNumSettings() const {
+  // we should probably detect what sensors are available and set this properly
+  if (gps_detected) {
+    return NUM_SENSOR_SETTINGS + 1;
+  }
   return NUM_SENSOR_SETTINGS;
 }
 

--- a/variants/promicro/target.h
+++ b/variants/promicro/target.h
@@ -14,6 +14,7 @@
 #ifdef DISPLAY_CLASS
   #include <helpers/ui/SSD1306Display.h>
 #endif
+#include <helpers/sensors/LocationProvider.h>
 
 #define NUM_SENSOR_SETTINGS 3
 
@@ -44,6 +45,10 @@ mesh::LocalIdentity radio_new_identity();
 #define TELEM_INA219_MAX_CURRENT 5
 
 class PromicroSensorManager: public SensorManager {
+  bool gps_active = false;
+  bool gps_detected = false;
+  LocationProvider* _location;
+
   bool INA3221initialized = false;
   bool INA219initialized = false;
   bool AHTXinitialized = false;
@@ -55,14 +60,19 @@ class PromicroSensorManager: public SensorManager {
   void initINA3221();
   void initINA219();
   void initAHTX();
+
+  void initGPS();
+  void start_gps();
+  void stop_gps();
 public:
-  PromicroSensorManager(){};
+  PromicroSensorManager(LocationProvider &location): _location(&location) {};
   bool begin() override;
   bool querySensors(uint8_t requester_permissions, CayenneLPP& telemetry) override;
   int getNumSettings() const override;
   const char* getSettingName(int i) const override;
   const char* getSettingValue(int i) const override;
   bool setSettingValue(const char* name, const char* value) override;
+  void loop() override;
 };
 
 


### PR DESCRIPTION
Support for NMEA based GPS on ProMicro. Tested working with ublox neo-6m.

@ngavars Maybe you could take a look at this and make sure it doesn't break your other sensors? We should probably sort out the GetNumSettings function so that it reports correctly depending on what sensors were detected as well?