### PR TITLE
wio_e5_mini: led and rescue cli

### DIFF
--- a/src/helpers/stm32/STM32Board.h
+++ b/src/helpers/stm32/STM32Board.h
@@ -8,7 +8,7 @@ protected:
   uint8_t startup_reason;
 
 public:
-  void begin() {
+  virtual void begin() {
     startup_reason = BD_STARTUP_NORMAL;
   }
 
@@ -24,6 +24,15 @@ public:
 
   void reboot() override {
   }
+
+#if defined(P_LORA_TX_LED)
+  void onBeforeTransmit() override {
+    digitalWrite(P_LORA_TX_LED, LOW);   // turn TX LED on
+  }
+  void onAfterTransmit() override {
+    digitalWrite(P_LORA_TX_LED, HIGH);   // turn TX LED off
+  }
+#endif
 
   bool startOTAUpdate(const char* id, char reply[]) override { return false; };
 };

--- a/variants/wio-e5-mini/NullDisplayDriver.h
+++ b/variants/wio-e5-mini/NullDisplayDriver.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <helpers/ui/DisplayDriver.h>
+
+class NullDisplayDriver : public DisplayDriver {
+public:
+  NullDisplayDriver() : DisplayDriver(128, 64) { }
+  bool begin() { return false; }   // not present
+
+  bool isOn() override { return false; }
+  void turnOn() override { }
+  void turnOff() override { }
+  void clear() override { }
+  void startFrame(Color bkg = DARK) override { }
+  void setTextSize(int sz) override { }
+  void setColor(Color c) override { }
+  void setCursor(int x, int y) override { }
+  void print(const char* str) override { }
+  void fillRect(int x, int y, int w, int h) override { }
+  void drawRect(int x, int y, int w, int h) override { }
+  void drawXbm(int x, int y, const uint8_t* bits, int w, int h) override { }
+  uint16_t getTextWidth(const char* str) override { return 0; }
+  void endFrame() { }
+};

--- a/variants/wio-e5-mini/platformio.ini
+++ b/variants/wio-e5-mini/platformio.ini
@@ -7,6 +7,9 @@ build_flags = ${stm32_base.build_flags}
   -D WRAPPER_CLASS=CustomSTM32WLxWrapper
   -D SPI_INTERFACES_COUNT=0
   -D RX_BOOSTED_GAIN=true
+  -D P_LORA_TX_LED=LED_RED
+  -D PIN_USER_BTN=USER_BTN
+  -D USER_BTN_PRESSED=LOW
   -I variants/wio-e5-mini
 build_src_filter = ${stm32_base.build_src_filter}
   +<../variants/wio-e5-mini>
@@ -27,7 +30,8 @@ extends = lora_e5_mini
 build_flags = ${lora_e5_mini.build_flags}
   -D LORA_TX_POWER=22
   -D MAX_CONTACTS=100
-  -D MAX_GROUP_CHANNELS=8
+  -D MAX_GROUP_CHANNELS=8  
+  -D DISPLAY_CLASS=NullDisplayDriver
 build_src_filter = ${lora_e5_mini.build_src_filter}
   +<../examples/companion_radio/*.cpp>
 lib_deps = ${lora_e5_mini.lib_deps}

--- a/variants/wio-e5-mini/target.cpp
+++ b/variants/wio-e5-mini/target.cpp
@@ -20,6 +20,10 @@ static const Module::RfSwitchMode_t rfswitch_table[] = {
 VolatileRTCClock rtc_clock;
 WIOE5SensorManager sensors;
 
+#ifdef DISPLAY_CLASS
+  NullDisplayDriver display;
+#endif
+
 #ifndef LORA_CR
   #define LORA_CR      5
 #endif

--- a/variants/wio-e5-mini/target.h
+++ b/variants/wio-e5-mini/target.h
@@ -7,20 +7,38 @@
 #include <helpers/CustomSTM32WLxWrapper.h>
 #include <helpers/ArduinoHelpers.h>
 #include <helpers/SensorManager.h>
+#ifdef DISPLAY_CLASS
+  #include "NullDisplayDriver.h"
+#endif
 
 #include <BME280I2C.h>
 #include <Wire.h>
 
+#ifdef DISPLAY_CLASS
+  extern NullDisplayDriver display;
+#endif
+
 class WIOE5Board : public STM32Board {
 public:
+    void begin() override {
+        STM32Board::begin();
+
+        pinMode(LED_RED, OUTPUT);
+        digitalWrite(LED_RED, HIGH);
+        pinMode(USER_BTN, INPUT_PULLUP);
+    }
+
     const char* getManufacturerName() const override {
         return "Seeed Wio E5 mini";
     }
 
     uint16_t getBattMilliVolts() override {
         analogReadResolution(12);
-        uint32_t raw = analogRead(PIN_A3);            
-        return raw;
+        uint32_t raw = 0;
+        for (int i=0; i<8;i++) {
+            raw += analogRead(PIN_A3);
+        }            
+        return ((double)raw) * 1.73 * 5 * 1000 / 8 / 4096;
     }
 };
 


### PR DESCRIPTION
Bat reading on A3 (with 1.5M and 1M resistors as on RAKs)
LORA_TX_LED support
USER_BTN support (and ui_task)

Now rescue cli is working ;)

There is still a lot of space available

```
RAM:   [=====     ]  46.8% (used 30652 bytes from 65536 bytes)
Flash: [========  ]  77.3% (used 177420 bytes from 229376 bytes)
```