### PR TITLE
Improved Button Management

### DIFF
--- a/examples/companion_radio/Button.cpp
+++ b/examples/companion_radio/Button.cpp
@@ -60,10 +60,10 @@ void Button::update() {
         _state = IDLE;
     }
     
-    // Handle long press
+    // Handle long press while button is held
     if (_state == PRESSED && (now - _pressTime) > BUTTON_LONG_PRESS_TIME_MS) {
         triggerEvent(LONG_PRESS);
-        _state = IDLE;  // Prevent multiple long press events
+        _state = IDLE;  // Prevent multiple press events
         _clickCount = 0;
     }
 }
@@ -97,7 +97,7 @@ void Button::handleStateChange() {
             } else {
                 // Long press already handled in update()
                 _state = IDLE;
-                _clickCount = 0;  // Reset click count after long press
+                _clickCount = 0;
             }
         }
     }

--- a/examples/companion_radio/Button.cpp
+++ b/examples/companion_radio/Button.cpp
@@ -13,9 +13,6 @@ Button::Button(uint8_t pin, bool activeState, bool isAnalog, uint16_t analogThre
 }
 
 void Button::begin() {
-    if (!_isAnalog) {
-        pinMode(_pin, INPUT_PULLUP);
-    }
     _currentState = readButton();
     _lastState = _currentState;
 }

--- a/examples/companion_radio/Button.cpp
+++ b/examples/companion_radio/Button.cpp
@@ -1,0 +1,127 @@
+#include "Button.h"
+
+Button::Button(uint8_t pin, bool activeState) 
+    : _pin(pin), _activeState(activeState), _isAnalog(false), _analogThreshold(20) {
+    _currentState = !_activeState;
+    _lastState = _currentState;
+}
+
+Button::Button(uint8_t pin, bool activeState, bool isAnalog, uint16_t analogThreshold)
+    : _pin(pin), _activeState(activeState), _isAnalog(isAnalog), _analogThreshold(analogThreshold) {
+    _currentState = !_activeState;
+    _lastState = _currentState;
+}
+
+void Button::begin() {
+    if (!_isAnalog) {
+        pinMode(_pin, INPUT_PULLUP);
+    }
+    _currentState = readButton();
+    _lastState = _currentState;
+}
+
+void Button::update() {
+    uint32_t now = millis();
+    
+    // Read button at specified interval
+    if (now - _lastReadTime < BUTTON_READ_INTERVAL_MS) {
+        return;
+    }
+    _lastReadTime = now;
+    
+    bool newState = readButton();
+    
+    // Check if state has changed
+    if (newState != _lastState) {
+        _stateChangeTime = now;
+    }
+    
+    // Debounce check
+    if ((now - _stateChangeTime) > BUTTON_DEBOUNCE_TIME_MS) {
+        if (newState != _currentState) {
+            _currentState = newState;
+            handleStateChange();
+        }
+    }
+    
+    _lastState = newState;
+    
+    // Handle multi-click timeout
+    if (_state == WAITING_FOR_MULTI_CLICK && (now - _releaseTime) > BUTTON_CLICK_TIMEOUT_MS) {
+        // Timeout reached, process the clicks
+        if (_clickCount == 1) {
+            triggerEvent(SHORT_PRESS);
+        } else if (_clickCount == 2) {
+            triggerEvent(DOUBLE_PRESS);
+        } else if (_clickCount >= 3) {
+            triggerEvent(TRIPLE_PRESS);
+        }
+        _clickCount = 0;
+        _state = IDLE;
+    }
+    
+    // Handle long press
+    if (_state == PRESSED && (now - _pressTime) > BUTTON_LONG_PRESS_TIME_MS) {
+        triggerEvent(LONG_PRESS);
+        _state = IDLE;  // Prevent multiple long press events
+        _clickCount = 0;
+    }
+}
+
+bool Button::readButton() {
+    if (_isAnalog) {
+        return (analogRead(_pin) < _analogThreshold) ? _activeState : !_activeState;
+    } else {
+        return digitalRead(_pin);
+    }
+}
+
+void Button::handleStateChange() {
+    uint32_t now = millis();
+    
+    if (_currentState == _activeState) {
+        // Button pressed
+        _pressTime = now;
+        _state = PRESSED;
+        triggerEvent(ANY_PRESS);
+    } else {
+        // Button released
+        if (_state == PRESSED) {
+            uint32_t pressDuration = now - _pressTime;
+            
+            if (pressDuration < BUTTON_LONG_PRESS_TIME_MS) {
+                // Short press detected
+                _clickCount++;
+                _releaseTime = now;
+                _state = WAITING_FOR_MULTI_CLICK;
+            } else {
+                // Long press already handled in update()
+                _state = IDLE;
+            }
+        }
+    }
+}
+
+void Button::triggerEvent(EventType event) {
+    _lastEvent = event;
+    
+    switch (event) {
+        case ANY_PRESS:
+            if (_onAnyPress) _onAnyPress();
+            break;
+        case SHORT_PRESS:
+            if (_onShortPress) _onShortPress();
+            break;
+        case DOUBLE_PRESS:
+            if (_onDoublePress) _onDoublePress();
+            break;
+        case TRIPLE_PRESS:
+            if (_onTriplePress) _onTriplePress();
+            break;
+        case LONG_PRESS:
+            if (_onLongPress) _onLongPress();
+            break;
+        default:
+            break;
+    }
+}

