### PR TITLE
Fix T114 display flicker

### DIFF
--- a/src/helpers/ui/ST7789Display.cpp
+++ b/src/helpers/ui/ST7789Display.cpp
@@ -40,7 +40,7 @@ void ST7789Display::turnOn() {
     // Re-initialize the display
     display.init();
     display.displayOn();
-    delay(10);
+    delay(20);
 
     // Now turn on the backlight
     digitalWrite(PIN_TFT_LEDA_CTL, LOW);

--- a/src/helpers/ui/ST7789Display.cpp
+++ b/src/helpers/ui/ST7789Display.cpp
@@ -32,7 +32,21 @@ bool ST7789Display::begin() {
 }
 
 void ST7789Display::turnOn() {
-  ST7789Display::begin();
+  if (!_isOn) {
+    // Restore power to the display but keep backlight off
+    digitalWrite(PIN_TFT_VDD_CTL, LOW);
+    digitalWrite(PIN_TFT_RST, HIGH);
+    
+    // Re-initialize the display
+    display.init();
+    display.displayOn();
+    delay(10);
+
+    // Now turn on the backlight
+    digitalWrite(PIN_TFT_LEDA_CTL, LOW);
+    
+    _isOn = true;
+  }
 }
 
 void ST7789Display::turnOff() {


### PR DESCRIPTION
Currently if you wake up the display on the T114 you get a flickering effect because the display shows some content during re-initialization and then clears and re-renders again. This implements a slightly better `turnOn` method for a smoother effect. `begin` also had some redundant things that don't need to be called on every `turnOn`.