### PR TITLE
Buzzer  disable when quiet

### DIFF
--- a/src/helpers/ui/buzzer.cpp
+++ b/src/helpers/ui/buzzer.cpp
@@ -46,6 +46,13 @@ void genericBuzzer::shutdown() {
 
 void genericBuzzer::quiet(bool buzzer_state) {
     _is_quiet = buzzer_state;
+#ifdef PIN_BUZZER_EN
+    if (_is_quiet) {
+      digitalWrite(PIN_BUZZER_EN, LOW);
+    } else {
+      digitalWrite(PIN_BUZZER_EN, HIGH);
+    }
+#endif
 }
 
 bool genericBuzzer::isQuiet() {


### PR DESCRIPTION
ATM the buzzer pin stays HIGH even if not used.

As a first step, to assess power draw (on the t1000), let's drive it to low when buzzer is quiet.

As calls are asynchronous, it would need some polling to drive it to LOW when music finishes