### PR TITLE
Adding sensor classes support to Heltec v3

### DIFF
--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -17,6 +17,10 @@ build_flags =
   -D SX126X_DIO3_TCXO_VOLTAGE=1.8
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
+  -D ENV_INCLUDE_AHTX0=1
+  -D ENV_INCLUDE_BME280=1
+  -D ENV_INCLUDE_INA3221=1
+  -D ENV_INCLUDE_INA219=1  
 build_src_filter = ${esp32_base.build_src_filter}
   +<../variants/heltec_v3>
   +<helpers/sensors>    

--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -43,7 +43,6 @@ build_flags =
 build_src_filter = ${Heltec_lora32_v3.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_repeater>
-  +<helpers/sensors>    
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   ${esp32_ota.lib_deps}
@@ -63,7 +62,6 @@ build_flags =
 build_src_filter = ${Heltec_lora32_v3.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_room_server>
-  +<helpers/sensors>    
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   ${esp32_ota.lib_deps}
@@ -78,7 +76,6 @@ build_flags =
 ;  -D MESH_DEBUG=1
 build_src_filter = ${Heltec_lora32_v3.build_src_filter}
   +<../examples/simple_secure_chat/main.cpp>
-  +<helpers/sensors>    
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -97,7 +94,6 @@ build_flags =
 build_src_filter = ${Heltec_lora32_v3.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<../examples/companion_radio>
-  +<helpers/sensors>    
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -120,7 +116,6 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio>
-  +<helpers/sensors>    
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -143,7 +138,6 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio>
-  +<helpers/sensors>      
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0

--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -47,10 +47,6 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   ${esp32_ota.lib_deps}
-  adafruit/Adafruit INA3221 Library @ ^1.0.1
-  adafruit/Adafruit INA219 @ ^1.2.3
-  adafruit/Adafruit AHTX0 @ ^2.0.5
-  adafruit/Adafruit BME280 Library @ ^2.3.0  
 
 [env:Heltec_v3_room_server]
 extends = Heltec_lora32_v3
@@ -71,10 +67,6 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   ${esp32_ota.lib_deps}
-  adafruit/Adafruit INA3221 Library @ ^1.0.1
-  adafruit/Adafruit INA219 @ ^1.2.3
-  adafruit/Adafruit AHTX0 @ ^2.0.5
-  adafruit/Adafruit BME280 Library @ ^2.3.0  
 
 [env:Heltec_v3_terminal_chat]
 extends = Heltec_lora32_v3
@@ -90,10 +82,6 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0
-  adafruit/Adafruit INA3221 Library @ ^1.0.1
-  adafruit/Adafruit INA219 @ ^1.2.3
-  adafruit/Adafruit AHTX0 @ ^2.0.5
-  adafruit/Adafruit BME280 Library @ ^2.3.0    
 
 [env:Heltec_v3_companion_radio_usb]
 extends = Heltec_lora32_v3
@@ -113,10 +101,6 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0
-  adafruit/Adafruit INA3221 Library @ ^1.0.1
-  adafruit/Adafruit INA219 @ ^1.2.3
-  adafruit/Adafruit AHTX0 @ ^2.0.5
-  adafruit/Adafruit BME280 Library @ ^2.3.0  
 
 [env:Heltec_v3_companion_radio_ble]
 extends = Heltec_lora32_v3
@@ -140,10 +124,6 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0
-  adafruit/Adafruit INA3221 Library @ ^1.0.1
-  adafruit/Adafruit INA219 @ ^1.2.3
-  adafruit/Adafruit AHTX0 @ ^2.0.5
-  adafruit/Adafruit BME280 Library @ ^2.3.0    
 
 [env:Heltec_v3_companion_radio_wifi]
 extends = Heltec_lora32_v3
@@ -167,10 +147,6 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0
-  adafruit/Adafruit INA3221 Library @ ^1.0.1
-  adafruit/Adafruit INA219 @ ^1.2.3
-  adafruit/Adafruit AHTX0 @ ^2.0.5
-  adafruit/Adafruit BME280 Library @ ^2.3.0    
 
 [env:Heltec_WSL3_repeater]
 extends = Heltec_lora32_v3

--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -19,9 +19,14 @@ build_flags =
   -D SX126X_RX_BOOSTED_GAIN=1
 build_src_filter = ${esp32_base.build_src_filter}
   +<../variants/heltec_v3>
+  +<helpers/sensors>    
 lib_deps =
   ${esp32_base.lib_deps}
   adafruit/Adafruit SSD1306 @ ^2.5.13
+  adafruit/Adafruit INA3221 Library @ ^1.0.1
+  adafruit/Adafruit INA219 @ ^1.2.3
+  adafruit/Adafruit AHTX0 @ ^2.0.5
+  adafruit/Adafruit BME280 Library @ ^2.3.0    
 
 [env:Heltec_v3_repeater]
 extends = Heltec_lora32_v3
@@ -38,9 +43,14 @@ build_flags =
 build_src_filter = ${Heltec_lora32_v3.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_repeater>
+  +<helpers/sensors>    
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   ${esp32_ota.lib_deps}
+  adafruit/Adafruit INA3221 Library @ ^1.0.1
+  adafruit/Adafruit INA219 @ ^1.2.3
+  adafruit/Adafruit AHTX0 @ ^2.0.5
+  adafruit/Adafruit BME280 Library @ ^2.3.0  
 
 [env:Heltec_v3_room_server]
 extends = Heltec_lora32_v3
@@ -57,9 +67,14 @@ build_flags =
 build_src_filter = ${Heltec_lora32_v3.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_room_server>
+  +<helpers/sensors>    
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   ${esp32_ota.lib_deps}
+  adafruit/Adafruit INA3221 Library @ ^1.0.1
+  adafruit/Adafruit INA219 @ ^1.2.3
+  adafruit/Adafruit AHTX0 @ ^2.0.5
+  adafruit/Adafruit BME280 Library @ ^2.3.0  
 
 [env:Heltec_v3_terminal_chat]
 extends = Heltec_lora32_v3
@@ -71,9 +86,14 @@ build_flags =
 ;  -D MESH_DEBUG=1
 build_src_filter = ${Heltec_lora32_v3.build_src_filter}
   +<../examples/simple_secure_chat/main.cpp>
+  +<helpers/sensors>    
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0
+  adafruit/Adafruit INA3221 Library @ ^1.0.1
+  adafruit/Adafruit INA219 @ ^1.2.3
+  adafruit/Adafruit AHTX0 @ ^2.0.5
+  adafruit/Adafruit BME280 Library @ ^2.3.0    
 
 [env:Heltec_v3_companion_radio_usb]
 extends = Heltec_lora32_v3
@@ -89,9 +109,14 @@ build_flags =
 build_src_filter = ${Heltec_lora32_v3.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<../examples/companion_radio>
+  +<helpers/sensors>    
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0
+  adafruit/Adafruit INA3221 Library @ ^1.0.1
+  adafruit/Adafruit INA219 @ ^1.2.3
+  adafruit/Adafruit AHTX0 @ ^2.0.5
+  adafruit/Adafruit BME280 Library @ ^2.3.0  
 
 [env:Heltec_v3_companion_radio_ble]
 extends = Heltec_lora32_v3
@@ -111,9 +136,14 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio>
+  +<helpers/sensors>    
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0
+  adafruit/Adafruit INA3221 Library @ ^1.0.1
+  adafruit/Adafruit INA219 @ ^1.2.3
+  adafruit/Adafruit AHTX0 @ ^2.0.5
+  adafruit/Adafruit BME280 Library @ ^2.3.0    
 
 [env:Heltec_v3_companion_radio_wifi]
 extends = Heltec_lora32_v3
@@ -133,9 +163,14 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio>
+  +<helpers/sensors>      
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0
+  adafruit/Adafruit INA3221 Library @ ^1.0.1
+  adafruit/Adafruit INA219 @ ^1.2.3
+  adafruit/Adafruit AHTX0 @ ^2.0.5
+  adafruit/Adafruit BME280 Library @ ^2.3.0    
 
 [env:Heltec_WSL3_repeater]
 extends = Heltec_lora32_v3

--- a/variants/heltec_v3/target.cpp
+++ b/variants/heltec_v3/target.cpp
@@ -14,7 +14,7 @@ WRAPPER_CLASS radio_driver(radio, board);
 
 ESP32RTCClock fallback_clock;
 AutoDiscoverRTCClock rtc_clock(fallback_clock);
-SensorManager sensors;
+EnvironmentSensorManager sensors;
 
 #ifdef DISPLAY_CLASS
   DISPLAY_CLASS display;

--- a/variants/heltec_v3/target.h
+++ b/variants/heltec_v3/target.h
@@ -7,6 +7,7 @@
 #include <helpers/CustomSX1262Wrapper.h>
 #include <helpers/AutoDiscoverRTCClock.h>
 #include <helpers/SensorManager.h>
+#include <helpers/sensors/EnvironmentSensorManager.h>
 #ifdef DISPLAY_CLASS
   #include <helpers/ui/SSD1306Display.h>
 #endif
@@ -14,7 +15,7 @@
 extern HeltecV3Board board;
 extern WRAPPER_CLASS radio_driver;
 extern AutoDiscoverRTCClock rtc_clock;
-extern SensorManager sensors;
+extern EnvironmentSensorManager sensors;
 
 #ifdef DISPLAY_CLASS
   extern DISPLAY_CLASS display;


### PR DESCRIPTION
Adding sensor classes support to Heltec v3

Works with pin 17 and 18 only. Using 41 and 42 causes display problems.

![20250522-1320](https://github.com/user-attachments/assets/165aebce-a8b1-426a-9284-63652d39e83c)
