### PR TITLE
WioTracker L1 various fixes

### DIFF
--- a/boards/seeed-wio-tracker-l1.json
+++ b/boards/seeed-wio-tracker-l1.json
@@ -40,8 +40,8 @@
   ],
   "name": "Seeed Wio Tracker L1",
   "upload": {
-    "maximum_ram_size": 248832,
-    "maximum_size": 815104,
+    "maximum_ram_size": 237568,
+    "maximum_size": 811008,
     "protocol": "nrfutil",
     "speed": 115200,
     "protocols": [

--- a/variants/wio-tracker-l1/variant.h
+++ b/variants/wio-tracker-l1/variant.h
@@ -91,12 +91,12 @@
 #define PIN_GPS_EN              (18)
 
 // QSPI Pins
-#define PIN_QSPI_SCK            (21)
-#define PIN_QSPI_CS             (22)
-#define PIN_QSPI_IO0            (23)
-#define PIN_QSPI_IO1            (24)
-#define PIN_QSPI_IO2            (25)
-#define PIN_QSPI_IO3            (26)
+#define PIN_QSPI_SCK            (19)
+#define PIN_QSPI_CS             (20)
+#define PIN_QSPI_IO0            (21)
+#define PIN_QSPI_IO1            (22)
+#define PIN_QSPI_IO2            (23)
+#define PIN_QSPI_IO3            (24)
 
 #define EXTERNAL_FLASH_DEVICES P25Q16H
 #define EXTERNAL_FLASH_USE_QSPI


### PR DESCRIPTION
Wio Tracker L1 board.json had the wrong maximum flash and ram sizes for SoftDevice S140 v7.3.0