### PR TITLE
xiao_c3: small fixups

### DIFF
--- a/variants/xiao_c3/platformio.ini
+++ b/variants/xiao_c3/platformio.ini
@@ -5,15 +5,14 @@ build_flags =
   ${esp32_base.build_flags}
   -I variants/xiao_c3
   -D ESP32_CPU_FREQ=80
-  ; -D LORA_TX_BOOST_PIN=D3
-  ; -D P_LORA_TX_LED=D5
   -D PIN_VBAT_READ=D0
   -D P_LORA_DIO_1=D1
   -D P_LORA_NSS=D4
-  -D P_LORA_RESET=RADIOLIB_NC
+  -D P_LORA_RESET=D2
   -D P_LORA_BUSY=D3
   -D PIN_BOARD_SDA=D6
   -D PIN_BOARD_SCL=D7
+  -D SX126X_RXEN=D5
   -D SX126X_DIO2_AS_RF_SWITCH=true
   -D SX126X_DIO3_TCXO_VOLTAGE=1.8
   -D SX126X_CURRENT_LIMIT=140
@@ -52,7 +51,7 @@ build_flags =
   -D WRAPPER_CLASS=CustomSX1262Wrapper
   -D SX126X_RX_BOOSTED_GAIN=1
   -D LORA_TX_POWER=22
-  -D ADVERT_NAME='"Xiao Repeater"'
+  -D ADVERT_NAME='"Xiao C3 Repeater"'
   -D ADVERT_LAT=0.0
   -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'
@@ -63,27 +62,7 @@ lib_deps =
   ${Xiao_esp32_C3.lib_deps}
   ${esp32_ota.lib_deps}
 
-[env:Xiao_C3_Repeater_sx1268]
-extends = Xiao_esp32_C3
-build_src_filter = ${Xiao_esp32_C3.build_src_filter}
-  +<../examples/simple_repeater/main.cpp>
-build_flags =
-  ${Xiao_esp32_C3.build_flags}
-  -D RADIO_CLASS=CustomSX1268
-  -D WRAPPER_CLASS=CustomSX1268Wrapper
-  -D LORA_TX_POWER=22
-  -D ADVERT_NAME='"Xiao Repeater"'
-  -D ADVERT_LAT=0.0
-  -D ADVERT_LON=0.0
-  -D ADMIN_PASSWORD='"password"'
-  -D MAX_NEIGHBOURS=8
- ; -D MESH_PACKET_LOGGING=1
- ; -D MESH_DEBUG=1
-lib_deps =
-  ${Xiao_esp32_C3.lib_deps}
-  ${esp32_ota.lib_deps}
-
-[env:Xiao_C3_sx1262_companion_radio_ble]
+[env:Xiao_C3_companion_radio_ble]
 extends = Xiao_esp32_C3
 build_src_filter = ${Xiao_esp32_C3.build_src_filter}
   +<../examples/companion_radio>
@@ -97,6 +76,28 @@ build_flags =
   -D MAX_CONTACTS=100
   -D MAX_GROUP_CHANNELS=8
   -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+  ; -D BLE_DEBUG_LOGGING=1
+  ; -D MESH_PACKET_LOGGING=1
+  ; -D MESH_DEBUG=1
+lib_deps =
+  ${Xiao_esp32_C3.lib_deps}
+  ${esp32_ota.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:Xiao_C3_companion_radio_usb]
+extends = Xiao_esp32_C3
+build_src_filter = ${Xiao_esp32_C3.build_src_filter}
+  +<../examples/companion_radio>
+  +<helpers/esp32/*.cpp>
+build_flags =
+  ${Xiao_esp32_C3.build_flags}
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D SX126X_RX_BOOSTED_GAIN=1
+  -D LORA_TX_POWER=22
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=8
   -D OFFLINE_QUEUE_SIZE=256
   ; -D BLE_DEBUG_LOGGING=1
   ; -D MESH_PACKET_LOGGING=1


### PR DESCRIPTION
As the refactoring for xiao_c3 been included in dev, here are some small fixups in a new PR

* wired RESET and RXEN
* removed repeater_sx1268 (as there is no wio board with this chip)
* renamed companion_radio_ble target to match names for other xiao variant
* added a companion_radio_usb

Overall this was a good job @jrkalf !