### PR TITLE
added basic support for LilyGo Tlora C6

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -47,6 +47,11 @@ lib_deps =
   me-no-dev/ESPAsyncWebServer @ ^3.6.0
   file://arch/esp32/AsyncElegantOTA
 
+; esp32c6 uses arduino framework 3.x
+[esp32c6_base]
+extends = esp32_base
+platform = https://github.com/pioarduino/platform-espressif32.git
+
 ; ----------------- NRF52 ---------------------
 
 [nrf52_base]

--- a/src/helpers/ESP32Board.cpp
+++ b/src/helpers/ESP32Board.cpp
@@ -2,7 +2,7 @@
 
 #include "ESP32Board.h"
 
-#if defined(ADMIN_PASSWORD)   // Repeater or Room Server only
+#if defined(ADMIN_PASSWORD) && !defined(DISABLE_WIFI_OTA)   // Repeater or Room Server only
 #include <WiFi.h>
 #include <AsyncTCP.h>
 #include <ESPAsyncWebServer.h>

--- a/variants/lilygo_tlora_c6/platformio.ini
+++ b/variants/lilygo_tlora_c6/platformio.ini
@@ -1,0 +1,68 @@
+[tlora_c6]
+extends = esp32c6_base
+board = esp32-c6-devkitm-1
+board_build.partitions = min_spiffs.csv ; get around 4mb flash limit
+build_flags =
+  ${esp32c6_base.build_flags}
+  -I variants/lilygo_tlora_c6
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D ARDUINO_USB_MODE=1
+  -D P_LORA_TX_LED=7
+  -D P_LORA_SCLK=6
+  -D P_LORA_MISO=1
+  -D P_LORA_MOSI=0
+  -D P_LORA_NSS=18
+  -D P_LORA_DIO_1=23
+  -D P_LORA_BUSY=22
+  -D P_LORA_RESET=21
+  -D PIN_BOARD_SDA=8
+  -D PIN_BOARD_SCL=9
+  -D SX126X_RXEN=15
+  -D SX126X_TXEN=14
+  -D SX126X_DIO2_AS_RF_SWITCH=true
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
+  -D SX126X_CURRENT_LIMIT=140
+  -D SX126X_RX_BOOSTED_GAIN=1
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D LORA_TX_POWER=22
+  -D SKIP_WIFI_OTA=1
+build_src_filter = ${esp32c6_base.build_src_filter}
+  +<../variants/lilygo_tlora_c6>
+
+[env:LilyGo_Tlora_c6_Repeater]
+extends = tlora_c6
+build_src_filter = ${tlora_c6.build_src_filter}
+  +<../examples/simple_repeater/main.cpp>
+build_flags =
+  ${tlora_c6.build_flags}
+  -D ADVERT_NAME='"Tlora C6 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=8
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+lib_deps =
+  ${tlora_c6.lib_deps}
+;  ${esp32_ota.lib_deps}
+
+[env:LilyGo_Tlora_c6_companion_radio_ble]
+extends = tlora_c6
+build_flags = ${tlora_c6.build_flags}
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=8
+  -D BLE_PIN_CODE=123456
+  -D BLE_DEBUG_LOGGING=1
+  -D OFFLINE_QUEUE_SIZE=256
+;  -D ENABLE_PRIVATE_KEY_IMPORT=1
+;  -D ENABLE_PRIVATE_KEY_EXPORT=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${tlora_c6.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  -<helpers/esp32/ESPNOWRadio.cpp>
+  +<../examples/companion_radio>
+lib_deps =
+  ${tlora_c6.lib_deps}
+  densaugeo/base64 @ ~1.4.0

--- a/variants/lilygo_tlora_c6/platformio.ini
+++ b/variants/lilygo_tlora_c6/platformio.ini
@@ -26,7 +26,7 @@ build_flags =
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper
   -D LORA_TX_POWER=22
-  -D SKIP_WIFI_OTA=1
+  -D DISABLE_WIFI_OTA=1
 build_src_filter = ${esp32c6_base.build_src_filter}
   +<../variants/lilygo_tlora_c6>
 

--- a/variants/lilygo_tlora_c6/target.cpp
+++ b/variants/lilygo_tlora_c6/target.cpp
@@ -1,0 +1,82 @@
+#include <Arduino.h>
+#include "target.h"
+
+ESP32Board board;
+
+#if defined(P_LORA_SCLK)
+  static SPIClass spi(0);
+  RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, spi);
+#else
+  RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY);
+#endif
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+ESP32RTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+SensorManager sensors;
+
+#ifndef LORA_CR
+  #define LORA_CR      5
+#endif
+
+bool radio_init() {
+  fallback_clock.begin();
+  rtc_clock.begin(Wire);
+
+#ifdef SX126X_DIO3_TCXO_VOLTAGE
+  float tcxo = SX126X_DIO3_TCXO_VOLTAGE;
+#else
+  float tcxo = 1.6f;
+#endif
+
+#if defined(P_LORA_SCLK)
+  spi.begin(P_LORA_SCLK, P_LORA_MISO, P_LORA_MOSI);
+#endif
+  int status = radio.begin(LORA_FREQ, LORA_BW, LORA_SF, LORA_CR, RADIOLIB_SX126X_SYNC_WORD_PRIVATE, LORA_TX_POWER, 8, tcxo);
+  if (status != RADIOLIB_ERR_NONE) {
+    Serial.print("ERROR: radio init failed: ");
+    Serial.println(status);
+    return false;  // fail
+  }
+
+  radio.setCRC(1);
+
+#if defined(SX126X_RXEN) && defined(SX126X_TXEN)
+  radio.setRfSwitchPins(SX126X_RXEN, SX126X_TXEN);
+#endif
+
+#ifdef SX126X_CURRENT_LIMIT
+  radio.setCurrentLimit(SX126X_CURRENT_LIMIT);
+#endif
+
+#ifdef SX126X_DIO2_AS_RF_SWITCH
+  radio.setDio2AsRfSwitch(SX126X_DIO2_AS_RF_SWITCH);
+#endif
+
+#ifdef SX126X_RX_BOOSTED_GAIN
+  radio.setRxBoostedGainMode(SX126X_RX_BOOSTED_GAIN);
+#endif
+
+  return true;  // success
+}
+
+uint32_t radio_get_rng_seed() {
+  return radio.random(0x7FFFFFFF);
+}
+
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr) {
+  radio.setFrequency(freq);
+  radio.setSpreadingFactor(sf);
+  radio.setBandwidth(bw);
+  radio.setCodingRate(cr);
+}
+
+void radio_set_tx_power(uint8_t dbm) {
+  radio.setOutputPower(dbm);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);  // create new random identity
+}

--- a/variants/lilygo_tlora_c6/target.h
+++ b/variants/lilygo_tlora_c6/target.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/RadioLibWrappers.h>
+#include <helpers/ESP32Board.h>
+#include <helpers/CustomSX1262Wrapper.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/SensorManager.h>
+
+extern ESP32Board board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern SensorManager sensors;
+
+bool radio_init();
+uint32_t radio_get_rng_seed();
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr);
+void radio_set_tx_power(uint8_t dbm);
+mesh::LocalIdentity radio_new_identity();


### PR DESCRIPTION
warning: esp32c6 uses arduino framework 3.x, it's not officialy supported by platform.io. some of the functionalities of esp32 need changes - like wifi OTA and esp-now support. those are disabled for this board.