### PR TITLE
Allow the SDA and SCL pins for Environment sensors to be configured independently of the OLED I2C

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.h
+++ b/src/helpers/sensors/EnvironmentSensorManager.h
@@ -16,6 +16,7 @@ protected:
   bool SHTC3_initialized = false;
   bool LPS22HB_initialized = false;
   bool MLX90614_initialized = false;
+  bool VL53L0X_initialized = false;
 
   bool gps_detected = false;
   bool gps_active = false;

--- a/src/helpers/sensors/EnvironmentSensorManager.h
+++ b/src/helpers/sensors/EnvironmentSensorManager.h
@@ -15,6 +15,7 @@ protected:
   bool INA219_initialized = false;
   bool SHTC3_initialized = false;
   bool LPS22HB_initialized = false;
+  bool MLX90614_initialized = false;
 
   bool gps_detected = false;
   bool gps_active = false;

--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -147,6 +147,26 @@ lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
+[env:Heltec_v3_sensor]
+extends = Heltec_lora32_v3
+build_flags =
+  ${Heltec_lora32_v3.build_flags}
+  -D ADVERT_NAME='"Heltec v3 Sensor"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ENV_PIN_SDA=33
+  -D ENV_PIN_SCL=34
+  -D DISPLAY_CLASS=SSD1306Display
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_lora32_v3.build_src_filter}
+  +<helpers/ui/SSD1306Display.cpp>
+  +<../examples/simple_sensor>
+lib_deps =
+  ${Heltec_lora32_v3.lib_deps}
+  ${esp32_ota.lib_deps}
+
 [env:Heltec_WSL3_repeater]
 extends = Heltec_lora32_v3
 build_flags =
@@ -214,4 +234,3 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   ${esp32_ota.lib_deps}
-

--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -157,6 +157,7 @@ build_flags =
   -D ADMIN_PASSWORD='"password"'
   -D ENV_PIN_SDA=33
   -D ENV_PIN_SCL=34
+  -D ENV_INCLUDE_MLX90614=1
   -D DISPLAY_CLASS=SSD1306Display
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
@@ -166,6 +167,7 @@ build_src_filter = ${Heltec_lora32_v3.build_src_filter}
 lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   ${esp32_ota.lib_deps}
+  adafruit/Adafruit MLX90614 Library @ ^2.1.5
 
 [env:Heltec_WSL3_repeater]
 extends = Heltec_lora32_v3

--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -158,6 +158,7 @@ build_flags =
   -D ENV_PIN_SDA=33
   -D ENV_PIN_SCL=34
   -D ENV_INCLUDE_MLX90614=1
+  -D ENV_INCLUDE_VL53L0X=1
   -D DISPLAY_CLASS=SSD1306Display
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
@@ -168,6 +169,7 @@ lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   ${esp32_ota.lib_deps}
   adafruit/Adafruit MLX90614 Library @ ^2.1.5
+  adafruit/Adafruit_VL53L0X @ ^1.2.4
 
 [env:Heltec_WSL3_repeater]
 extends = Heltec_lora32_v3


### PR DESCRIPTION
I'm not sure if there's interest in this but, I wanted more convenient I2C pins for environment sensors on the Heltec V3, without sacrificing the OLED display.

So I picked these two unused pins:
<img width="1210" height="852" alt="Heltec V3 Sensor" src="https://github.com/user-attachments/assets/a78aee0f-a7f4-46e8-a21a-07aea6fb651f" />

And added two new build flags
```
  -D ENV_PIN_SDA=33
  -D ENV_PIN_SCL=34
```
Totally happy to renaming these to match any conventions if there's interest in merging this.