### PR TITLE
Changed the Barometric Pressure value for the BME280 sensor since it was a factor 100 to high

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -154,7 +154,7 @@ bool EnvironmentSensorManager::querySensors(uint8_t requester_permissions, Cayen
     if (BME280_initialized) {
       telemetry.addTemperature(TELEM_CHANNEL_SELF, BME280.readTemperature());
       telemetry.addRelativeHumidity(TELEM_CHANNEL_SELF, BME280.readHumidity());
-      telemetry.addBarometricPressure(TELEM_CHANNEL_SELF, BME280.readPressure());
+      telemetry.addBarometricPressure(TELEM_CHANNEL_SELF, BME280.readPressure()/100);
       telemetry.addAltitude(TELEM_CHANNEL_SELF, BME280.readAltitude(TELEM_BME280_SEALEVELPRESSURE_HPA));
     }
     #endif


### PR DESCRIPTION
The BME280.readPressure function returns a Pa value, while the telemetry object should get a hPa value assigned.
This resulted in a very high reading in the MeshCore app. I have tested the change with a Heltec V3 in combination with repeater firmware. Reading is now correct.