### PR TITLE
stm32: implement halt and reset

### DIFF
--- a/src/helpers/stm32/STM32Board.h
+++ b/src/helpers/stm32/STM32Board.h
@@ -23,6 +23,13 @@ public:
   }
 
   void reboot() override {
+    NVIC_SystemReset(); 
+  }
+
+  void powerOff() override {
+    HAL_PWREx_DisableInternalWakeUpLine();
+    __disable_irq();
+    HAL_PWREx_EnterSHUTDOWNMode();
   }
 
 #if defined(P_LORA_TX_LED)


### PR DESCRIPTION
STM32 boards should now reset and halt correctly (halt with no wakeup programmed, rst button restarts the board)