### PR TITLE
add basic alert system to companion UI

### DIFF
--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -162,7 +162,16 @@ void UITask::renderCurrScreen() {
   if (_display == NULL) return;  // assert() ??
 
   char tmp[80];
-  if (_origin[0] && _msg[0]) { // message preview
+  if (_alert[0]) {
+    uint16_t textWidth = _display->getTextWidth(_alert);
+    _display->setCursor((_display->width() - textWidth) / 2, 22);
+    _display->setTextSize(1.4);
+    _display->setColor(DisplayDriver::GREEN);
+    _display->print(_alert);
+    _alert[0] = 0;
+    _need_refresh = true;
+    return;
+  } else if (_origin[0] && _msg[0]) { // message preview
     // render message preview
     _display->setCursor(0, 0);
     _display->setTextSize(1);
@@ -343,11 +352,17 @@ void UITask::handleButtonShortPress() {
 void UITask::handleButtonDoublePress() {
   MESH_DEBUG_PRINTLN("UITask: double press triggered, sending advert");
   // ADVERT
+  #ifdef PIN_BUZZER
+      soundBuzzer(UIEventType::ack);
+  #endif
   if (the_mesh.advert()) {
     MESH_DEBUG_PRINTLN("Advert sent!");
+    sprintf(_alert, "Advert sent!");
   } else {
     MESH_DEBUG_PRINTLN("Advert failed!");
+    sprintf(_alert, "Advert failed..");
   }
+  _need_refresh = true;
 }
 
 void UITask::handleButtonTriplePress() {

--- a/examples/companion_radio/UITask.h
+++ b/examples/companion_radio/UITask.h
@@ -33,6 +33,7 @@ class UITask {
   char _version_info[32];
   char _origin[62];
   char _msg[80];
+  char _alert[80];
   int _msgcount;
   bool _need_refresh = true;
   bool _displayWasOn = false;  // Track display state before button press


### PR DESCRIPTION
Adds `_alert[80]` which can be set along with `_needs_refresh` to trigger a simple on screen alert that lasts 1s at this time.

Implements POC with double press to advert action