### PR TITLE
RAK4631: Add BME680 and RAK18001 Buzzer

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.h
+++ b/src/helpers/sensors/EnvironmentSensorManager.h
@@ -4,6 +4,10 @@
 #include <helpers/SensorManager.h>
 #include <helpers/sensors/LocationProvider.h>
 
+#ifdef ENV_INCLUDE_BME680
+#include <bsec2.h>
+#endif
+
 class EnvironmentSensorManager : public SensorManager {
 protected:
   int next_available_channel = TELEM_CHANNEL_SELF + 1;
@@ -11,6 +15,7 @@ protected:
   bool AHTX0_initialized = false;
   bool BME280_initialized = false;
   bool BMP280_initialized = false;
+  bool BME680_initialized = false;
   bool INA3221_initialized = false;
   bool INA219_initialized = false;
   bool SHTC3_initialized = false;
@@ -32,6 +37,10 @@ protected:
   #endif
   #endif
 
+  #if ENV_INCLUDE_BME680
+  static void checkBMEStatus(Bsec2 bsec);
+  static void newDataCallback(const bme68xData data, const bsecOutputs outputs, Bsec2 bsec);
+  #endif
 
 public:
   #if ENV_INCLUDE_GPS
@@ -41,7 +50,7 @@ public:
   #endif
   bool begin() override;
   bool querySensors(uint8_t requester_permissions, CayenneLPP& telemetry) override;
-  #if ENV_INCLUDE_GPS
+  #if ENV_INCLUDE_GPS || ENV_INCLUDE_BME680
   void loop() override;
   #endif
   int getNumSettings() const override;

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -18,13 +18,16 @@ build_flags = ${nrf52_base.build_flags}
   -D LORA_TX_POWER=22
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
+  -D PIN_BUZZER=WB_IO5 ;for socket D on RAK19007 and RAK19003
   -D ENV_INCLUDE_GPS=1
   -D ENV_INCLUDE_SHTC3=1
   -D ENV_INCLUDE_LPS22HB=1
   -D ENV_INCLUDE_INA219=1
+  -D ENV_INCLUDE_BME680=1
 build_src_filter = ${nrf52_base.build_src_filter}
   +<../variants/rak4631>
   +<helpers/sensors> 
+  +<helpers/ui/buzzer.cpp>
 lib_deps =
   ${nrf52_base.lib_deps}
   adafruit/Adafruit SSD1306 @ ^2.5.13
@@ -33,6 +36,9 @@ lib_deps =
   arduino-libraries/Arduino_LPS22HB@^1.0.2
   adafruit/Adafruit INA219@^1.2.3
   sparkfun/SparkFun u-blox GNSS Arduino Library@^2.2.27
+  https://github.com/boschsensortec/Bosch-BSEC2-Library
+  https://github.com/boschsensortec/Bosch-BME68x-Library
+  end2endzone/NonBlockingRTTTL@^1.3.0
 
 [env:RAK_4631_Repeater]
 extends = rak4631


### PR DESCRIPTION
Large add to ESM for the BME680. Confirmed working on all RAK sockets. Non-RAK boards untested. 
-Temp, Humidity, and Pressure are sent to Channel 1 in Liam's app. 
-IAQ and CO2 are sent to Channel 2 as Generic Sensor and Concentration

RAK18001 buzzer added for use on Socket D on both the 19007 and 19003. Verified working with startup sound as well as message received.