### PR TITLE
refactor: promicro with CustomSX1262::std_init()

### DIFF
--- a/src/helpers/CustomSX1262.h
+++ b/src/helpers/CustomSX1262.h
@@ -30,6 +30,12 @@ class CustomSX1262 : public SX1262 {
     #endif
   #endif
       int status = begin(LORA_FREQ, LORA_BW, LORA_SF, cr, RADIOLIB_SX126X_SYNC_WORD_PRIVATE, LORA_TX_POWER, 8, tcxo);
+      // if radio init fails with -707/-706, try again with tcxo voltage set to 0.0f
+      if (status == RADIOLIB_ERR_SPI_CMD_FAILED || status == RADIOLIB_ERR_SPI_CMD_INVALID) {
+        #define SX126X_DIO3_TCXO_VOLTAGE (0.0f);
+        tcxo = SX126X_DIO3_TCXO_VOLTAGE;
+        status = begin(LORA_FREQ, LORA_BW, LORA_SF, cr, RADIOLIB_SX126X_SYNC_WORD_PRIVATE, LORA_TX_POWER, 8, tcxo);
+      }
       if (status != RADIOLIB_ERR_NONE) {
         Serial.print("ERROR: radio init failed: ");
         Serial.println(status);

--- a/variants/promicro/target.cpp
+++ b/variants/promicro/target.cpp
@@ -2,9 +2,6 @@
 #include "target.h"
 #include <helpers/ArduinoHelpers.h>
 
-#if ENV_INCLUDE_GPS
-#endif
-
 PromicroBoard board;
 
 RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, SPI);
@@ -25,47 +22,10 @@ AutoDiscoverRTCClock rtc_clock(fallback_clock);
   DISPLAY_CLASS display;
 #endif
 
-#ifndef LORA_CR
-  #define LORA_CR      5
-#endif
-
 bool radio_init() {
   rtc_clock.begin(Wire);
   
-#ifdef SX126X_DIO3_TCXO_VOLTAGE
-  float tcxo = SX126X_DIO3_TCXO_VOLTAGE;
-#else
-  float tcxo = 1.6f;
-#endif
-
-  SPI.setPins(P_LORA_MISO, P_LORA_SCLK, P_LORA_MOSI);
-  SPI.begin();
-  radio.setRfSwitchPins(SX126X_RXEN, SX126X_TXEN);
-  int status = radio.begin(LORA_FREQ, LORA_BW, LORA_SF, LORA_CR, RADIOLIB_SX126X_SYNC_WORD_PRIVATE, LORA_TX_POWER, 8, tcxo);
-  if (status == RADIOLIB_ERR_SPI_CMD_FAILED || status == RADIOLIB_ERR_SPI_CMD_INVALID) {
-    #define SX126X_DIO3_TCXO_VOLTAGE (0.0f);
-    tcxo = SX126X_DIO3_TCXO_VOLTAGE;
-    status = radio.begin(LORA_FREQ, LORA_BW, LORA_SF, LORA_CR, RADIOLIB_SX126X_SYNC_WORD_PRIVATE, LORA_TX_POWER, 8, tcxo);
-  }
-  if (status != RADIOLIB_ERR_NONE) {
-    Serial.print("ERROR: radio init failed: ");
-    Serial.println(status);
-    return false;  // fail
-  }
-  
-  radio.setCRC(1);
-  
-#ifdef SX126X_CURRENT_LIMIT
-  radio.setCurrentLimit(SX126X_CURRENT_LIMIT);
-#endif
-#ifdef SX126X_DIO2_AS_RF_SWITCH
-  radio.setDio2AsRfSwitch(SX126X_DIO2_AS_RF_SWITCH);
-#endif
-#ifdef SX126X_RX_BOOSTED_GAIN
-  radio.setRxBoostedGainMode(SX126X_RX_BOOSTED_GAIN);
-#endif
-
-  return true;  // success
+  return radio.std_init(&SPI);
 }
 
 uint32_t radio_get_rng_seed() {


### PR DESCRIPTION
added check in CustomSX1262.h to support both txco and non-txco radios
switched promicro to use CustomSX1262::std_init()

tested on faketec/promicro with HT-RA62 and RA-01SH