### PR TITLE
Heltec v3 GPS support

### DIFF
--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -21,6 +21,10 @@ build_flags =
   -D ENV_INCLUDE_BME280=1
   -D ENV_INCLUDE_INA3221=1
   -D ENV_INCLUDE_INA219=1  
+  -D ENV_INCLUDE_GPS=1
+  -D PIN_GPS_RX=45
+  -D PIN_GPS_TX=46
+  -D PIN_GPS_EN=-1
 build_src_filter = ${esp32_base.build_src_filter}
   +<../variants/heltec_v3>
   +<helpers/sensors>    
@@ -30,7 +34,8 @@ lib_deps =
   adafruit/Adafruit INA3221 Library @ ^1.0.1
   adafruit/Adafruit INA219 @ ^1.2.3
   adafruit/Adafruit AHTX0 @ ^2.0.5
-  adafruit/Adafruit BME280 Library @ ^2.3.0    
+  adafruit/Adafruit BME280 Library @ ^2.3.0
+  stevemarple/MicroNMEA @ ^2.0.6
 
 [env:Heltec_v3_repeater]
 extends = Heltec_lora32_v3

--- a/variants/heltec_v3/target.cpp
+++ b/variants/heltec_v3/target.cpp
@@ -14,7 +14,14 @@ WRAPPER_CLASS radio_driver(radio, board);
 
 ESP32RTCClock fallback_clock;
 AutoDiscoverRTCClock rtc_clock(fallback_clock);
-EnvironmentSensorManager sensors;
+
+#if ENV_INCLUDE_GPS
+  #include <helpers/sensors/MicroNMEALocationProvider.h>
+  MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1);
+  EnvironmentSensorManager sensors = EnvironmentSensorManager(nmea);
+#else
+  EnvironmentSensorManager sensors;
+#endif
 
 #ifdef DISPLAY_CLASS
   DISPLAY_CLASS display;


### PR DESCRIPTION
GPS support using EnvironmentSensorManager.

Tested with Ublox Neo-6M. Connect RX on GPS module to pin 45 and TX to pin 46.

Note that while you can enable and disable the GPS there is no way to actually power down the GPS module without using a mosfet and adjusting PIN_GPS_EN.

Closes: #328 