### PR TITLE
LR's (corrected) calculation instead of SX and minor changes

### DIFF
--- a/variants/t1000-e/target.cpp
+++ b/variants/t1000-e/target.cpp
@@ -61,7 +61,8 @@ bool radio_init() {
     return false;  // fail
   }
   
-  radio.setCRC(1);
+  radio.setCRC(2);
+  radio.explicitHeader();
 
 #ifdef RF_SWITCH_TABLE
   radio.setRfSwitchTable(rfswitch_dios, rfswitch_table);


### PR DESCRIPTION
Radiolib LR gettimeonair calculation wrongly assumes preamble is not in symbols already (in Lora, it is) so it's trying to make symbols from symbols.
if we are using radiolib's code, plugging in preamble lengths shows the error:
preamble 8 = 8
preamble 16 = 0
preamble 24 = 32

That's why it was working with 8 or 24 but not with 16.

override code copied from radiolib, stripped down to lora only and commented/corrected

also CRC increased and explicit header added (info via radiolib's wiki)