### PR TITLE
Scan devices in board

### DIFF
--- a/src/helpers/ESP32Board.cpp
+++ b/src/helpers/ESP32Board.cpp
@@ -43,4 +43,64 @@ bool ESP32Board::startOTAUpdate(const char* id, char reply[]) {
 }
 #endif
 
+uint8_t ESP32Board::scanI2CDevices(TwoWire *w)
+{
+    uint8_t err, addr;
+    int nDevices = 0;
+    uint32_t start = 0;
+
+    MESH_DEBUG_PRINTLN("Scanning I2C for Devices");
+    for (addr = 1; addr < 127; addr++) {
+        start = millis();
+        w->beginTransmission(addr); delay(2);
+        err = w->endTransmission();
+        if (err == 0) {
+            nDevices++;
+            switch (addr) {
+            case 0x77:
+            case 0x76:
+                MESH_DEBUG_PRINTLN("\tFound BME280 Sensor");
+                _deviceOnline |= BME280_ONLINE;
+                break;
+            case 0x34:
+                MESH_DEBUG_PRINTLN("\tFound AXP192/AXP2101 PMU");
+                _deviceOnline |= POWERMANAGE_ONLINE;
+                break;
+            case 0x3C:
+                MESH_DEBUG_PRINTLN("\tFound SSD1306/SH1106 dispaly");
+                _deviceOnline |= DISPLAY_ONLINE;
+                break;
+            case 0x51:
+                MESH_DEBUG_PRINTLN("\tFound PCF8563 RTC");
+                _deviceOnline |= PCF8563_ONLINE;
+                break;
+            case 0x1C:
+                MESH_DEBUG_PRINTLN("\tFound QMC6310 MAG Sensor");
+                _deviceOnline |= QMC6310_ONLINE;
+                break;
+            default:
+                MESH_DEBUG_PRINTLN("\tI2C device found at address 0x");
+                if (addr < 16) {
+                    MESH_DEBUG_PRINT("0");
+                }
+                MESH_DEBUG_PRINT(addr, HEX);
+                MESH_DEBUG_PRINTLN(" !");
+                break;
+            }
+
+        } else if (err == 4) {
+            MESH_DEBUG_PRINT("Unknown error at address 0x");
+            if (addr < 16) {
+                MESH_DEBUG_PRINTLN("0");
+            }
+            MESH_DEBUG_PRINTLN(addr, HEX);
+        }
+    }
+    if (nDevices == 0)
+        MESH_DEBUG_PRINTLN("No I2C devices found\n");
+
+    MESH_DEBUG_PRINTLN("Scan for devices is complete.");
+    return _deviceOnline;
+}
+
 #endif

--- a/src/helpers/ESP32Board.h
+++ b/src/helpers/ESP32Board.h
@@ -9,9 +9,27 @@
 #include <sys/time.h>
 #include <Wire.h>
 
+enum {
+  POWERMANAGE_ONLINE  = _BV(0),
+  DISPLAY_ONLINE      = _BV(1),
+  RADIO_ONLINE        = _BV(2),
+  GPS_ONLINE          = _BV(3),
+  PSRAM_ONLINE        = _BV(4),
+  SDCARD_ONLINE       = _BV(5),
+  AXDL345_ONLINE      = _BV(6),
+  BME280_ONLINE       = _BV(7),
+  BMP280_ONLINE       = _BV(8),
+  BME680_ONLINE       = _BV(9),
+  QMC6310_ONLINE      = _BV(10),
+  QMI8658_ONLINE      = _BV(11),
+  PCF8563_ONLINE      = _BV(12),
+  OSC32768_ONLINE      = _BV(13),
+};
+
 class ESP32Board : public mesh::MainBoard {
 protected:
   uint8_t startup_reason;
+  uint8_t _deviceOnline; // for I2C
 
 public:
   void begin() {
@@ -78,7 +96,9 @@ public:
   }
 
   bool startOTAUpdate(const char* id, char reply[]) override;
+  uint8_t scanI2CDevices(TwoWire *w);
 };
