### PR TITLE
fix: Wio Tracker L1: add DIO2 as rfSwitch and correct TCXO voltage.

### DIFF
--- a/variants/wio-tracker-l1/variant.h
+++ b/variants/wio-tracker-l1/variant.h
@@ -70,6 +70,8 @@
 #define  P_LORA_NSS             (4)
 #define  SX126X_RXEN            (5)
 #define  SX126X_TXEN            RADIOLIB_NC
+#define  SX126X_DIO2_AS_RF_SWITCH true
+#define  SX126X_DIO3_TCXO_VOLTAGE (1.8f)
 
 // Wire Interfaces
 #define WIRE_INTERFACES_COUNT   (2)


### PR DESCRIPTION
These accidentally got left out of the initial commit for Wio Tracker L1. Oops.