### PR TITLE
Add sensor support to Xiao Nrf

### DIFF
--- a/variants/xiao_nrf52/platformio.ini
+++ b/variants/xiao_nrf52/platformio.ini
@@ -16,6 +16,11 @@ lib_ignore =
 lib_deps =
   ${nrf52_base.lib_deps}
   rweather/Crypto @ ^0.4.0
+  adafruit/Adafruit INA3221 Library @ ^1.0.1
+  adafruit/Adafruit INA219 @ ^1.2.3
+  adafruit/Adafruit AHTX0 @ ^2.0.5
+  adafruit/Adafruit BME280 Library @ ^2.3.0  
+
 
 [Xiao_nrf52]
 extends = nrf52840_xiao
@@ -35,8 +40,15 @@ build_flags = ${nrf52840_xiao.build_flags}
   -D SX126X_DIO3_TCXO_VOLTAGE=1.8
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
+  -D PIN_WIRE_SCL=6
+  -D PIN_WIRE_SDA=7
+  -D ENV_INCLUDE_AHTX0=1
+  -D ENV_INCLUDE_BME280=1
+  -D ENV_INCLUDE_INA3221=1
+  -D ENV_INCLUDE_INA219=1
 build_src_filter = ${nrf52840_xiao.build_src_filter}
   +<helpers/*.cpp>
+  +<helpers/sensors>  
   +<helpers/nrf52/XiaoNrf52Board.cpp>
   +<../variants/xiao_nrf52>
 debug_tool = jlink

--- a/variants/xiao_nrf52/target.cpp
+++ b/variants/xiao_nrf52/target.cpp
@@ -9,7 +9,7 @@ RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BU
 WRAPPER_CLASS radio_driver(radio, board);
 
 VolatileRTCClock rtc_clock;
-SensorManager sensors;
+EnvironmentSensorManager sensors;
 
 #ifndef LORA_CR
   #define LORA_CR      5

--- a/variants/xiao_nrf52/target.h
+++ b/variants/xiao_nrf52/target.h
@@ -6,12 +6,12 @@
 #include <helpers/nrf52/XiaoNrf52Board.h>
 #include <helpers/CustomSX1262Wrapper.h>
 #include <helpers/ArduinoHelpers.h>
-#include <helpers/SensorManager.h>
+#include <helpers/sensors/EnvironmentSensorManager.h>
 
 extern XiaoNrf52Board board;
 extern WRAPPER_CLASS radio_driver;
 extern VolatileRTCClock rtc_clock;
-extern SensorManager sensors;
+extern EnvironmentSensorManager sensors;
 
 bool radio_init();
 uint32_t radio_get_rng_seed();

--- a/variants/xiao_nrf52/variant.h
+++ b/variants/xiao_nrf52/variant.h
@@ -110,8 +110,8 @@ static const uint8_t A5  = PIN_A5;
 // Wire Interfaces
 #define WIRE_INTERFACES_COUNT   (1)
 
-#define PIN_WIRE_SDA            (17) // 4 and 5 are used for the sx1262 !
-#define PIN_WIRE_SCL            (16) // use WIRE1_SDA
+// #define PIN_WIRE_SDA            (17) // 4 and 5 are used for the sx1262 !
+// #define PIN_WIRE_SCL            (16) // use WIRE1_SDA
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;


### PR DESCRIPTION
This PR adds sensor support to Xiao Nrf. GPS is not enabled because it needs 3 additional pins.