### PR TITLE
esp32c6: pin the pioarduino version to last working one

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -67,7 +67,7 @@ lib_deps =
 ; esp32c6 uses arduino framework 3.x
 [esp32c6_base]
 extends = esp32_base
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/54.03.21/platform-espressif32.zip
 
 ; ----------------- NRF52 ---------------------
 


### PR DESCRIPTION
`stable` always points to newest version, and the few latest ones are broken.