### PR TITLE
Rename PAYLOAD_TYPE_ANON_REQ to PAYLOAD_TYPE_ID_REQ (#457)

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -306,12 +306,12 @@ See here for packet-type: [https://github.com/ripplebiz/MeshCore/blob/main/src/P
  
 
     #define PAYLOAD_TYPE_REQ 0x00 // request (prefixed with dest/src hashes, MAC) (enc data: timestamp, blob) 
-    #define PAYLOAD_TYPE_RESPONSE 0x01 // response to REQ or ANON_REQ (prefixed with dest/src hashes, MAC) (enc data: timestamp, blob) 
+    #define PAYLOAD_TYPE_RESPONSE 0x01 // response to REQ or ID_REQ (prefixed with dest/src hashes, MAC) (enc data: timestamp, blob)
     #define PAYLOAD_TYPE_TXT_MSG 0x02 // a plain text message (prefixed with dest/src hashes, MAC) (enc data: timestamp, text) 
     #define PAYLOAD_TYPE_ACK 0x03 // a simple ack #define PAYLOAD_TYPE_ADVERT 0x04 // a node advertising its Identity 
     #define PAYLOAD_TYPE_GRP_TXT 0x05 // an (unverified) group text message (prefixed with channel hash, MAC) (enc data: timestamp, "name: msg") 
     #define PAYLOAD_TYPE_GRP_DATA 0x06 // an (unverified) group datagram (prefixed with channel hash, MAC) (enc data: timestamp, blob) 
-    #define PAYLOAD_TYPE_ANON_REQ 0x07 // generic request (prefixed with dest_hash, ephemeral pub_key, MAC) (enc data: ...) 
+    #define PAYLOAD_TYPE_ID_REQ 0x07 // generic request (prefixed with dest_hash, ephemeral pub_key, MAC) (enc data: ...)
     #define PAYLOAD_TYPE_PATH 0x08 // returned path (prefixed with dest/src hashes, MAC) (enc data: path, extra)
 
 [Source](https://discord.com/channels/1343693475589263471/1343693475589263474/1350611321040932966)

--- a/docs/packet_structure.md
+++ b/docs/packet_structure.md
@@ -33,13 +33,13 @@ bit 0 means the lowest bit (1s place)
 | Value  | Name                      | Description                                   |
 |--------|---------------------------|-----------------------------------------------|
 | `0x00` | `PAYLOAD_TYPE_REQ`        | Request (destination/source hashes + MAC).    |
-| `0x01` | `PAYLOAD_TYPE_RESPONSE`   | Response to REQ or ANON_REQ.                  |
+| `0x01` | `PAYLOAD_TYPE_RESPONSE`   | Response to REQ or ID_REQ.                    |
 | `0x02` | `PAYLOAD_TYPE_TXT_MSG`    | Plain text message.                           |
 | `0x03` | `PAYLOAD_TYPE_ACK`        | Acknowledgment.                               |
 | `0x04` | `PAYLOAD_TYPE_ADVERT`     | Node advertisement.                           |
 | `0x05` | `PAYLOAD_TYPE_GRP_TXT`    | Group text message (unverified).              |
 | `0x06` | `PAYLOAD_TYPE_GRP_DATA`   | Group datagram (unverified).                  |
-| `0x07` | `PAYLOAD_TYPE_ANON_REQ`   | Anonymous request.                            |
+| `0x07` | `PAYLOAD_TYPE_ID_REQ`     | Request with senders public key.              |
 | `0x08` | `PAYLOAD_TYPE_PATH`       | Returned path.                                |
 | `0x09` | `PAYLOAD_TYPE_TRACE`      | trace a path, collecting SNI for each hop.    |
 | `0x0F` | `PAYLOAD_TYPE_RAW_CUSTOM` | Custom packet (raw bytes, custom encryption). |

--- a/docs/payloads.md
+++ b/docs/payloads.md
@@ -5,9 +5,9 @@ Inside of each [meshcore packet](./packet_structure.md) is a payload, identified
 * Acknowledgment.
 * Returned path.
 * Request (destination/source hashes + MAC).
-* Response to REQ or ANON_REQ.
+* Response to REQ or ID_REQ.
 * Plain text message.
-* Anonymous request.
+* Identified request.
 * Group text message (unverified).
 * Group datagram (unverified).
 * Custom packet (raw bytes, custom encryption).
@@ -152,7 +152,7 @@ Flags
 | `0x01` | CLI command               | the command text of the message                            |
 | `0x02` | signed plain text message | two bytes of sender prefix, followed by plain text message |
 
-# Anonymous request
+# Identified request
 
 | Field            | Size (bytes)    | Description                               |
 |------------------|-----------------|-------------------------------------------|

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -82,7 +82,7 @@
 #define REQ_TYPE_KEEP_ALIVE          0x02
 #define REQ_TYPE_GET_TELEMETRY_DATA  0x03
 
-#define RESP_SERVER_LOGIN_OK      0   // response to ANON_REQ
+#define RESP_SERVER_LOGIN_OK      0   // response to ID_REQ
 
 struct RepeaterStats {
   uint16_t batt_milli_volts;
@@ -341,8 +341,8 @@ protected:
     return ((int)_prefs.agc_reset_interval) * 4000;   // milliseconds
   }
 
-  void onAnonDataRecv(mesh::Packet* packet, uint8_t type, const mesh::Identity& sender, uint8_t* data, size_t len) override {
-    if (type == PAYLOAD_TYPE_ANON_REQ) {  // received an initial request by a possible admin client (unknown at this stage)
+  void onIdDataRecv(mesh::Packet* packet, uint8_t type, const mesh::Identity& sender, uint8_t* data, size_t len) override {
+    if (type == PAYLOAD_TYPE_ID_REQ) {  // received an initial request by a possible admin client (unknown at this stage)
       uint32_t timestamp;
       memcpy(&timestamp, data, 4);
 

--- a/examples/simple_room_server/main.cpp
+++ b/examples/simple_room_server/main.cpp
@@ -131,7 +131,7 @@ struct PostInfo {
 #define REQ_TYPE_KEEP_ALIVE          0x02
 #define REQ_TYPE_GET_TELEMETRY_DATA  0x03
 
-#define RESP_SERVER_LOGIN_OK      0   // response to ANON_REQ
+#define RESP_SERVER_LOGIN_OK      0   // response to ID_REQ
 
 struct ServerStats {
   uint16_t batt_milli_volts;
@@ -432,8 +432,8 @@ protected:
     return true;
   }
 
-  void onAnonDataRecv(mesh::Packet* packet, uint8_t type, const mesh::Identity& sender, uint8_t* data, size_t len) override {
-    if (type == PAYLOAD_TYPE_ANON_REQ) {  // received an initial request by a possible admin client (unknown at this stage)
+  void onIdDataRecv(mesh::Packet* packet, uint8_t type, const mesh::Identity& sender, uint8_t* data, size_t len) override {
+    if (type == PAYLOAD_TYPE_ID_REQ) {  // received an initial request by a possible admin client (unknown at this stage)
       uint32_t sender_timestamp, sender_sync_since;
       memcpy(&sender_timestamp, data, 4);
       memcpy(&sender_sync_since, &data[4], 4);  // sender's "sync messags SINCE x" timestamp

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -107,10 +107,10 @@ protected:
   /**
    * \brief  A (now decrypted) data packet has been received.
    *         NOTE: these can be received multiple times (per sender/contents), via different routes
-   * \param  type  one of: PAYLOAD_TYPE_ANON_REQ
+   * \param  type  one of: PAYLOAD_TYPE_ID_REQ
    * \param  sender  public key provided by sender
   */
-  virtual void onAnonDataRecv(Packet* packet, uint8_t type, const Identity& sender, uint8_t* data, size_t len) { }
+  virtual void onIdDataRecv(Packet* packet, uint8_t type, const Identity& sender, uint8_t* data, size_t len) { }
 
   /**
    * \brief  A path TO 'sender' has been received. (also with optional 'extra' data encoded)
@@ -162,7 +162,7 @@ public:
 
   Packet* createAdvert(const LocalIdentity& id, const uint8_t* app_data=NULL, size_t app_data_len=0);
   Packet* createDatagram(uint8_t type, const Identity& dest, const uint8_t* secret, const uint8_t* data, size_t len);
-  Packet* createAnonDatagram(uint8_t type, const LocalIdentity& sender, const Identity& dest, const uint8_t* secret, const uint8_t* data, size_t data_len);
+  Packet* createIdDatagram(uint8_t type, const LocalIdentity& sender, const Identity& dest, const uint8_t* secret, const uint8_t* data, size_t data_len);
   Packet* createGroupDatagram(uint8_t type, const GroupChannel& channel, const uint8_t* data, size_t data_len);
   Packet* createAck(uint32_t ack_crc);
   Packet* createPathReturn(const uint8_t* dest_hash, const uint8_t* secret, const uint8_t* path, uint8_t path_len, uint8_t extra_type, const uint8_t*extra, size_t extra_len);

--- a/src/Packet.h
+++ b/src/Packet.h
@@ -17,13 +17,13 @@ namespace mesh {
 #define ROUTE_TYPE_TRANSPORT_DIRECT  0x03    // direct route + transport codes
 
 #define PAYLOAD_TYPE_REQ         0x00    // request (prefixed with dest/src hashes, MAC) (enc data: timestamp, blob)
-#define PAYLOAD_TYPE_RESPONSE    0x01    // response to REQ or ANON_REQ (prefixed with dest/src hashes, MAC) (enc data: timestamp, blob)
+#define PAYLOAD_TYPE_RESPONSE    0x01    // response to REQ or ID_REQ (prefixed with dest/src hashes, MAC) (enc data: timestamp, blob)
 #define PAYLOAD_TYPE_TXT_MSG     0x02    // a plain text message (prefixed with dest/src hashes, MAC) (enc data: timestamp, text)
 #define PAYLOAD_TYPE_ACK         0x03    // a simple ack
 #define PAYLOAD_TYPE_ADVERT      0x04    // a node advertising its Identity
 #define PAYLOAD_TYPE_GRP_TXT     0x05    // an (unverified) group text message (prefixed with channel hash, MAC) (enc data: timestamp, "name: msg")
 #define PAYLOAD_TYPE_GRP_DATA    0x06    // an (unverified) group datagram (prefixed with channel hash, MAC) (enc data: timestamp, blob)
-#define PAYLOAD_TYPE_ANON_REQ    0x07    // generic request (prefixed with dest_hash, ephemeral pub_key, MAC) (enc data: ...)
+#define PAYLOAD_TYPE_ID_REQ      0x07    // generic request (prefixed with dest_hash, ephemeral pub_key, MAC) (enc data: ...)
 #define PAYLOAD_TYPE_PATH        0x08    // returned path (prefixed with dest/src hashes, MAC) (enc data: path, extra)
 #define PAYLOAD_TYPE_TRACE       0x09    // trace a path, collecting SNI for each hop
 //...

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -418,7 +418,7 @@ int BaseChatMesh::sendLogin(const ContactInfo& recipient, const char* password, 
     tlen = 4 + len;
   }
 
-  auto pkt = createAnonDatagram(PAYLOAD_TYPE_ANON_REQ, self_id, recipient.id, recipient.shared_secret, temp, tlen);
+  auto pkt = createIdDatagram(PAYLOAD_TYPE_ID_REQ, self_id, recipient.id, recipient.shared_secret, temp, tlen);
   if (pkt) {
     uint32_t t = _radio->getEstAirtimeFor(pkt->getRawLength());
     if (recipient.out_path_len < 0) {

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -18,7 +18,7 @@
 #define REQ_TYPE_GET_STATUS      0x01   // same as _GET_STATS
 #define REQ_TYPE_KEEP_ALIVE      0x02
 
-#define RESP_SERVER_LOGIN_OK      0   // response to ANON_REQ
+#define RESP_SERVER_LOGIN_OK      0   // response to ID_REQ
 
 class ContactVisitor {
 public:


### PR DESCRIPTION
Renames PAYLOAD_TYPE_ANON_REQ to PAYLOAD_TYPE_ID_REQ for clarity.

The current name is misleading, as the payload includes the sender’s public key, making it not anonymous. This change makes the naming more accurate and avoids confusion for new contributors.

Reference: [#457](https://github.com/ripplebiz/MeshCore/issues/457)