### PR TITLE
Added support for TI INA260

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.h
+++ b/src/helpers/sensors/EnvironmentSensorManager.h
@@ -13,6 +13,7 @@ protected:
   bool BMP280_initialized = false;
   bool INA3221_initialized = false;
   bool INA219_initialized = false;
+  bool INA260_initialized = false;
   bool SHTC3_initialized = false;
   bool LPS22HB_initialized = false;
   bool MLX90614_initialized = false;

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -26,6 +26,7 @@ build_flags = ${nrf52_base.build_flags}
   -D ENV_INCLUDE_LPS22HB=1
   -D ENV_INCLUDE_INA3221=1
   -D ENV_INCLUDE_INA219=1
+  -D ENV_INCLUDE_INA260=1
 build_src_filter = ${nrf52_base.build_src_filter}
   +<../variants/rak4631>
   +<helpers/sensors>
@@ -40,6 +41,7 @@ lib_deps =
   adafruit/Adafruit BME280 Library @ ^2.3.0
   adafruit/Adafruit BMP280 Library @ ^2.6.8
   adafruit/Adafruit SHTC3 Library @ ^1.0.1
+  adafruit/Adafruit INA260 Library @ ^1.5.3
   sparkfun/SparkFun u-blox GNSS Arduino Library@^2.2.27
 
 [env:RAK_4631_Repeater]


### PR DESCRIPTION
A support for Texas Instruments INA260 voltage/current/power monitor. The address is 0x41 to work seamlessly with uART LTO battery BMS (https://github.com/slintak/lto-bms). Support is only for RAK4630/RAK4631, where these batteries are used to most.

Known issue: the power telemetry value shows 0W, because the datatype for power is uint32_t as defined in CayenneLPP v.1.4.0. Fix would have to be made in the CayenneLPP library and issue has been raised: https://github.com/ElectronicCats/CayenneLPP/issues/58

<img width="375" height="667" alt="signal-2025-07-27-163540" src="https://github.com/user-attachments/assets/babb8aca-3c59-4d3a-80c4-772109fed8d8" />