+
 
 class ESP32RTCClock : public mesh::RTCClock {
 public:

--- a/src/helpers/esp32/ESPNOWRadio.cpp
+++ b/src/helpers/esp32/ESPNOWRadio.cpp
@@ -1,3 +1,4 @@
+#ifdef ENABLE_ESPNOW
 #include "ESPNOWRadio.h"
 #include <esp_now.h>
 #include <WiFi.h>
@@ -111,3 +112,4 @@ int ESPNOWRadio::recvRaw(uint8_t* bytes, int sz) {
 uint32_t ESPNOWRadio::getEstAirtimeFor(int len_bytes) {
   return 4;  // Fast AF
 }
+#endif

--- a/src/helpers/esp32/ESPNOWRadio.h
+++ b/src/helpers/esp32/ESPNOWRadio.h
@@ -1,3 +1,4 @@
+#ifdef ENABLE_ESPNOW
 #pragma once
 
 #include <Mesh.h>
@@ -36,4 +37,5 @@ public:
 #else
   #define ESPNOW_DEBUG_PRINT(...) {}
   #define ESPNOW_DEBUG_PRINTLN(...) {}
+#endif
 #endif

--- a/variants/generic_espnow/platformio.ini
+++ b/variants/generic_espnow/platformio.ini
@@ -8,6 +8,7 @@ board = esp32-c3-devkitm-1
 build_flags =
   ${esp32_base.build_flags}
   -I variants/generic_espnow
+  -D ENABLE_ESPNOW
 ;  -D ESP32_CPU_FREQ=80
   -D PIN_BOARD_SDA=-1
   -D PIN_BOARD_SCL=-1

--- a/variants/lilygo_tbeam_supreme_SX1262/target.cpp
+++ b/variants/lilygo_tbeam_supreme_SX1262/target.cpp
@@ -33,66 +33,6 @@ static void setPMUIntFlag(){
 }
 
 #ifdef MESH_DEBUG
-uint32_t deviceOnline = 0x00;
-void scanDevices(TwoWire *w)
-{
-    uint8_t err, addr;
-    int nDevices = 0;
-    uint32_t start = 0;
-
-    Serial.println("Scanning I2C for Devices");
-    for (addr = 1; addr < 127; addr++) {
-        start = millis();
-        w->beginTransmission(addr); delay(2);
-        err = w->endTransmission();
-        if (err == 0) {
-            nDevices++;
-            switch (addr) {
-            case 0x77:
-            case 0x76:
-                Serial.println("\tFound BME280 Sensor");
-                deviceOnline |= BME280_ONLINE;
-                break;
-            case 0x34:
-                Serial.println("\tFound AXP192/AXP2101 PMU");
-                deviceOnline |= POWERMANAGE_ONLINE;
-                break;
-            case 0x3C:
-                Serial.println("\tFound SSD1306/SH1106 dispaly");
-                deviceOnline |= DISPLAY_ONLINE;
-                break;
-            case 0x51:
-                Serial.println("\tFound PCF8563 RTC");
-                deviceOnline |= PCF8563_ONLINE;
-                break;
-            case 0x1C:
-                Serial.println("\tFound QMC6310 MAG Sensor");
-                deviceOnline |= QMC6310_ONLINE;
-                break;
-            default:
-                Serial.print("\tI2C device found at address 0x");
-                if (addr < 16) {
-                    Serial.print("0");
-                }
-                Serial.print(addr, HEX);
-                Serial.println(" !");
-                break;
-            }
-
-        } else if (err == 4) {
-            Serial.print("Unknow error at address 0x");
-            if (addr < 16) {
-                Serial.print("0");
-            }
-            Serial.println(addr, HEX);
-        }
-    }
-    if (nDevices == 0)
-        Serial.println("No I2C devices found\n");
-
-    Serial.println("Scan for devices is complete.");
-    Serial.println("\n");
-}
 void TBeamS3SupremeBoard::printPMU()
 {
     Serial.print("isCharging:"); Serial.println(PMU.isCharging() ? "YES" : "NO");

--- a/variants/lilygo_tbeam_supreme_SX1262/target.h
+++ b/variants/lilygo_tbeam_supreme_SX1262/target.h
@@ -47,23 +47,6 @@ extern TbeamSupSensorManager sensors;
   extern DISPLAY_CLASS display;
 #endif
 
-enum {
-  POWERMANAGE_ONLINE  = _BV(0),
-  DISPLAY_ONLINE      = _BV(1),
-  RADIO_ONLINE        = _BV(2),
-  GPS_ONLINE          = _BV(3),
-  PSRAM_ONLINE        = _BV(4),
-  SDCARD_ONLINE       = _BV(5),
-  AXDL345_ONLINE      = _BV(6),
-  BME280_ONLINE       = _BV(7),
-  BMP280_ONLINE       = _BV(8),
-  BME680_ONLINE       = _BV(9),
-  QMC6310_ONLINE      = _BV(10),
-  QMI8658_ONLINE      = _BV(11),
-  PCF8563_ONLINE      = _BV(12),
-  OSC32768_ONLINE      = _BV(13),
-};
-
 bool radio_init();
 uint32_t radio_get_rng_seed();
 void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr);


### PR DESCRIPTION
Moving scanDevices (renamed to scanI2CDevices for clarity) up into the ESP32Board level. Considered higher but figured I'd leave that for another day - we can always implement it just for ESP32 boards for now and then move it up as a virtual later. This will allow us to deduplicate code between the tbeam and tbeamsupreme which is nice.

In addition, ran into a major compilation issue in the latest HEAD of dev with ESPNow. Fixed it by adding an ESPNow INI define and adding preprocessor guards around that code so it's not compiled into tbeam code for no reason. Even when I made it compile through code changes, it overran the flash size.