### PR TITLE
Minor companion ui fixes

### DIFF
--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -163,9 +163,9 @@ void UITask::renderCurrScreen() {
 
   char tmp[80];
   if (_alert[0]) {
+    _display->setTextSize(1.4);
     uint16_t textWidth = _display->getTextWidth(_alert);
     _display->setCursor((_display->width() - textWidth) / 2, 22);
-    _display->setTextSize(1.4);
     _display->setColor(DisplayDriver::GREEN);
     _display->print(_alert);
     _alert[0] = 0;

--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -374,11 +374,10 @@ void UITask::handleButtonTriplePress() {
     if (buzzer.isQuiet()) {
       buzzer.quiet(false);
       soundBuzzer(UIEventType::ack);
-      sprintf(_alert, "Quiet mode: OFF");
+      sprintf(_alert, "Buzzer: ON");
     } else {
-      soundBuzzer(UIEventType::ack);
       buzzer.quiet(true);
-      sprintf(_alert, "Quiet mode: ON");
+      sprintf(_alert, "Buzzer: OFF");
     }
     _need_refresh = true;
   #endif

--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -5,7 +5,7 @@
 #include "MyMesh.h"
 
 #define AUTO_OFF_MILLIS     15000   // 15 seconds
-#define BOOT_SCREEN_MILLIS   4000   // 4 seconds
+#define BOOT_SCREEN_MILLIS   3000   // 3 seconds
 
 #ifdef PIN_STATUS_LED
 #define LED_ON_MILLIS     20
@@ -191,7 +191,7 @@ void UITask::renderCurrScreen() {
     sprintf(tmp, "%d", _msgcount);
     _display->print(tmp);
     _display->setColor(DisplayDriver::YELLOW); // last color will be kept on T114
-  } else if (millis() < BOOT_SCREEN_MILLIS) { // boot screen
+  } else if ((millis() - ui_started_at) < BOOT_SCREEN_MILLIS) { // boot screen
     // meshcore logo
     _display->setColor(DisplayDriver::BLUE);
     int logoWidth = 128;
@@ -302,7 +302,7 @@ void UITask::loop() {
 
   if (_display != NULL && _display->isOn()) {
     static bool _firstBoot = true;
-    if(_firstBoot && millis() >= BOOT_SCREEN_MILLIS) {
+    if(_firstBoot && (millis() - ui_started_at) >= BOOT_SCREEN_MILLIS) {
       _need_refresh = true;
       _firstBoot = false;
     }
@@ -344,6 +344,8 @@ void UITask::handleButtonShortPress() {
         // Otherwise, refresh the display
         _need_refresh = true;
       }
+    } else {
+      _need_refresh = true; // display just turned on, so we need to refresh
     }
     // Note: Display turn-on and auto-off timer extension are handled by handleButtonAnyPress
   }
@@ -372,10 +374,13 @@ void UITask::handleButtonTriplePress() {
     if (buzzer.isQuiet()) {
       buzzer.quiet(false);
       soundBuzzer(UIEventType::ack);
+      sprintf(_alert, "Quiet mode: OFF");
     } else {
       soundBuzzer(UIEventType::ack);
       buzzer.quiet(true);
+      sprintf(_alert, "Quiet mode: ON");
     }
+    _need_refresh = true;
   #endif
 }
 


### PR DESCRIPTION
1. If the boot took longer than a few seconds we would completely miss the boot screen. This isn't too critical but it's nice to see the current version number and logo. using the `ui_started_at` timestamp to make sure we always show it no matter how long boot took. This happened a lot on e-paper displays too due to the display taking some extra time to fire up.
2. Display wouldnt refresh after being turned on with a single button press. Needed an extra `else` to make sure the render happens after display turns on. This was causing a blank screen occasionally due to the `renderCurrScreen()` not being called in that scenario.
3. Added an alert message for quiet mode on/off
4. Fixed alignment of alert text

Tested on T114, Heltec V3, and ThinkNode M1