### PR TITLE
wio_e5 : bme280 support

### DIFF
--- a/src/helpers/stm32/InternalFileSystem.cpp
+++ b/src/helpers/stm32/InternalFileSystem.cpp
@@ -126,11 +126,14 @@ InternalFileSystem::InternalFileSystem(void)
 
 bool InternalFileSystem::begin(void)
 {
+  volatile bool format_fs;
   #ifdef FORMAT_FS
-  this->format();
+  format_fs = true;
+  #else
+  format_fs = false; // you can always use debugger to force formatting ;)
   #endif
   // failed to mount, erase all sector then format and mount again
-  if ( !Adafruit_LittleFS::begin() )
+  if ( format_fs || !Adafruit_LittleFS::begin() )
   {
     // lfs format
     this->format();

--- a/variants/wio-e5-mini/platformio.ini
+++ b/variants/wio-e5-mini/platformio.ini
@@ -10,6 +10,8 @@ build_flags = ${stm32_base.build_flags}
   -I variants/wio-e5-mini
 build_src_filter = ${stm32_base.build_src_filter}
   +<../variants/wio-e5-mini>
+lib_deps = ${stm32_base.lib_deps}
+  finitespace/BME280 @ ^3.0.0
 
 [env:wio-e5-mini-repeater]
 extends = lora_e5_mini

--- a/variants/wio-e5-mini/target.cpp
+++ b/variants/wio-e5-mini/target.cpp
@@ -18,8 +18,7 @@ static const Module::RfSwitchMode_t rfswitch_table[] = {
 };
 
 VolatileRTCClock rtc_clock;
-BME280I2C bme;   
-WIOE5SensorManager sensors(bme);
+WIOE5SensorManager sensors;
 
 #ifndef LORA_CR
   #define LORA_CR      5
@@ -73,9 +72,9 @@ bool WIOE5SensorManager::querySensors(uint8_t requester_permissions, CayenneLPP&
   float temp(NAN), hum(NAN), pres(NAN);
 
   BME280::TempUnit tempUnit(BME280::TempUnit_Celsius);
-  BME280::PresUnit presUnit(BME280::PresUnit_bar);
+  BME280::PresUnit presUnit(BME280::PresUnit_hPa);
 
-  _bme->read(pres, temp, hum, tempUnit, presUnit);
+  bme.read(pres, temp, hum, tempUnit, presUnit);
 
   telemetry.addTemperature(TELEM_CHANNEL_SELF, temp);
   telemetry.addRelativeHumidity(TELEM_CHANNEL_SELF, hum);
@@ -85,7 +84,7 @@ bool WIOE5SensorManager::querySensors(uint8_t requester_permissions, CayenneLPP&
 }
 
 bool WIOE5SensorManager::begin() {
-  has_bme = _bme->begin();
+  has_bme = bme.begin();
 
   return has_bme;
 }

--- a/variants/wio-e5-mini/target.h
+++ b/variants/wio-e5-mini/target.h
@@ -25,11 +25,11 @@ public:
 };
 
 class WIOE5SensorManager : public SensorManager {
-    BME280I2C* _bme;
+    BME280I2C bme;
     bool has_bme = false;   
 
 public:
-    WIOE5SensorManager(BME280I2C& bme) : _bme(&bme) {}
+    WIOE5SensorManager() {}
     bool begin() override;
     bool querySensors(uint8_t requester_permissions, CayenneLPP& telemetry) override;
 };

--- a/variants/wio-e5-mini/target.h
+++ b/variants/wio-e5-mini/target.h
@@ -8,6 +8,9 @@
 #include <helpers/ArduinoHelpers.h>
 #include <helpers/SensorManager.h>
 
+#include <BME280I2C.h>
+#include <Wire.h>
+
 class WIOE5Board : public STM32Board {
 public:
     const char* getManufacturerName() const override {
@@ -21,10 +24,20 @@ public:
     }
 };
 
+class WIOE5SensorManager : public SensorManager {
+    BME280I2C* _bme;
+    bool has_bme = false;   
+
+public:
+    WIOE5SensorManager(BME280I2C& bme) : _bme(&bme) {}
+    bool begin() override;
+    bool querySensors(uint8_t requester_permissions, CayenneLPP& telemetry) override;
+};
+
 extern WIOE5Board board;
 extern WRAPPER_CLASS radio_driver;
 extern VolatileRTCClock rtc_clock;
-extern SensorManager sensors;
+extern WIOE5SensorManager sensors;
 
 bool radio_init();
 uint32_t radio_get_rng_seed();


### PR DESCRIPTION
Some sensors for wio-e5 ... that's necessary for a sensor node ;)

Could not use Adafruit lib ... some strange things with spi defs, while I don't use spi :(

But found an alternative