### PR TITLE
Initial Support for Heltec Wireless Paper

### DIFF
--- a/src/helpers/HeltecV3Board.h
+++ b/src/helpers/HeltecV3Board.h
@@ -4,7 +4,7 @@
 #include <helpers/RefCountedDigitalPin.h>
 
 // LoRa radio module pins for Heltec V3
-// Also for Heltec Wireless Tracker
+// Also for Heltec Wireless Tracker/Paper
 #define  P_LORA_DIO_1   14
 #define  P_LORA_NSS      8
 #define  P_LORA_RESET   RADIOLIB_NC
@@ -14,7 +14,9 @@
 #define  P_LORA_MOSI    10
 
 // built-ins
-#define  PIN_VBAT_READ    1
+#ifndef PIN_VBAT_READ              // set in platformio.ini for boards like Heltec Wireless Paper (20)
+  #define  PIN_VBAT_READ    1
+#endif
 #ifndef PIN_ADC_CTRL              // set in platformio.ini for Heltec Wireless Tracker (2)
   #define  PIN_ADC_CTRL    37
 #endif

--- a/src/helpers/ui/E213Display.cpp
+++ b/src/helpers/ui/E213Display.cpp
@@ -1,0 +1,116 @@
+#include "E213Display.h"
+#include "../../MeshCore.h"
+
+bool E213Display::begin() {
+  if (_init) return true;
+  
+  powerOn();
+  display.begin();
+  
+  // Set to landscape mode rotated 180 degrees
+  display.setRotation(3);
+  
+  _init = true;
+  _isOn = true;
+  
+  clear();
+  display.fastmodeOn(); // Enable fast mode for quicker (partial) updates
+  
+  return true;
+}
+
+void E213Display::powerOn() {
+  #ifdef PIN_VEXT_EN
+    pinMode(PIN_VEXT_EN, OUTPUT);
+    digitalWrite(PIN_VEXT_EN, LOW); // Active low
+    delay(50); // Allow power to stabilize
+  #endif
+}
+
+void E213Display::powerOff() {
+  #ifdef PIN_VEXT_EN
+    digitalWrite(PIN_VEXT_EN, HIGH); // Turn off power
+  #endif
+}
+
+void E213Display::turnOn() {
+  if (!_init) begin();
+  powerOn();
+  _isOn = true;
+}
+
+void E213Display::turnOff() {
+  powerOff();
+  _isOn = false;
+}
+
+void E213Display::clear() {
+  display.clear();
+}
+
+void E213Display::startFrame(Color bkg) {
+  // Fill screen with white first to ensure clean background
+  display.fillRect(0, 0, width(), height(), WHITE);
+  if (bkg == LIGHT) {
+    // Fill with black if light background requested (inverted for e-ink)
+    display.fillRect(0, 0, width(), height(), BLACK);
+  }
+}
+
+void E213Display::setTextSize(int sz) {
+  // The library handles text size internally
+  display.setTextSize(sz);
+}
+
+void E213Display::setColor(Color c) {
+  // implemented in individual display methods
+}
+
+void E213Display::setCursor(int x, int y) {
+  display.setCursor(x, y);
+}
+
+void E213Display::print(const char* str) {
+  display.print(str);
+}
+
+void E213Display::fillRect(int x, int y, int w, int h) {
+  display.fillRect(x, y, w, h, BLACK);
+}
+
+void E213Display::drawRect(int x, int y, int w, int h) {
+  display.drawRect(x, y, w, h, BLACK);
+}
+
+void E213Display::drawXbm(int x, int y, const uint8_t* bits, int w, int h) {
+  // Width in bytes for bitmap processing
+  uint16_t widthInBytes = (w + 7) / 8;
+  
+  // Process the bitmap row by row
+  for (int by = 0; by < h; by++) {
+    // Scan across the row bit by bit
+    for (int bx = 0; bx < w; bx++) {
+      // Get the current bit using MSB ordering (like GxEPDDisplay)
+      uint16_t byteOffset = (by * widthInBytes) + (bx / 8);
+      uint8_t bitMask = 0x80 >> (bx & 7);
+      bool bitSet = bits[byteOffset] & bitMask;
+      
+      // If the bit is set, draw the pixel
+      if (bitSet) {
+        display.drawPixel(x + bx, y + by, BLACK);
+      }
+    }
+  }
+}
+
+uint16_t E213Display::getTextWidth(const char* str) {
+  int16_t x1, y1;
+  uint16_t w, h;
+  display.getTextBounds(str, 0, 0, &x1, &y1, &w, &h);
+  return w;
+}
+
+void E213Display::endFrame() {
+  display.update();
+}
+

