### PR TITLE
Disable LED lights on t-echo device

### DIFF
--- a/variants/techo/variant.h
+++ b/variants/techo/variant.h
@@ -61,9 +61,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Builtin LEDs
 
-#define LED_RED                 (34)
-#define LED_GREEN               (33)
-#define LED_BLUE                (14)
+#define LED_RED                 (-1)
+#define LED_GREEN               (-1)
+#define LED_BLUE                (-1)
 
 #define PIN_STATUS_LED          LED_GREEN
 #define LED_BUILTIN             LED_GREEN


### PR DESCRIPTION
Sorry for the less-than-ideal change in the code, but is it possible to disable the LED lights on the T-Echo device for now, until someone adds an option in the UI to disable them?
They unnecessarily drain the battery, especially since the device cannot enter deep sleep by user control for now.

I hope there will be plenty of users who don’t like a device flashing like a Christmas tree. 

Edit: sorry for Unverified commit, I used accidentally old one of my ssh keys ...