--- a/examples/companion_radio/Button.cpp
+++ b/examples/companion_radio/Button.cpp
@@ -97,6 +97,7 @@ void Button::handleStateChange() {
             } else {
                 // Long press already handled in update()
                 _state = IDLE;
+                _clickCount = 0;  // Reset click count after long press
             }
         }
     }

--- a/examples/companion_radio/Button.cpp
+++ b/examples/companion_radio/Button.cpp
@@ -2,13 +2,13 @@
 
 Button::Button(uint8_t pin, bool activeState) 
     : _pin(pin), _activeState(activeState), _isAnalog(false), _analogThreshold(20) {
-    _currentState = !_activeState;
+    _currentState = false;  // Initialize as not pressed
     _lastState = _currentState;
 }
 
 Button::Button(uint8_t pin, bool activeState, bool isAnalog, uint16_t analogThreshold)
     : _pin(pin), _activeState(activeState), _isAnalog(isAnalog), _analogThreshold(analogThreshold) {
-    _currentState = !_activeState;
+    _currentState = false;  // Initialize as not pressed
     _lastState = _currentState;
 }
 
@@ -70,16 +70,16 @@ void Button::update() {
 
 bool Button::readButton() {
     if (_isAnalog) {
-        return (analogRead(_pin) < _analogThreshold) ? _activeState : !_activeState;
+        return (analogRead(_pin) < _analogThreshold);
     } else {
-        return digitalRead(_pin);
+        return (digitalRead(_pin) == _activeState);
     }
 }
 
 void Button::handleStateChange() {
     uint32_t now = millis();
     
-    if (_currentState == _activeState) {
+    if (_currentState) {
         // Button pressed
         _pressTime = now;
         _state = PRESSED;

--- a/examples/companion_radio/Button.h
+++ b/examples/companion_radio/Button.h
@@ -36,7 +36,7 @@ public:
     void onAnyPress(EventCallback callback) { _onAnyPress = callback; }
     
     // State getters
-    bool isPressed() const { return _currentState == _activeState; }
+    bool isPressed() const { return _currentState; }
     EventType getLastEvent() const { return _lastEvent; }
 
 private:

--- a/examples/companion_radio/Button.h
+++ b/examples/companion_radio/Button.h
@@ -6,7 +6,7 @@
 // Button timing configuration
 #define BUTTON_DEBOUNCE_TIME_MS    50      // Debounce time in ms
 #define BUTTON_CLICK_TIMEOUT_MS    500     // Max time between clicks for multi-click
-#define BUTTON_LONG_PRESS_TIME_MS  5000    // Time to trigger long press (5 seconds)
+#define BUTTON_LONG_PRESS_TIME_MS  3000    // Time to trigger long press (3 seconds)
 #define BUTTON_READ_INTERVAL_MS    10      // How often to read the button
 
 class Button {
@@ -33,7 +33,7 @@ public:
     void onDoublePress(EventCallback callback) { _onDoublePress = callback; }
     void onTriplePress(EventCallback callback) { _onTriplePress = callback; }
     void onLongPress(EventCallback callback) { _onLongPress = callback; }
-    void onAnyPress(EventCallback callback) { _onAnyPress = callback; } // New method
+    void onAnyPress(EventCallback callback) { _onAnyPress = callback; }
     
     // State getters
     bool isPressed() const { return _currentState == _activeState; }

--- a/examples/companion_radio/Button.h
+++ b/examples/companion_radio/Button.h
@@ -5,7 +5,7 @@
 
 // Button timing configuration
 #define BUTTON_DEBOUNCE_TIME_MS    50      // Debounce time in ms
-#define BUTTON_CLICK_TIMEOUT_MS    400     // Max time between clicks for multi-click
+#define BUTTON_CLICK_TIMEOUT_MS    500     // Max time between clicks for multi-click
 #define BUTTON_LONG_PRESS_TIME_MS  5000    // Time to trigger long press (5 seconds)
 #define BUTTON_READ_INTERVAL_MS    10      // How often to read the button
 

--- a/examples/companion_radio/Button.h
+++ b/examples/companion_radio/Button.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <Arduino.h>
+#include <functional>
+
+// Button timing configuration
+#define BUTTON_DEBOUNCE_TIME_MS    50      // Debounce time in ms
+#define BUTTON_CLICK_TIMEOUT_MS    400     // Max time between clicks for multi-click
+#define BUTTON_LONG_PRESS_TIME_MS  5000    // Time to trigger long press (5 seconds)
+#define BUTTON_READ_INTERVAL_MS    10      // How often to read the button
+
+class Button {
+public:
+    enum EventType {
+        NONE,
+        SHORT_PRESS,
+        DOUBLE_PRESS,
+        TRIPLE_PRESS,
+        LONG_PRESS,
+        ANY_PRESS
+    };
+
+    using EventCallback = std::function<void()>;
+
+    Button(uint8_t pin, bool activeState = LOW);
+    Button(uint8_t pin, bool activeState, bool isAnalog, uint16_t analogThreshold = 20);
+    
+    void begin();
+    void update();
+    
+    // Set callbacks for different events
+    void onShortPress(EventCallback callback) { _onShortPress = callback; }
+    void onDoublePress(EventCallback callback) { _onDoublePress = callback; }
+    void onTriplePress(EventCallback callback) { _onTriplePress = callback; }
+    void onLongPress(EventCallback callback) { _onLongPress = callback; }
+    void onAnyPress(EventCallback callback) { _onAnyPress = callback; } // New method
+    
+    // State getters
+    bool isPressed() const { return _currentState == _activeState; }
+    EventType getLastEvent() const { return _lastEvent; }
+
+private:
+    enum State {
+        IDLE,
+        PRESSED,
+        RELEASED,
+        WAITING_FOR_MULTI_CLICK
+    };
+
+    uint8_t _pin;
+    bool _activeState;
+    bool _isAnalog;
+    uint16_t _analogThreshold;
+    
+    State _state = IDLE;
+    bool _currentState;
+    bool _lastState;
+    
+    uint32_t _stateChangeTime = 0;
+    uint32_t _pressTime = 0;
+    uint32_t _releaseTime = 0;
+    uint32_t _lastReadTime = 0;
+    
+    uint8_t _clickCount = 0;
+    EventType _lastEvent = NONE;
+    
+    // Callbacks
+    EventCallback _onShortPress = nullptr;
+    EventCallback _onDoublePress = nullptr;
+    EventCallback _onTriplePress = nullptr;
+    EventCallback _onLongPress = nullptr;
+    EventCallback _onAnyPress = nullptr;
+    
+    bool readButton();
+    void handleStateChange();
+    void triggerEvent(EventType event);
+};

--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -87,6 +87,9 @@ switch(bet){
   case UIEventType::channelMessage:
     buzzer.play("kerplop:d=16,o=6,b=120:32g#,32c#");
     break;
+  case UIEventType::ack:
+    buzzer.play("ack:d=32,o=7,b=120:c");
+    break;
   case UIEventType::roomMessage:
   case UIEventType::newContactMessage:
   case UIEventType::none:
@@ -345,7 +348,13 @@ void UITask::handleButtonTriplePress() {
   MESH_DEBUG_PRINTLN("UITask: triple press triggered");
   // Toggle buzzer quiet mode
   #ifdef PIN_BUZZER
-    buzzer.quiet(!buzzer.isQuiet());
+    if (buzzer.isQuiet()) {
+      buzzer.quiet(false);
+      soundBuzzer(UIEventType::ack);
+    } else {
+      soundBuzzer(UIEventType::ack);
+      buzzer.quiet(true);
+    }
   #endif
 }
 

--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -311,12 +311,8 @@ void UITask::handleButtonAnyPress() {
   if (_display != NULL) {
     if (!_display->isOn()) {
       _display->turnOn();
-      _need_refresh = true;
-    } else {
-      // Turn on display
-      _display->turnOn();
-      _need_refresh = true;
     }
+    _need_refresh = true;
     _auto_off = millis() + AUTO_OFF_MILLIS;   // extend auto-off timer
   }
 }

--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -88,7 +88,7 @@ switch(bet){
     buzzer.play("kerplop:d=16,o=6,b=120:32g#,32c#");
     break;
   case UIEventType::ack:
-    buzzer.play("ack:d=32,o=7,b=120:c");
+    buzzer.play("ack:d=32,o=8,b=120:c");
     break;
   case UIEventType::roomMessage:
   case UIEventType::newContactMessage:

--- a/examples/companion_radio/UITask.h
+++ b/examples/companion_radio/UITask.h
@@ -35,6 +35,7 @@ class UITask {
   char _msg[80];
   int _msgcount;
   bool _need_refresh = true;
+  bool _displayWasOn = false;  // Track display state before button press
 
   // Button handlers
 #if defined(PIN_USER_BTN) || defined(PIN_USER_BTN_ANA)

--- a/examples/companion_radio/UITask.h
+++ b/examples/companion_radio/UITask.h
@@ -9,6 +9,7 @@
 #endif
 
 #include "NodePrefs.h"
+#include "Button.h"
 
  enum class UIEventType
 {
@@ -35,10 +36,22 @@ class UITask {
   int _msgcount;
   bool _need_refresh = true;
 
+  // Button handlers
+#if defined(PIN_USER_BTN) || defined(PIN_USER_BTN_ANA)
+  Button* _userButton = nullptr;
+#endif
+
   void renderCurrScreen();
-  void buttonHandler();
   void userLedHandler();
   void renderBatteryIndicator(uint16_t batteryMilliVolts);
+  
+  // Button action handlers
+  void handleButtonAnyPress();
+  void handleButtonShortPress();
+  void handleButtonDoublePress();
+  void handleButtonTriplePress();
+  void handleButtonLongPress();
+
  
 public:
 

--- a/examples/companion_radio/UITask.h
+++ b/examples/companion_radio/UITask.h
@@ -17,7 +17,8 @@
     contactMessage,
     channelMessage,
     roomMessage,
-    newContactMessage
+    newContactMessage,
+    ack
 };
 
 class UITask {

--- a/variants/t114/platformio.ini
+++ b/variants/t114/platformio.ini
@@ -79,8 +79,7 @@ build_flags =
 build_src_filter = ${Heltec_t114.build_src_filter}
   +<helpers/nrf52/T114Board.cpp>
   +<helpers/nrf52/SerialBLEInterface.cpp>
-  +<../examples/companion_radio/main.cpp>
-  +<../examples/companion_radio/UITask.cpp>
+  +<../examples/companion_radio>
   +<helpers/ui/ST7789Display.cpp>
   +<helpers/ui/OLEDDisplay.cpp>
   +<helpers/ui/OLEDDisplayFonts.cpp>


### PR DESCRIPTION
Tossing this up for comments mostly, I am perfectly ok if this isn't merged right away or even at all, but wanted to get at least some eyes on it. I've seen some comments on wanting to refactor UITask too, so if its better to hold off on this, no worries!

The button handler in UITask was getting a little crazy with all the logic, and would get more crazy if we keep adding to it. This PR encapsulates the button into its own class that can fire multiple and different events for the UI to "listen" to. 

For now I've added:

- **Any Press**: turn on display / update it (this ends up firing before the events below too)
- **Single Press**: dismiss messages if there are any (can be used for pagination later)
- **Double Press**: nothing. (idea: send advert?)
- **Triple Press**: put buzzer in quiet mode. (Is this better as a nodepref so it can be persisted?)
- **Long Press**: call existing `shutdown()`

No new functionality was added, aside from the buzzer quiet mode. I like the cleanness of the actions being in different functions now. I also like this still being tied with UITask so that we can make sure all boards act the same. We can still implement secondary buttons for boards that have those, but at least we will know they all behave the same. 

Curious what folks think of this, again just tossing the idea up for now. Tested on Heltec V3, T114, T1000E, and ThinkNode M1.

#333 #226 are related