### PR TITLE
wio-e5-sdk: adjust uart location

### DIFF
--- a/variants/wio-e5-dev/platformio.ini
+++ b/variants/wio-e5-dev/platformio.ini
@@ -7,6 +7,8 @@ build_flags = ${stm32_base.build_flags}
   -D WRAPPER_CLASS=CustomSTM32WLxWrapper
   -D SPI_INTERFACES_COUNT=0
   -D RX_BOOSTED_GAIN=true
+  -D PIN_SERIAL_RX=PB7
+  -D PIN_SERIAL_TX=PB6
   -I variants/wio-e5-dev
 build_src_filter = ${stm32_base.build_src_filter}
   +<../variants/wio-e5-dev>

--- a/variants/wio-e5-dev/variant.h
+++ b/variants/wio-e5-dev/variant.h
@@ -1,10 +1,5 @@
 #pragma once
 
-// UART Definitions
-// #ifndef SERIAL_UART_INSTANCE
-//   #define SERIAL_UART_INSTANCE  101
-// #endif
-
 #include <variant_generic.h>
 
 #undef RNG


### PR DESCRIPTION
By default Serial is on TTL pins (RX2/TX2), rewired to USB port 