### PR TITLE
move rak usr btn to companions

### DIFF
--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -6,8 +6,6 @@ board_check = true
 build_flags = ${nrf52840_base.build_flags}
   -I variants/rak4631
   -D RAK_4631
-  -D PIN_USER_BTN=9
-  -D PIN_USER_BTN_ANA=31
   -D PIN_BOARD_SCL=14
   -D PIN_BOARD_SDA=13
   -D PIN_OLED_RESET=-1
@@ -84,6 +82,8 @@ build_src_filter = ${rak4631.build_src_filter}
 extends = rak4631
 build_flags =
   ${rak4631.build_flags}
+  -D PIN_USER_BTN=9
+  -D PIN_USER_BTN_ANA=31
   -D DISPLAY_CLASS=SSD1306Display
   -D MAX_CONTACTS=100
   -D MAX_GROUP_CHANNELS=8
@@ -100,6 +100,8 @@ lib_deps =
 extends = rak4631
 build_flags =
   ${rak4631.build_flags}
+  -D PIN_USER_BTN=9
+  -D PIN_USER_BTN_ANA=31
   -D DISPLAY_CLASS=SSD1306Display
   -D MAX_CONTACTS=100
   -D MAX_GROUP_CHANNELS=8
@@ -120,6 +122,8 @@ lib_deps =
 extends = rak4631
 build_flags =
   ${rak4631.build_flags}
+  -D PIN_USER_BTN=9
+  -D PIN_USER_BTN_ANA=31
   -D DISPLAY_CLASS=SSD1306Display
   -D MAX_CONTACTS=100
   -D MAX_GROUP_CHANNELS=8
@@ -145,6 +149,8 @@ lib_deps =
 extends = rak4631
 build_flags =
   ${rak4631.build_flags}
+  -D PIN_USER_BTN=9
+  -D PIN_USER_BTN_ANA=31
   -D MAX_CONTACTS=100
   -D MAX_GROUP_CHANNELS=1
 ;  -D MESH_PACKET_LOGGING=1


### PR DESCRIPTION
repeaters do not typically have user buttons and there is only one analog pin available on most, if not all, base boards.

so this allows repeaters to add custom peripherals or alternate battery signals