### PR TITLE
Fix Buzzer Power Draw

### DIFF
--- a/src/helpers/ui/buzzer.cpp
+++ b/src/helpers/ui/buzzer.cpp
@@ -11,6 +11,7 @@ void genericBuzzer::begin() {
 
     quiet(false);
     pinMode(PIN_BUZZER, OUTPUT);
+    digitalWrite(PIN_BUZZER, LOW); // need to pull low by default to avoid extreme power draw
     startup();
 }
 


### PR DESCRIPTION
This PR fixes the insane power draw caused by the buzzer pin being in a floating state.

The ThinkNode M1 is pulling ~150mA.
After this fix, the power draw goes down to ~11mA

Tested the T1000E and it still does the beeps, but don't have a way to test power draw on that board since battery is connected internally.