### PR TITLE
ThinkNode M1 TX LED

### DIFF
--- a/src/helpers/nrf52/ThinkNodeM1Board.cpp
+++ b/src/helpers/nrf52/ThinkNodeM1Board.cpp
@@ -26,6 +26,11 @@ void ThinkNodeM1Board::begin() {
 
   Wire.begin();
 
+  #ifdef P_LORA_TX_LED
+    pinMode(P_LORA_TX_LED, OUTPUT);
+    digitalWrite(P_LORA_TX_LED, LOW);
+  #endif
+
   pinMode(SX126X_POWER_EN, OUTPUT);
   digitalWrite(SX126X_POWER_EN, HIGH);
   delay(10);   // give sx1262 some time to power up

--- a/src/helpers/nrf52/ThinkNodeM1Board.h
+++ b/src/helpers/nrf52/ThinkNodeM1Board.h
@@ -39,6 +39,15 @@ public:
     return startup_reason;
   }
 
+  #if defined(P_LORA_TX_LED)
+  void onBeforeTransmit() override {
+    digitalWrite(P_LORA_TX_LED, HIGH);   // turn TX LED on
+  }
+  void onAfterTransmit() override {
+    digitalWrite(P_LORA_TX_LED, LOW);   // turn TX LED off
+  }
+  #endif
+
   const char* getManufacturerName() const override {
     return "Elecrow ThinkNode-M1";
   }

--- a/variants/thinknode_m1/platformio.ini
+++ b/variants/thinknode_m1/platformio.ini
@@ -19,6 +19,7 @@ build_flags = ${nrf52840_thinknode_m1.build_flags}
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper
   -D LORA_TX_POWER=22
+  -D P_LORA_TX_LED=13
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
 build_src_filter = ${nrf52840_thinknode_m1.build_src_filter}


### PR DESCRIPTION
- ThinkNode didnt have the TX LED setup like our other variants. Added it.

https://github.com/user-attachments/assets/f8eff525-2f24-4888-97fd-7c90c6f370a1

