### PR TITLE
change fixed preamble to match the new 16

### DIFF
--- a/src/helpers/CustomLR1110Wrapper.h
+++ b/src/helpers/CustomLR1110Wrapper.h
@@ -17,7 +17,7 @@ public:
 
   void onSendFinished() override {
     RadioLibWrapper::onSendFinished();
-    _radio->setPreambleLength(8); // overcomes weird issues with small and big pkts
+    _radio->setPreambleLength(16); // overcomes weird issues with small and big pkts
   }
 
   float getLastRSSI() const override { return ((CustomLR1110 *)_radio)->getRSSI(); }


### PR DESCRIPTION
T1000 is deaf without matching the preamble length