### PR TITLE
fix: remove extra spi.begin() on heltec v3

### DIFF
--- a/variants/heltec_v3/target.cpp
+++ b/variants/heltec_v3/target.cpp
@@ -32,7 +32,6 @@ bool radio_init() {
   rtc_clock.begin(Wire);
   
 #if defined(P_LORA_SCLK)
-  spi.begin(P_LORA_SCLK, P_LORA_MISO, P_LORA_MOSI);
   return radio.std_init(&spi);
 #else
   return radio.std_init();


### PR DESCRIPTION
While I was going over the remaining sx1262 boards that need updating to use CustomSX1262::std_init() I noticed that Heltec V3 has an extra spi.begin() which I guess is unneeded.