### PR TITLE
Enable buzzer for Thinknode M1, add scaling to bitmaps for GxEPDDisplay

### DIFF
--- a/src/helpers/ui/GxEPDDisplay.cpp
+++ b/src/helpers/ui/GxEPDDisplay.cpp
@@ -81,7 +81,39 @@ void GxEPDDisplay::drawRect(int x, int y, int w, int h) {
 }
 
 void GxEPDDisplay::drawXbm(int x, int y, const uint8_t* bits, int w, int h) {
-  display.drawBitmap(x*SCALE_X, (y*SCALE_Y) + 10, bits, w, h, GxEPD_BLACK);
+  // Calculate the base position in display coordinates
+  uint16_t startX = x * SCALE_X;
+  uint16_t startY = y * SCALE_Y;
+  
+  // Width in bytes for bitmap processing
+  uint16_t widthInBytes = (w + 7) / 8;
+  
+  // Process the bitmap row by row
+  for (uint16_t by = 0; by < h; by++) {
+    // Calculate the target y-coordinates for this logical row
+    int y1 = startY + (int)(by * SCALE_Y);
+    int y2 = startY + (int)((by + 1) * SCALE_Y);
+    int block_h = y2 - y1;
+    
+    // Scan across the row bit by bit
+    for (uint16_t bx = 0; bx < w; bx++) {
+      // Calculate the target x-coordinates for this logical column
+      int x1 = startX + (int)(bx * SCALE_X);
+      int x2 = startX + (int)((bx + 1) * SCALE_X);
+      int block_w = x2 - x1;
+      
+      // Get the current bit
+      uint16_t byteOffset = (by * widthInBytes) + (bx / 8);
+      uint8_t bitMask = 0x80 >> (bx & 7);
+      bool bitSet = pgm_read_byte(bits + byteOffset) & bitMask;
+      
+      // If the bit is set, draw a block of pixels
+      if (bitSet) {
+        // Draw the block as a filled rectangle
+        display.fillRect(x1, y1, block_w, block_h, GxEPD_BLACK);
+      }
+    }
+  }
 }
 
 uint16_t GxEPDDisplay::getTextWidth(const char* str) {

--- a/variants/thinknode_m1/platformio.ini
+++ b/variants/thinknode_m1/platformio.ini
@@ -71,6 +71,7 @@ build_flags =
   -D DISPLAY_ROTATION=4
   -D DISPLAY_CLASS=GxEPDDisplay
   -D OFFLINE_QUEUE_SIZE=256
+  -D PIN_BUZZER=6
 ;  -D ENABLE_PRIVATE_KEY_IMPORT=1
 ;  -D ENABLE_PRIVATE_KEY_EXPORT=1
 ;  -D MESH_PACKET_LOGGING=1
@@ -79,8 +80,10 @@ build_src_filter = ${ThinkNode_M1.build_src_filter}
   +<helpers/nrf52/ThinkNodeM1.cpp>
   +<helpers/nrf52/SerialBLEInterface.cpp>
   +<helpers/ui/GxEPDDisplay.cpp>
+  +<helpers/ui/buzzer.cpp>
   +<../examples/companion_radio>
 lib_deps =
   ${ThinkNode_M1.lib_deps}
   densaugeo/base64 @ ~1.4.0
   zinggjm/GxEPD2 @ 1.6.2
+  end2endzone/NonBlockingRTTTL@^1.3.0


### PR DESCRIPTION
- Enable the new RTTTL buzzer for Thinknode M1
- Add scaling to bitmaps for GxEPDDisplay (makes the logo the correct size for the display)

scaling code was mostly a port of the code we did on the T114 with a couple changes due to different contract for fillRect and no offset.

Sound needed for this video =)

https://github.com/user-attachments/assets/fb5e2d66-54a4-43ad-bfec-f9f42777469a

