### PR TITLE
fix: Heltec V3 amended GPS pins

### DIFF
--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -25,7 +25,7 @@ build_flags =
   -D ENV_INCLUDE_GPS=1
   -D PIN_GPS_RX=47
   -D PIN_GPS_TX=48
-  -D PIN_GPS_EN=46
+  -D PIN_GPS_EN=26
 build_src_filter = ${esp32_base.build_src_filter}
   +<../variants/heltec_v3>
   +<helpers/sensors>

--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -23,9 +23,9 @@ build_flags =
   -D ENV_INCLUDE_INA3221=1
   -D ENV_INCLUDE_INA219=1
   -D ENV_INCLUDE_GPS=1
-  -D PIN_GPS_RX=45
-  -D PIN_GPS_TX=46
-  -D PIN_GPS_EN=-1
+  -D PIN_GPS_RX=47
+  -D PIN_GPS_TX=48
+  -D PIN_GPS_EN=46
 build_src_filter = ${esp32_base.build_src_filter}
   +<../variants/heltec_v3>
   +<helpers/sensors>


### PR DESCRIPTION
Pin 45 and 46 are strapping pins on ESP32-S3, which can lead to unintended consequences on boot.

I have amended the pins and added an enable pin as well.

Closes https://github.com/ripplebiz/MeshCore/issues/480