### PR TITLE
Refactor nRF52 BLE to use connection callbacks

### DIFF
--- a/src/helpers/nrf52/SerialBLEInterface.h
+++ b/src/helpers/nrf52/SerialBLEInterface.h
@@ -5,10 +5,8 @@
 
 class SerialBLEInterface : public BaseSerialInterface {
   BLEUart bleuart;
-  bool deviceConnected;
-  bool oldDeviceConnected;
-  bool checkAdvRestart;
   bool _isEnabled;
+  bool _isDeviceConnected;
   unsigned long _last_write;
 
   struct Frame {
@@ -21,18 +19,19 @@ class SerialBLEInterface : public BaseSerialInterface {
   Frame send_queue[FRAME_QUEUE_SIZE];
 
   void clearBuffers() { send_queue_len = 0; }
-  void startAdv();
+  static void onConnect(uint16_t connection_handle);
+  static void onDisconnect(uint16_t connection_handle, uint8_t reason);
 
 public:
   SerialBLEInterface() {
-    deviceConnected = false;
-    oldDeviceConnected = false;
-    checkAdvRestart = false;
     _isEnabled = false;
+    _isDeviceConnected = false;
     _last_write = 0;
     send_queue_len = 0;
   }
 
+  void startAdv();
+  void stopAdv();
   void begin(const char* device_name, uint32_t pin_code);
 
   // BaseSerialInterface methods


### PR DESCRIPTION
Currently, when going in and out of range of a companion device, sometimes bluetooth will not start advertising again.

After a bit of debugging, it was noted that although we are calling `startAdv`, which calls`Bluefruit.Advertising.start(0)`, it was actually failing due to the internal BLE stack not quite being ready to advertise again.

This PR reworks the `SerialBLEInterface` on nRF52 devices to use the Bluefruit library callbacks, to start advertising when a disconnect callback is received. Advertising after a disconnect seems to be very reliable now, and I haven't seen any failures after a disconnect.

I've tested on the following devices:

- RAK4631
- T1000-E
- ThinkNode M1

The esp32 implementation of `SerialBLEInterface` has been left as is, but if this one is having similar issues I can look at reworking that as well...

