### PR TITLE
remove LORA_CR fallback from target.cpp on xiao_nrf52, xiao_s3 and t-…

### DIFF
--- a/variants/techo/target.cpp
+++ b/variants/techo/target.cpp
@@ -18,10 +18,6 @@ TechoSensorManager sensors = TechoSensorManager(nmea);
   DISPLAY_CLASS display;
 #endif
 
-#ifndef LORA_CR
-  #define LORA_CR      5
-#endif
-
 bool radio_init() {
   rtc_clock.begin(Wire);
   

--- a/variants/xiao_nrf52/target.cpp
+++ b/variants/xiao_nrf52/target.cpp
@@ -12,10 +12,6 @@ VolatileRTCClock fallback_clock;
 AutoDiscoverRTCClock rtc_clock(fallback_clock);
 EnvironmentSensorManager sensors;
 
-#ifndef LORA_CR
-  #define LORA_CR      5
-#endif
-
 bool radio_init() {
     rtc_clock.begin(Wire);
   

--- a/variants/xiao_s3_wio/target.cpp
+++ b/variants/xiao_s3_wio/target.cpp
@@ -20,10 +20,6 @@ SensorManager sensors;
   DISPLAY_CLASS display;
 #endif
 
-#ifndef LORA_CR
-  #define LORA_CR      5
-#endif
-
 bool radio_init() {
   fallback_clock.begin();
   rtc_clock.begin(Wire);


### PR DESCRIPTION
As spotted by @jquatier the case where `LORA_CR` is not defined in platformio.ini is handled in `std_init`