### PR TITLE
ct62: adding companion radios

### DIFF
--- a/variants/heltec_ct62/platformio.ini
+++ b/variants/heltec_ct62/platformio.ini
@@ -33,6 +33,8 @@ build_src_filter = ${esp32_base.build_src_filter}
 extends = Heltec_ct62
 build_flags =
   ${Heltec_ct62.build_flags}
+  ;-D ARDUINO_USB_MODE=1
+  ;-D ARDUINO_USB_CDC_ON_BOOT=1
   -D ADVERT_NAME='"HT-CT62 Repeater"'
   -D ADVERT_LAT=0.0
   -D ADVERT_LON=0.0
@@ -45,3 +47,40 @@ build_src_filter = ${Heltec_ct62.build_src_filter}
 lib_deps =
   ${Heltec_ct62.lib_deps}
   ${esp32_ota.lib_deps}
+
+[env:Heltec_ct62_companion_radio_usb]
+extends = Heltec_ct62
+build_flags =
+  ${Heltec_ct62.build_flags}
+;  -D ARDUINO_USB_MODE=1
+;  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=8
+  -D OFFLINE_QUEUE_SIZE=256
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_ct62.build_src_filter}
+  +<../examples/companion_radio>
+lib_deps =
+  ${Heltec_ct62.lib_deps}
+  ${esp32_ota.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:Heltec_ct62_companion_radio_ble]
+extends = Heltec_ct62
+build_flags =
+  ${Heltec_ct62.build_flags}
+;  -D ARDUINO_USB_MODE=1
+;  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=8
+  -D OFFLINE_QUEUE_SIZE=256
+  -D BLE_PIN_CODE=123456
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_ct62.build_src_filter}
+  +<../examples/companion_radio>
+lib_deps =
+  ${Heltec_ct62.lib_deps}
+  ${esp32_ota.lib_deps}
+  densaugeo/base64 @ ~1.4.0


### PR DESCRIPTION
Thanks for adding ct62, I used to have a branch for it but it was not polished and not up to date ...

Just adding usb/serial target, as well as some commented options I use (I use it hooked to the usb port of the esp)

Works for me if I comment the pins I don't use on your base target