### PR TITLE
add GPS UI alert to quad-press

### DIFF
--- a/examples/companion_radio/UITask.cpp
+++ b/examples/companion_radio/UITask.cpp
@@ -408,8 +408,12 @@ void UITask::handleButtonQuadruplePress() {
       if (strcmp(_sensors->getSettingName(i), "gps") == 0) {
         if (strcmp(_sensors->getSettingValue(i), "1") == 0) {
           _sensors->setSettingValue("gps", "0");
+          soundBuzzer(UIEventType::ack);
+          sprintf(_alert, "GPS: Disabled");
         } else {
           _sensors->setSettingValue("gps", "1");
+          soundBuzzer(UIEventType::ack);
+          sprintf(_alert, "GPS: Enabled");
         }
         break;
       }


### PR DESCRIPTION
This PR adds a UI alert when doing a quadruple press to bring it into line with the triple press behaviour for buzzer on/off.

Devices which have a GPS will pop up an alert on the display that says GPS: Enabled / GPS: Disabled and will also make the ack sound with the buzzer if available.

Tested on Seeed Wio Tracker L1, and also on a Faketec without GPS or Buzzer to confirm no issues when these aren't available.