### PR TITLE
gps : sync time on fix

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -1643,7 +1643,7 @@ public:
 
 StdRNG fast_rng;
 SimpleMeshTables tables;
-MyMesh the_mesh(radio_driver, fast_rng, *new VolatileRTCClock(), tables); // TODO: test with 'rtc_clock' in target.cpp
+MyMesh the_mesh(radio_driver, fast_rng, rtc_clock, tables); 
 
 void halt() {
   while (1) ;

--- a/src/helpers/sensors/LocationProvider.h
+++ b/src/helpers/sensors/LocationProvider.h
@@ -4,13 +4,19 @@
 
 
 class LocationProvider {
+protected:
+    bool _time_sync_needed = true;
 
 public:
+    virtual void syncTime() { _time_sync_needed = true; }
+    virtual bool waitingTimeSync() { return _time_sync_needed; }
     virtual long getLatitude() = 0;
     virtual long getLongitude() = 0;
     virtual long getAltitude() = 0;
+    virtual long satellitesCount() = 0;
     virtual bool isValid() = 0;
     virtual long getTimestamp() = 0;
+    virtual void sendSentence(const char * sentence);
     virtual void reset();
     virtual void begin();
     virtual void stop();

--- a/src/helpers/sensors/MicroNMEALocationProvider.h
+++ b/src/helpers/sensors/MicroNMEALocationProvider.h
@@ -98,7 +98,7 @@ public :
             next_check = millis() + 1000;
             if (_time_sync_needed && time_valid > 2) {
                 if (_clock != NULL) {
-                    _clock.setCurrentTime(getTimestamp());
+                    _clock->setCurrentTime(getTimestamp());
                     _time_sync_needed = false;
                 }
             }

--- a/src/helpers/sensors/MicroNMEALocationProvider.h
+++ b/src/helpers/sensors/MicroNMEALocationProvider.h
@@ -98,7 +98,7 @@ public :
             next_check = millis() + 1000;
             if (_time_sync_needed && time_valid > 2) {
                 if (_clock != NULL) {
-                    rtc_clock.setCurrentTime(getTimestamp());
+                    _clock.setCurrentTime(getTimestamp());
                     _time_sync_needed = false;
                 }
             }

--- a/variants/t1000-e/target.cpp
+++ b/variants/t1000-e/target.cpp
@@ -179,26 +179,14 @@ void T1000SensorManager::loop() {
   }
 }
 
-int T1000SensorManager::getNumSettings() const { return 2; }  // just one supported: "gps" (power switch)
+int T1000SensorManager::getNumSettings() const { return 1; }  // just one supported: "gps" (power switch)
 
 const char* T1000SensorManager::getSettingName(int i) const {
-  switch (i) {
-    case 0:
-      return "gps";
-      break;
-    case 1:
-      return "sync";
-      break;
-    default:
-      return NULL;
-      break;
-  }
+  return i == 0 ? "gps" : NULL;
 }
 const char* T1000SensorManager::getSettingValue(int i) const {
   if (i == 0) {
     return gps_active ? "1" : "0";
-  } else if (i == 1) {
-    return _nmea->waitingTimeSync() ? "1" : "0";
   }
   return NULL;
 }
@@ -209,9 +197,6 @@ bool T1000SensorManager::setSettingValue(const char* name, const char* value) {
     } else {
       start_gps();
     }
-    return true;
-  } else if (strcmp(name, "sync") == 0) {
-    _nmea->syncTime(); // whatever the value ...
     return true;
   }
   return false;  // not supported


### PR DESCRIPTION
Some changes in LocationProvider

* will sync time at first fix (_time_sync_needed variable)
* syncTime method will force _time_sync_needed to true
* "sync" custom variable on T1000 let the user force update

Validated change in companion radio to use rtc_clock defined in target (was still creating a new rtc_clock).