### PR TITLE
Don't show CLI replies on display

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -315,23 +315,20 @@ void MyMesh::queueMessage(const ContactInfo &from, uint8_t txt_type, mesh::Packe
   i += tlen;
   addToOfflineQueue(out_frame, i);
 
-  // we only want to show text messages on display, not cli data
-  bool should_display = txt_type == TXT_TYPE_PLAIN || txt_type == TXT_TYPE_SIGNED_PLAIN;
-
   if (_serial->isConnected()) {
     uint8_t frame[1];
     frame[0] = PUSH_CODE_MSG_WAITING; // send push 'tickle'
     _serial->writeFrame(frame, 1);
-  } else {
+  }
+
 #ifdef DISPLAY_CLASS
-    if(should_display){
+  // we only want to show text messages on display, not cli data
+  bool should_display = txt_type == TXT_TYPE_PLAIN || txt_type == TXT_TYPE_SIGNED_PLAIN;
+  if (should_display) {
+    ui_task.newMsg(path_len, from.name, text, offline_queue_len);
+    if (!_serial->isConnected()) {
       ui_task.soundBuzzer(UIEventType::contactMessage);
     }
-#endif
-  }
-#ifdef DISPLAY_CLASS
-  if(should_display){
-    ui_task.newMsg(path_len, from.name, text, offline_queue_len);
   }
 #endif
 }

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -315,17 +315,24 @@ void MyMesh::queueMessage(const ContactInfo &from, uint8_t txt_type, mesh::Packe
   i += tlen;
   addToOfflineQueue(out_frame, i);
 
+  // we only want to show text messages on display, not cli data
+  bool should_display = txt_type == TXT_TYPE_PLAIN || txt_type == TXT_TYPE_SIGNED_PLAIN;
+
   if (_serial->isConnected()) {
     uint8_t frame[1];
     frame[0] = PUSH_CODE_MSG_WAITING; // send push 'tickle'
     _serial->writeFrame(frame, 1);
   } else {
 #ifdef DISPLAY_CLASS
-    ui_task.soundBuzzer(UIEventType::contactMessage);
+    if(should_display){
+      ui_task.soundBuzzer(UIEventType::contactMessage);
+    }
 #endif
   }
 #ifdef DISPLAY_CLASS
-  ui_task.newMsg(path_len, from.name, text, offline_queue_len);
+  if(should_display){
+    ui_task.newMsg(path_len, from.name, text, offline_queue_len);
+  }
 #endif
 }
 


### PR DESCRIPTION
Currently, when sending a CLI command to a repeater, the response is shown on the display for a brief moment before disappearing. This PR adjusts the companion display logic so it only shows `TXT_TYPE_PLAIN` or `TXT_TYPE_SIGNED_PLAIN` messages.

