### PR TITLE
Basic File Manager for Rescue CLI

### DIFF
--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -42,6 +42,16 @@ void DataStore::begin() {
   #include <LittleFS.h>
 #endif
 
+File DataStore::openRead(const char* filename) {
+#if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
+  return _fs->open(filename, FILE_O_READ);
+#elif defined(RP2040_PLATFORM)
+  return _fs->open(filename, "r");
+#else
+  return _fs->open(filename, "r", true);
+#endif
+}
+
 bool DataStore::formatFileSystem() {
 #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
   return _fs->format();

--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -48,7 +48,7 @@ File DataStore::openRead(const char* filename) {
 #elif defined(RP2040_PLATFORM)
   return _fs->open(filename, "r");
 #else
-  return _fs->open(filename, "r", true);
+  return _fs->open(filename, "r", false);
 #endif
 }
 

--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -52,6 +52,10 @@ File DataStore::openRead(const char* filename) {
 #endif
 }
 
+bool DataStore::removeFile(const char* filename) {
+  return _fs->remove(filename);
+}
+
 bool DataStore::formatFileSystem() {
 #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
   return _fs->format();

--- a/examples/companion_radio/DataStore.h
+++ b/examples/companion_radio/DataStore.h
@@ -37,4 +37,5 @@ public:
   void saveChannels(DataStoreHost* host);
   uint8_t getBlobByKey(const uint8_t key[], int key_len, uint8_t dest_buf[]);
   bool putBlobByKey(const uint8_t key[], int key_len, const uint8_t src_buf[], uint8_t len);
+  File openRead(const char* filename);
 };

--- a/examples/companion_radio/DataStore.h
+++ b/examples/companion_radio/DataStore.h
@@ -38,4 +38,5 @@ public:
   uint8_t getBlobByKey(const uint8_t key[], int key_len, uint8_t dest_buf[]);
   bool putBlobByKey(const uint8_t key[], int key_len, const uint8_t src_buf[], uint8_t len);
   File openRead(const char* filename);
+  bool removeFile(const char* filename);
 };

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1357,13 +1357,20 @@ void MyMesh::checkCLIRescueCmd() {
 
       // get path from command e.g: "rm /adv_blobs"
       const char *path = &cli_command[4];
-      
-      // remove file
-      bool removed = _store->removeFile(path);
-      if(removed){
-        Serial.println("File removed");
+
+      // ensure path is not empty, or root dir
+      if(!path || strlen(path) == 0 || strcmp(path, "/") == 0){
+        Serial.println("Invalid path provided");
       } else {
-        Serial.println("Failed to remove file");
+
+        // remove file
+        bool removed = _store->removeFile(path);
+        if(removed){
+          Serial.println("File removed");
+        } else {
+          Serial.println("Failed to remove file");
+        }
+
       }
 
     } else if (strcmp(cli_command, "reboot") == 0) {

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1312,8 +1312,9 @@ void MyMesh::checkCLIRescueCmd() {
       
       // log each file and directory
       File root = _store->openRead(path);
-      File file = root.openNextFile();
-      while (file) {
+      if(root){
+        File file = root.openNextFile();
+        while (file) {
 
           if (file.isDirectory()) {
             Serial.print("[dir] ");
@@ -1329,6 +1330,7 @@ void MyMesh::checkCLIRescueCmd() {
           // move to next file
           file = root.openNextFile();
 
+        }
       }
 
     } else if (memcmp(cli_command, "cat", 3) == 0) {

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1305,6 +1305,54 @@ void MyMesh::checkCLIRescueCmd() {
       } else {
         Serial.println("  Error: erase failed");
       }
+    } else if (memcmp(cli_command, "ls", 2) == 0) {
+
+      // get path from command e.g: "ls /adafruit"
+      const char *path = &cli_command[3];
+      
+      // log each file and directory
+      File root = _store->openRead(path);
+      File file = root.openNextFile();
+      while (file) {
+
+          if (file.isDirectory()) {
+            Serial.print("[dir] ");
+            Serial.println(file.name());
+          } else {
+            Serial.print("[file] ");
+            Serial.print(file.name());
+            Serial.print(" (");
+            Serial.print(file.size());
+            Serial.println(" bytes)");
+          }
+
+          // move to next file
+          file = root.openNextFile();
+
+      }
+
+    } else if (memcmp(cli_command, "cat", 3) == 0) {
+
+      // get path from command e.g: "cat /contacts3"
+      const char *path = &cli_command[4];
+      
+      // log file content as hex
+      File file = _store->openRead(path);
+      if(file){
+
+        // get file content
+        int file_size = file.available();
+        uint8_t buffer[file_size];
+        file.read(buffer, file_size);
+
+        // print hex
+        mesh::Utils::printHex(Serial, buffer, file_size);
+        Serial.print("\n");
+
+        file.close();
+
+      }
+
     } else if (strcmp(cli_command, "reboot") == 0) {
       board.reboot();  // doesn't return
     } else {

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1353,6 +1353,19 @@ void MyMesh::checkCLIRescueCmd() {
 
       }
 
+    } else if (memcmp(cli_command, "rm ", 3) == 0) {
+
+      // get path from command e.g: "rm /adv_blobs"
+      const char *path = &cli_command[4];
+      
+      // remove file
+      bool removed = _store->removeFile(path);
+      if(removed){
+        Serial.println("File removed");
+      } else {
+        Serial.println("Failed to remove file");
+      }
+
     } else if (strcmp(cli_command, "reboot") == 0) {
       board.reboot();  // doesn't return
     } else {

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1326,6 +1326,7 @@ void MyMesh::checkCLIRescueCmd() {
           file = root.openNextFile();
 
         }
+        root.close();
       }
 
     } else if (memcmp(cli_command, "cat", 3) == 0) {

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1317,14 +1317,9 @@ void MyMesh::checkCLIRescueCmd() {
         while (file) {
 
           if (file.isDirectory()) {
-            Serial.print("[dir] ");
-            Serial.println(file.name());
+            Serial.printf("[dir] %s\n", file.name());
           } else {
-            Serial.print("[file] ");
-            Serial.print(file.name());
-            Serial.print(" (");
-            Serial.print(file.size());
-            Serial.println(" bytes)");
+            Serial.printf("[file] %s (%d bytes)\n", file.name(), file.size());
           }
 
           // move to next file


### PR DESCRIPTION
This PR adds a simple file manager tool to the new Rescue CLI.

- `ls <path>` - list files in path
- `rm <path>` - remove file at path
- `cat <path>` - print file content in hex

Tested and working on:

- RAK4631
- Heltec v3
- Heltec T114