### PR TITLE
t1000e: don't update position if gps is off

### DIFF
--- a/variants/t1000-e/target.cpp
+++ b/variants/t1000-e/target.cpp
@@ -174,7 +174,7 @@ void T1000SensorManager::loop() {
   _nmea->loop();
 
   if (millis() > next_gps_update) {
-    if (_nmea->isValid()) {
+    if (gps_active && _nmea->isValid()) {
       node_lat = ((double)_nmea->getLatitude())/1000000.;
       node_lon = ((double)_nmea->getLongitude())/1000000.;
       node_altitude = ((double)_nmea->getAltitude()) / 1000.0;


### PR DESCRIPTION
When gps is disabled, position keeps updating to last seen gps position ... preventing manually changing coordinates