### PR TITLE
Remove ScanResponse.addName() to fix re-advertising after disconnect

### DIFF
--- a/src/helpers/nrf52/SerialBLEInterface.cpp
+++ b/src/helpers/nrf52/SerialBLEInterface.cpp
@@ -18,6 +18,10 @@ void SerialBLEInterface::begin(const char* device_name, uint32_t pin_code) {
 }
 
 void SerialBLEInterface::startAdv() {
+  Bluefruit.Advertising.stop(); // always clean restart
+  Bluefruit.Advertising.clearData(); // clear advertising data
+  Bluefruit.ScanResponse.clearData(); // clear scan response data
+  
   // Advertising packet
   Bluefruit.Advertising.addFlags(BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE);
   Bluefruit.Advertising.addTxPower();
@@ -27,7 +31,7 @@ void SerialBLEInterface::startAdv() {
 
   // Secondary Scan Response packet (optional)
   // Since there is no room for 'Name' in Advertising packet
-  // Bluefruit.ScanResponse.addName();
+  Bluefruit.ScanResponse.addName();
 
   /* Start Advertising
    * - Enable auto advertising if disconnected
@@ -38,7 +42,7 @@ void SerialBLEInterface::startAdv() {
    * For recommended advertising interval
    * https://developer.apple.com/library/content/qa/qa1931/_index.html   
    */
-  Bluefruit.Advertising.restartOnDisconnect(true);
+  Bluefruit.Advertising.restartOnDisconnect(false); // don't restart automatically as already beeing done in checkRecvFrame()
   Bluefruit.Advertising.setInterval(32, 244);    // in unit of 0.625 ms
   Bluefruit.Advertising.setFastTimeout(30);      // number of seconds in fast mode
   Bluefruit.Advertising.start(0);                // 0 = Don't stop advertising after n seconds 

--- a/src/helpers/nrf52/SerialBLEInterface.cpp
+++ b/src/helpers/nrf52/SerialBLEInterface.cpp
@@ -27,7 +27,7 @@ void SerialBLEInterface::startAdv() {
 
   // Secondary Scan Response packet (optional)
   // Since there is no room for 'Name' in Advertising packet
-  Bluefruit.ScanResponse.addName();
+  // Bluefruit.ScanResponse.addName();
 
   /* Start Advertising
    * - Enable auto advertising if disconnected


### PR DESCRIPTION
Removed the call to Bluefruit.ScanResponse.addName() in startAdv(), as it was preventing BLE from reliably restarting advertising after a disconnect.

Hypothesis: adding the device name to the scan response exceeds internal buffer limits or causes a conflict with advertising timing, leading to the BLE stack silently failing to re-advertise.

Tested successfully (on T-1000) without this line, advertising now resumes correctly after disconnection (on iPhone)