### PR TITLE
CustomSX1262: fix typo that would prevent compile when TXEN or RXEN i…

### DIFF
--- a/src/helpers/CustomSX1262.h
+++ b/src/helpers/CustomSX1262.h
@@ -67,11 +67,11 @@ class CustomSX1262 : public SX1262 {
       setRxBoostedGainMode(SX126X_RX_BOOSTED_GAIN);
   #endif
   #if defined(SX126X_RXEN) || defined(SX126X_TXEN)
-    #ifndef SX1262X_RXEN
-      #define SX1262X_RXEN RADIOLIB_NC
+    #ifndef SX126X_RXEN
+      #define SX126X_RXEN RADIOLIB_NC
     #endif
-    #ifndef SX1262X_TXEN
-      #define SX1262X_TXEN RADIOLIB_NC
+    #ifndef SX126X_TXEN
+      #define SX126X_TXEN RADIOLIB_NC
     #endif
       setRfSwitchPins(SX126X_RXEN, SX126X_TXEN);
   #endif 


### PR DESCRIPTION
CustomSX1262: fix typo that would prevent compile when TXEN or RXEN s not set