### PR TITLE
print BLE pairing pin to serial

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -623,6 +623,7 @@ NodePrefs *MyMesh::getNodePrefs() {
   return &_prefs;
 }
 uint32_t MyMesh::getBLEPin() {
+  Serial.printf("BLE PIN: %06d\n", _active_ble_pin);
   return _active_ble_pin;
 }
 


### PR DESCRIPTION
Users that use boards with damaged or no display on targets that don't have display detection(or not possible) need a way to read bluetooth dynamic pin.