### PR TITLE
add board battery percentage

### DIFF
--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -132,11 +132,7 @@ void UITask::newMsg(uint8_t path_len, const char* from_name, const char* text, i
   }
 }
 
-void UITask::renderBatteryIndicator(uint16_t batteryMilliVolts) {
-  // Convert millivolts to percentage
-  const int minMilliVolts = 3000; // Minimum voltage (e.g., 3.0V)
-  const int maxMilliVolts = 4200; // Maximum voltage (e.g., 4.2V)
-  int batteryPercentage = ((batteryMilliVolts - minMilliVolts) * 100) / (maxMilliVolts - minMilliVolts);
+void UITask::renderBatteryIndicator(uint16_t batteryPercentage) {
   if (batteryPercentage < 0) batteryPercentage = 0; // Clamp to 0%
   if (batteryPercentage > 100) batteryPercentage = 100; // Clamp to 100%
 
@@ -211,7 +207,7 @@ void UITask::renderCurrScreen() {
     _display->print(_node_prefs->node_name);
 
     // battery voltage
-    renderBatteryIndicator(_board->getBattMilliVolts());
+    renderBatteryIndicator(_board->getBattPercent());
 
     // freq / sf
     _display->setCursor(0, 20);

--- a/examples/companion_radio/UITask.h
+++ b/examples/companion_radio/UITask.h
@@ -46,7 +46,7 @@ class UITask {
 
   void renderCurrScreen();
   void userLedHandler();
-  void renderBatteryIndicator(uint16_t batteryMilliVolts);
+  void renderBatteryIndicator(uint16_t batteryPercentage);
   
   // Button action handlers
   void handleButtonAnyPress();

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -33,9 +33,30 @@ namespace mesh {
 #define  BD_STARTUP_NORMAL     0  // getStartupReason() codes
 #define  BD_STARTUP_RX_PACKET  1
 
+#define BATT_LIPO     0
+#define BATT_LIFEPO   1
+
 class MainBoard {
 public:
   virtual uint16_t getBattMilliVolts() = 0;
+  uint8_t getBattPercent() {
+    uint32_t mv = getBattMilliVolts();
+    // Convert millivolts to percentage
+    int minMilliVolts;
+    int maxMilliVolts;
+    switch (getBattType()) {
+    case BATT_LIPO:
+      minMilliVolts = 3000;
+      maxMilliVolts = 4200;
+      break;
+    case BATT_LIFEPO:
+      minMilliVolts = 2500;
+      maxMilliVolts = 3400;
+      break;
+    }
+    return ((mv - minMilliVolts) * 100) / (maxMilliVolts - minMilliVolts);
+  }
+  uint8_t getBattType() { return BATT_LIPO; };
   virtual const char* getManufacturerName() const = 0;
   virtual void onBeforeTransmit() { }
   virtual void onAfterTransmit() { }


### PR DESCRIPTION
defaults to lipo with no changes to existing variants

- adds two chemistry types to start BAT_LIPO and BATT_LIFEPO
- adds getBattPercent to MainBoard
- adds getBattType to MainBoard
- companion UI now uses getBattPercent in renderBatteryIndicator