--- a/src/helpers/ui/E213Display.cpp
+++ b/src/helpers/ui/E213Display.cpp
@@ -1,36 +1,37 @@
 #include "E213Display.h"
+
 #include "../../MeshCore.h"
 
 bool E213Display::begin() {
   if (_init) return true;
-  
+
   powerOn();
   display.begin();
-  
+
   // Set to landscape mode rotated 180 degrees
   display.setRotation(3);
-  
+
   _init = true;
   _isOn = true;
-  
+
   clear();
   display.fastmodeOn(); // Enable fast mode for quicker (partial) updates
-  
+
   return true;
 }
 
 void E213Display::powerOn() {
-  #ifdef PIN_VEXT_EN
-    pinMode(PIN_VEXT_EN, OUTPUT);
-    digitalWrite(PIN_VEXT_EN, LOW); // Active low
-    delay(50); // Allow power to stabilize
-  #endif
+#ifdef PIN_VEXT_EN
+  pinMode(PIN_VEXT_EN, OUTPUT);
+  digitalWrite(PIN_VEXT_EN, LOW); // Active low
+  delay(50);                      // Allow power to stabilize
+#endif
 }
 
 void E213Display::powerOff() {
-  #ifdef PIN_VEXT_EN
-    digitalWrite(PIN_VEXT_EN, HIGH); // Turn off power
-  #endif
+#ifdef PIN_VEXT_EN
+  digitalWrite(PIN_VEXT_EN, HIGH); // Turn off power
+#endif
 }
 
 void E213Display::turnOn() {
@@ -70,7 +71,7 @@ void E213Display::setCursor(int x, int y) {
   display.setCursor(x, y);
 }
 
-void E213Display::print(const char* str) {
+void E213Display::print(const char *str) {
   display.print(str);
 }
 
@@ -82,10 +83,10 @@ void E213Display::drawRect(int x, int y, int w, int h) {
   display.drawRect(x, y, w, h, BLACK);
 }
 
-void E213Display::drawXbm(int x, int y, const uint8_t* bits, int w, int h) {
+void E213Display::drawXbm(int x, int y, const uint8_t *bits, int w, int h) {
   // Width in bytes for bitmap processing
   uint16_t widthInBytes = (w + 7) / 8;
-  
+
   // Process the bitmap row by row
   for (int by = 0; by < h; by++) {
     // Scan across the row bit by bit
@@ -94,7 +95,7 @@ void E213Display::drawXbm(int x, int y, const uint8_t* bits, int w, int h) {
       uint16_t byteOffset = (by * widthInBytes) + (bx / 8);
       uint8_t bitMask = 0x80 >> (bx & 7);
       bool bitSet = bits[byteOffset] & bitMask;
-      
+
       // If the bit is set, draw the pixel
       if (bitSet) {
         display.drawPixel(x + bx, y + by, BLACK);
@@ -103,7 +104,7 @@ void E213Display::drawXbm(int x, int y, const uint8_t* bits, int w, int h) {
   }
 }
 
-uint16_t E213Display::getTextWidth(const char* str) {
+uint16_t E213Display::getTextWidth(const char *str) {
   int16_t x1, y1;
   uint16_t w, h;
   display.getTextBounds(str, 0, 0, &x1, &y1, &w, &h);
@@ -113,4 +114,3 @@ uint16_t E213Display::getTextWidth(const char* str) {
 void E213Display::endFrame() {
   display.update();
 }
-

--- a/src/helpers/ui/E213Display.h
+++ b/src/helpers/ui/E213Display.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include "DisplayDriver.h"
+
 #include <SPI.h>
 #include <Wire.h>
 #include <heltec-eink-modules.h>
-#include "DisplayDriver.h"
 
 // Display driver for E213 e-ink display
 class E213Display : public DisplayDriver {
@@ -12,8 +13,7 @@ class E213Display : public DisplayDriver {
   bool _isOn = false;
 
 public:
-  E213Display() : DisplayDriver(250, 122) {
-  }
+  E213Display() : DisplayDriver(250, 122) {}
 
   bool begin();
   bool isOn() override { return _isOn; }
@@ -24,13 +24,13 @@ public:
   void setTextSize(int sz) override;
   void setColor(Color c) override;
   void setCursor(int x, int y) override;
-  void print(const char* str) override;
+  void print(const char *str) override;
   void fillRect(int x, int y, int w, int h) override;
   void drawRect(int x, int y, int w, int h) override;
-  void drawXbm(int x, int y, const uint8_t* bits, int w, int h) override;
-  uint16_t getTextWidth(const char* str) override;
+  void drawXbm(int x, int y, const uint8_t *bits, int w, int h) override;
+  uint16_t getTextWidth(const char *str) override;
   void endFrame() override;
-  
+
 private:
   void powerOn();
   void powerOff();

--- a/src/helpers/ui/E213Display.h
+++ b/src/helpers/ui/E213Display.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <SPI.h>
+#include <Wire.h>
+#include <heltec-eink-modules.h>
+#include "DisplayDriver.h"
+
+// Display driver for E213 e-ink display
+class E213Display : public DisplayDriver {
+  EInkDisplay_VisionMasterE213 display;
+  bool _init = false;
+  bool _isOn = false;
+
+public:
+  E213Display() : DisplayDriver(250, 122) {
+  }
+
+  bool begin();
+  bool isOn() override { return _isOn; }
+  void turnOn() override;
+  void turnOff() override;
+  void clear() override;
+  void startFrame(Color bkg = DARK) override;
+  void setTextSize(int sz) override;
+  void setColor(Color c) override;
+  void setCursor(int x, int y) override;
+  void print(const char* str) override;
+  void fillRect(int x, int y, int w, int h) override;
+  void drawRect(int x, int y, int w, int h) override;
+  void drawXbm(int x, int y, const uint8_t* bits, int w, int h) override;
+  uint16_t getTextWidth(const char* str) override;
+  void endFrame() override;
+  
+private:
+  void powerOn();
+  void powerOff();
+};

--- a/variants/heltec_wireless_paper/platformio.ini
+++ b/variants/heltec_wireless_paper/platformio.ini
@@ -1,0 +1,84 @@
+[Heltec_Wireless_Paper_base]
+extends = esp32_base
+board = esp32-s3-devkitc-1
+build_flags =
+  ${esp32_base.build_flags}
+  -I variants/heltec_wireless_paper
+  -D HELTEC_WIRELESS_PAPER
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D LORA_TX_POWER=22
+  -D P_LORA_TX_LED=18
+  ; -D PIN_BOARD_SDA=17
+  ; -D PIN_BOARD_SCL=18
+  -D PIN_USER_BTN=0
+  -D PIN_VEXT_EN=45
+  -D PIN_VBAT_READ=20
+  -D PIN_ADC_CTRL=19
+  -D SX126X_DIO2_AS_RF_SWITCH=true
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
+  -D SX126X_CURRENT_LIMIT=140
+  -D SX126X_RX_BOOSTED_GAIN=1
+  -D DISP_CS=4
+  -D DISP_BUSY=7
+  -D DISP_DC=5
+  -D DISP_RST=6
+  -D DISP_SCLK=3
+  -D DISP_MOSI=2
+  -D ARDUINO_heltec_wifi_lora_32_V3
+  -D WIRELESS_PAPER
+build_src_filter = ${esp32_base.build_src_filter}
+  +<../variants/heltec_wireless_paper>    
+lib_deps =
+  ${esp32_base.lib_deps}
+  todd-herbert/heltec-eink-modules @ 4.5.0
+
+[env:Heltec_Wireless_Paper_companion_radio_ble]
+extends = Heltec_Wireless_Paper_base
+build_flags =
+  ${Heltec_Wireless_Paper_base.build_flags}
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=8
+  -D DISPLAY_CLASS=E213Display
+  -D BLE_PIN_CODE=0  ; dynamic, random PIN
+  -D BLE_DEBUG_LOGGING=1
+  -D OFFLINE_QUEUE_SIZE=256
+build_src_filter = ${Heltec_Wireless_Paper_base.build_src_filter}
+  +<helpers/ui/E213Display.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/companion_radio>
+lib_deps =
+  ${Heltec_Wireless_Paper_base.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:Heltec_Wireless_Paper_repeater]
+extends = Heltec_Wireless_Paper_base
+build_flags =
+  ${Heltec_Wireless_Paper_base.build_flags}
+  -D DISPLAY_CLASS=E213Display
+  -D ADVERT_NAME='"Heltec WP Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+build_src_filter = ${Heltec_Wireless_Paper_base.build_src_filter}
+  +<helpers/ui/E213Display.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${Heltec_Wireless_Paper_base.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:Heltec_Wireless_Paper_room_server]
+extends = Heltec_Wireless_Paper_base
+build_flags =
+  ${Heltec_Wireless_Paper_base.build_flags}
+  -D DISPLAY_CLASS=E213Display
+  -D ADVERT_NAME='"Heltec WP Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+build_src_filter = ${Heltec_Wireless_Paper_base.build_src_filter}
+  +<helpers/ui/E213Display.cpp>
+  +<../examples/simple_room_server>
+lib_deps =
+  ${Heltec_Wireless_Paper_base.lib_deps}
+  ${esp32_ota.lib_deps}

--- a/variants/heltec_wireless_paper/target.cpp
+++ b/variants/heltec_wireless_paper/target.cpp
@@ -1,0 +1,44 @@
+#include <Arduino.h>
+#include "target.h"
+
+HeltecV3Board board;
+
+static SPIClass spi;
+RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, spi);
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+ESP32RTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+
+SensorManager sensors;
+
+#ifdef DISPLAY_CLASS
+  DISPLAY_CLASS display;
+#endif
+
+bool radio_init() {
+  fallback_clock.begin();
+  rtc_clock.begin(Wire);
+  return radio.std_init(&spi);
+}
+
+uint32_t radio_get_rng_seed() {
+  return radio.random(0x7FFFFFFF);
+}
+
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr) {
+  radio.setFrequency(freq);
+  radio.setSpreadingFactor(sf);
+  radio.setBandwidth(bw);
+  radio.setCodingRate(cr);
+}
+
+void radio_set_tx_power(uint8_t dbm) {
+  radio.setOutputPower(dbm);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);  // create new random identity
+}

--- a/variants/heltec_wireless_paper/target.cpp
+++ b/variants/heltec_wireless_paper/target.cpp
@@ -1,5 +1,6 @@
-#include <Arduino.h>
 #include "target.h"
+
+#include <Arduino.h>
 
 HeltecV3Board board;
 
@@ -14,7 +15,7 @@ AutoDiscoverRTCClock rtc_clock(fallback_clock);
 SensorManager sensors;
 
 #ifdef DISPLAY_CLASS
-  DISPLAY_CLASS display;
+DISPLAY_CLASS display;
 #endif
 
 bool radio_init() {
@@ -40,5 +41,5 @@ void radio_set_tx_power(uint8_t dbm) {
 
 mesh::LocalIdentity radio_new_identity() {
   RadioNoiseListener rng(radio);
-  return mesh::LocalIdentity(&rng);  // create new random identity
+  return mesh::LocalIdentity(&rng); // create new random identity
 }

--- a/variants/heltec_wireless_paper/target.h
+++ b/variants/heltec_wireless_paper/target.h
@@ -2,13 +2,13 @@
 
 #define RADIOLIB_STATIC_ONLY 1
 #include <RadioLib.h>
-#include <helpers/RadioLibWrappers.h>
-#include <helpers/HeltecV3Board.h>
-#include <helpers/CustomSX1262Wrapper.h>
 #include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/CustomSX1262Wrapper.h>
+#include <helpers/HeltecV3Board.h>
+#include <helpers/RadioLibWrappers.h>
 #include <helpers/SensorManager.h>
 #ifdef DISPLAY_CLASS
-  #include <helpers/ui/E213Display.h>
+#include <helpers/ui/E213Display.h>
 #endif
 
 extern HeltecV3Board board;
@@ -17,7 +17,7 @@ extern AutoDiscoverRTCClock rtc_clock;
 extern SensorManager sensors;
 
 #ifdef DISPLAY_CLASS
-  extern DISPLAY_CLASS display;
+extern DISPLAY_CLASS display;
 #endif
 
 bool radio_init();

--- a/variants/heltec_wireless_paper/target.h
+++ b/variants/heltec_wireless_paper/target.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/RadioLibWrappers.h>
+#include <helpers/HeltecV3Board.h>
+#include <helpers/CustomSX1262Wrapper.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/SensorManager.h>
+#ifdef DISPLAY_CLASS
+  #include <helpers/ui/E213Display.h>
+#endif
+
+extern HeltecV3Board board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern SensorManager sensors;
+
+#ifdef DISPLAY_CLASS
+  extern DISPLAY_CLASS display;
+#endif
+
+bool radio_init();
+uint32_t radio_get_rng_seed();
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr);
+void radio_set_tx_power(uint8_t dbm);
+mesh::LocalIdentity radio_new_identity();


### PR DESCRIPTION
- Adding support for Heltec Wireless Paper
- Supports 1.1 version with LCMEN2R13EFC1 display
- Tested companion, repeater, room server variants. All build and flash with success.

Notes:
- `GxEPD` does not support this display so using a new driver, discussion here: https://forum.arduino.cc/t/lcmen2r13efc1-discussion-heltec-wireless-paper/1211430
- Alternative driver that could be used is in the meshtastic fork of `GxEPD`. https://github.com/meshtastic/GxEPD2/blob/master/src/epd/GxEPD2_213_FC1.h 


https://github.com/user-attachments/assets/efc0ac7b-6c02-4de1-91a1-3d4c7b9d31c9

