### PR TITLE
Xiao ESP32 C3 updates

### DIFF
--- a/variants/xiao_c3/platformio.ini
+++ b/variants/xiao_c3/platformio.ini
@@ -5,6 +5,28 @@ build_flags =
   ${esp32_base.build_flags}
   -I variants/xiao_c3
   -D ESP32_CPU_FREQ=80
+  ; -D LORA_TX_BOOST_PIN=D3
+  ; -D P_LORA_TX_LED=D5
+  -D PIN_VBAT_READ=D0
+  -D P_LORA_DIO_1=D1
+  -D P_LORA_NSS=D4
+  -D P_LORA_RESET=RADIOLIB_NC
+  -D P_LORA_BUSY=D3
+  -D PIN_BOARD_SDA=D6
+  -D PIN_BOARD_SCL=D7
+  -D SX126X_DIO2_AS_RF_SWITCH=true
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
+  -D SX126X_CURRENT_LIMIT=140
+build_src_filter = ${esp32_base.build_src_filter}
+  +<../variants/xiao_c3>
+
+[Xiao_esp32_C3_custom]
+extends = esp32_base
+board = seeed_xiao_esp32c3
+build_flags =
+  ${esp32_base.build_flags}
+  -I variants/xiao_c3
+  -D ESP32_CPU_FREQ=80
   -D LORA_TX_BOOST_PIN=D3
   -D P_LORA_TX_LED=D5
   -D PIN_VBAT_READ=D0
@@ -43,6 +65,70 @@ lib_deps =
 
 [env:Xiao_C3_Repeater_sx1268]
 extends = Xiao_esp32_C3
+build_src_filter = ${Xiao_esp32_C3.build_src_filter}
+  +<../examples/simple_repeater/main.cpp>
+build_flags =
+  ${Xiao_esp32_C3.build_flags}
+  -D RADIO_CLASS=CustomSX1268
+  -D WRAPPER_CLASS=CustomSX1268Wrapper
+  -D LORA_TX_POWER=22
+  -D ADVERT_NAME='"Xiao Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=8
+ ; -D MESH_PACKET_LOGGING=1
+ ; -D MESH_DEBUG=1
+lib_deps =
+  ${Xiao_esp32_C3.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:Xiao_C3_sx1262_companion_radio_ble]
+extends = Xiao_esp32_C3
+build_src_filter = ${Xiao_esp32_C3.build_src_filter}
+  +<../examples/companion_radio>
+  +<helpers/esp32/*.cpp>
+build_flags =
+  ${Xiao_esp32_C3.build_flags}
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D SX126X_RX_BOOSTED_GAIN=1
+  -D LORA_TX_POWER=22
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=8
+  -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+  ; -D BLE_DEBUG_LOGGING=1
+  ; -D MESH_PACKET_LOGGING=1
+  ; -D MESH_DEBUG=1
+lib_deps =
+  ${Xiao_esp32_C3.lib_deps}
+  ${esp32_ota.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:Xiao_C3_Repeater_sx1262_custom]
+extends = Xiao_esp32_C3_custom
+build_src_filter = ${Xiao_esp32_C3.build_src_filter}
+  +<../examples/simple_repeater/main.cpp>
+build_flags =
+  ${Xiao_esp32_C3.build_flags}
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D SX126X_RX_BOOSTED_GAIN=1
+  -D LORA_TX_POWER=22
+  -D ADVERT_NAME='"Xiao Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=8
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+lib_deps =
+  ${Xiao_esp32_C3.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:Xiao_C3_Repeater_sx1268_custom]
+extends = Xiao_esp32_C3_custom
 build_src_filter = ${Xiao_esp32_C3.build_src_filter}
   +<../examples/simple_repeater/main.cpp>
 build_flags =


### PR DESCRIPTION
* Fixed pin-out for mainstream wio sx1262 module (v1.0)
* Moved previous wio sx1262 support to _custom version as this board seems to only be sold in combination with the esp32-s3.
* Added a companion firmware for the C3 with mainstream wio sx1262