### PR TITLE
Ikoka Stick: Adding variant support for different Ebyte S22 modules

### DIFF
--- a/variants/ikoka_stick_nrf/ikoka_stick_nrf_board.h
+++ b/variants/ikoka_stick_nrf/ikoka_stick_nrf_board.h
@@ -5,20 +5,6 @@
 
 #ifdef XIAO_NRF52
 
-// redefine lora pins if using the S3 variant of SX1262 board
-#ifdef SX1262_XIAO_S3_VARIANT
-  #undef P_LORA_DIO_1
-  #undef P_LORA_BUSY
-  #undef P_LORA_RESET
-  #undef P_LORA_NSS
-  #undef SX126X_RXEN
-  #define  P_LORA_DIO_1       D0
-  #define  P_LORA_BUSY        D1
-  #define  P_LORA_RESET       D2
-  #define  P_LORA_NSS         D3
-  #define  SX126X_RXEN        D4
-#endif
-
 class ikoka_stick_nrf_board : public mesh::MainBoard {
 protected:
   uint8_t startup_reason;
@@ -29,10 +15,10 @@ public:
 
 #if defined(P_LORA_TX_LED)
   void onBeforeTransmit() override {
-    digitalWrite(P_LORA_TX_LED, HIGH);   // turn TX LED on
+    digitalWrite(P_LORA_TX_LED, LOW);   // turn TX LED on
   }
   void onAfterTransmit() override {
-    digitalWrite(P_LORA_TX_LED, LOW);   // turn TX LED off
+    digitalWrite(P_LORA_TX_LED, HIGH);   // turn TX LED off
   }
 #endif
 

--- a/variants/ikoka_stick_nrf/platformio.ini
+++ b/variants/ikoka_stick_nrf/platformio.ini
@@ -19,11 +19,10 @@ lib_deps =
   adafruit/Adafruit INA3221 Library @ ^1.0.1
   adafruit/Adafruit INA219 @ ^1.2.3
   adafruit/Adafruit AHTX0 @ ^2.0.5
-  adafruit/Adafruit BME280 Library @ ^2.3.0  
+  adafruit/Adafruit BME280 Library @ ^2.3.0
   adafruit/Adafruit SSD1306 @ ^2.5.13
 
-
-[ikoka_stick_nrf]
+[ikoka_stick_nrf_baseboard]
 extends = nrf52840_xiao
 ;board_build.ldscript = boards/nrf52840_s140_v7.ld
 build_flags = ${nrf52840_xiao.build_flags}
@@ -34,7 +33,6 @@ build_flags = ${nrf52840_xiao.build_flags}
   -D DISPLAY_ROTATION=2
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper
-  -D LORA_TX_POWER=9
   -D P_LORA_DIO_1=D1
   -D P_LORA_RESET=D2
   -D P_LORA_BUSY=D3
@@ -52,19 +50,59 @@ build_flags = ${nrf52840_xiao.build_flags}
   -D ENV_INCLUDE_BME280=1
   -D ENV_INCLUDE_INA3221=1
   -D ENV_INCLUDE_INA219=1
+debug_tool = jlink
+upload_protocol = nrfutil
+
+
+;;; abstracted hardware variants
+
+[ikoka_stick_nrf_e22_22dbm]
+extends = ikoka_stick_nrf_baseboard
+; No PA in this model, full 22dBm
+build_flags =
+  ${ikoka_stick_nrf_baseboard.build_flags}
+  -D LORA_TX_POWER=22
 build_src_filter = ${nrf52840_xiao.build_src_filter}
   +<helpers/*.cpp>
   +<helpers/sensors>
   +<helpers/ui/MomentaryButton.cpp>
   +<helpers/ui/SSD1306Display.cpp>
   +<../variants/ikoka_stick_nrf>
-debug_tool = jlink
-upload_protocol = nrfutil
 
-[env:ikoka_stick_nrf_companion_radio_ble]
-extends = ikoka_stick_nrf
+[ikoka_stick_nrf_e22_30dbm]
+extends = ikoka_stick_nrf_baseboard
+; limit txpower to 20dBm on E22-900M30S. Anything higher will
+; cause distortion in the PA output. 20dBm in -> 30dBm out
 build_flags =
-  ${ikoka_stick_nrf.build_flags}
+  ${ikoka_stick_nrf_baseboard.build_flags}
+  -D LORA_TX_POWER=20
+build_src_filter = ${nrf52840_xiao.build_src_filter}
+  +<helpers/*.cpp>
+  +<helpers/sensors>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
+  +<../variants/ikoka_stick_nrf>
+
+[ikoka_stick_nrf_e22_33dbm]
+extends = ikoka_stick_nrf_baseboard
+; limit txpower to 9dBm on E22-900M33S to avoid hardware damage
+; to the rf amplifier frontend. 9dBm in -> 33dBm out
+build_flags =
+  ${ikoka_stick_nrf_baseboard.build_flags}
+  -D LORA_TX_POWER=9
+build_src_filter = ${nrf52840_xiao.build_src_filter}
+  +<helpers/*.cpp>
+  +<helpers/sensors>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
+  +<../variants/ikoka_stick_nrf>
+
+;;; abstracted firmware roles
+
+[ikoka_stick_nrf_companion_radio_ble]
+extends = ikoka_stick_nrf_baseboard
+build_flags =
+  ${ikoka_stick_nrf_baseboard.build_flags}
   -D MAX_CONTACTS=100
   -D MAX_GROUP_CHANNELS=8
   -D BLE_PIN_CODE=123456
@@ -73,35 +111,35 @@ build_flags =
 ;  -D BLE_DEBUG_LOGGING=1
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
-build_src_filter = ${ikoka_stick_nrf.build_src_filter}
+build_src_filter = ${ikoka_stick_nrf_baseboard.build_src_filter}
   +<helpers/nrf52/SerialBLEInterface.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
-  ${ikoka_stick_nrf.lib_deps}
+  ${ikoka_stick_nrf_baseboard.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
-[env:ikoka_stick_nrf_companion_radio_usb]
-extends = ikoka_stick_nrf
+[ikoka_stick_nrf_companion_radio_usb]
+extends = ikoka_stick_nrf_baseboard
 build_flags =
-  ${ikoka_stick_nrf.build_flags}
+  ${ikoka_stick_nrf_baseboard.build_flags}
   -D MAX_CONTACTS=100
   -D MAX_GROUP_CHANNELS=8
   -I examples/companion_radio/ui-new
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
-build_src_filter = ${ikoka_stick_nrf.build_src_filter}
+build_src_filter = ${ikoka_stick_nrf_baseboard.build_src_filter}
   +<helpers/nrf52/SerialBLEInterface.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
-  ${ikoka_stick_nrf.lib_deps}
+  ${ikoka_stick_nrf_baseboard.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
-[env:ikoka_stick_nrf_repeater]
-extends = ikoka_stick_nrf
+[ikoka_stick_nrf_repeater]
+extends = ikoka_stick_nrf_baseboard
 build_flags =
-  ${ikoka_stick_nrf.build_flags}
+  ${ikoka_stick_nrf_baseboard.build_flags}
   -D ADVERT_NAME='"Ikoka Stick Repeater"'
   -D ADVERT_LAT=0.0
   -D ADVERT_LON=0.0
@@ -109,19 +147,161 @@ build_flags =
   -D MAX_NEIGHBOURS=8
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
-build_src_filter = ${ikoka_stick_nrf.build_src_filter}
+build_src_filter = ${ikoka_stick_nrf_baseboard.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_repeater/*.cpp>
 
-[env:ikoka_stick_nrf_room_server]
-extends = ikoka_stick_nrf
+[ikoka_stick_nrf_room_server]
+extends = ikoka_stick_nrf_baseboard
 build_flags =
-  ${ikoka_stick_nrf.build_flags}
+  ${ikoka_stick_nrf_baseboard.build_flags}
   -D ADVERT_NAME='"Ikoka Stick Room"'
   -D ADVERT_LAT=0.0
   -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
-build_src_filter = ${ikoka_stick_nrf.build_src_filter}
+build_src_filter = ${ikoka_stick_nrf_baseboard.build_src_filter}
   +<../examples/simple_room_server/*.cpp>
+
+;;; hardware + firmware variants
+
+;;;    22dBm EBYTE E22-900M22 variants
+
+[env:ikoka_stick_nrf_22dbm_companion_radio_usb]
+extends =
+   ikoka_stick_nrf_e22_22dbm
+   ikoka_stick_nrf_companion_radio_usb
+build_flags =
+   ${ikoka_stick_nrf_companion_radio_usb.build_flags}
+   ${ikoka_stick_nrf_e22_22dbm.build_flags}
+build_src_filter =
+   ${ikoka_stick_nrf_companion_radio_usb.build_src_filter}
+   ${ikoka_stick_nrf_e22_22dbm.build_src_filter}
+
+[env:ikoka_stick_nrf_22dbm_companion_radio_ble]
+extends =
+   ikoka_stick_nrf_e22_22dbm
+   ikoka_stick_nrf_companion_radio_ble
+build_flags =
+   ${ikoka_stick_nrf_companion_radio_ble.build_flags}
+   ${ikoka_stick_nrf_e22_22dbm.build_flags}
+build_src_filter =
+   ${ikoka_stick_nrf_companion_radio_ble.build_src_filter}
+   ${ikoka_stick_nrf_e22_22dbm.build_src_filter}
+
+[env:ikoka_stick_nrf_22dbm_repeater]
+extends =
+   ikoka_stick_nrf_e22_22dbm
+   ikoka_stick_nrf_repeater
+build_flags =
+   ${ikoka_stick_nrf_repeater.build_flags}
+   ${ikoka_stick_nrf_e22_22dbm.build_flags}
+build_src_filter =
+   ${ikoka_stick_nrf_repeater.build_src_filter}
+   ${ikoka_stick_nrf_e22_22dbm.build_src_filter}
+
+[env:ikoka_stick_nrf_22dbm_room_server]
+extends =
+   ikoka_stick_nrf_e22_22dbm
+   ikoka_stick_nrf_room_server
+build_flags =
+   ${ikoka_stick_nrf_room_server.build_flags}
+   ${ikoka_stick_nrf_e22_22dbm.build_flags}
+build_src_filter =
+   ${ikoka_stick_nrf_room_server.build_src_filter}
+   ${ikoka_stick_nrf_e22_22dbm.build_src_filter}
+
+
+;;;    30dBm EBYTE E22-900M30 variants
+
+[env:ikoka_stick_nrf_30dbm_companion_radio_usb]
+extends =
+   ikoka_stick_nrf_e22_30dbm
+   ikoka_stick_nrf_companion_radio_usb
+build_flags =
+   ${ikoka_stick_nrf_companion_radio_usb.build_flags}
+   ${ikoka_stick_nrf_e22_30dbm.build_flags}
+build_src_filter =
+   ${ikoka_stick_nrf_companion_radio_usb.build_src_filter}
+   ${ikoka_stick_nrf_e22_30dbm.build_src_filter}
+
+[env:ikoka_stick_nrf_30dbm_companion_radio_ble]
+extends =
+   ikoka_stick_nrf_e22_30dbm
+   ikoka_stick_nrf_companion_radio_ble
+build_flags =
+   ${ikoka_stick_nrf_companion_radio_ble.build_flags}
+   ${ikoka_stick_nrf_e22_30dbm.build_flags}
+build_src_filter =
+   ${ikoka_stick_nrf_companion_radio_ble.build_src_filter}
+   ${ikoka_stick_nrf_e22_30dbm.build_src_filter}
+
+[env:ikoka_stick_nrf_30dbm_repeater]
+extends =
+   ikoka_stick_nrf_e22_30dbm
+   ikoka_stick_nrf_repeater
+build_flags =
+   ${ikoka_stick_nrf_repeater.build_flags}
+   ${ikoka_stick_nrf_e22_30dbm.build_flags}
+build_src_filter =
+   ${ikoka_stick_nrf_repeater.build_src_filter}
+   ${ikoka_stick_nrf_e22_30dbm.build_src_filter}
+
+[env:ikoka_stick_nrf_30dbm_room_server]
+extends =
+   ikoka_stick_nrf_e22_30dbm
+   ikoka_stick_nrf_room_server
+build_flags =
+   ${ikoka_stick_nrf_room_server.build_flags}
+   ${ikoka_stick_nrf_e22_30dbm.build_flags}
+build_src_filter =
+   ${ikoka_stick_nrf_room_server.build_src_filter}
+   ${ikoka_stick_nrf_e22_30dbm.build_src_filter}
+
+
+;;;    33dBm EBYTE E22-900M33 variants
+
+[env:ikoka_stick_nrf_33dbm_companion_radio_usb]
+extends =
+   ikoka_stick_nrf_e22_33dbm
+   ikoka_stick_nrf_companion_radio_usb
+build_flags =
+   ${ikoka_stick_nrf_companion_radio_usb.build_flags}
+   ${ikoka_stick_nrf_e22_33dbm.build_flags}
+build_src_filter =
+   ${ikoka_stick_nrf_companion_radio_usb.build_src_filter}
+   ${ikoka_stick_nrf_e22_33dbm.build_src_filter}
+
+[env:ikoka_stick_nrf_33dbm_companion_radio_ble]
+extends =
+   ikoka_stick_nrf_e22_33dbm
+   ikoka_stick_nrf_companion_radio_ble
+build_flags =
+   ${ikoka_stick_nrf_companion_radio_ble.build_flags}
+   ${ikoka_stick_nrf_e22_33dbm.build_flags}
+build_src_filter =
+   ${ikoka_stick_nrf_companion_radio_ble.build_src_filter}
+   ${ikoka_stick_nrf_e22_33dbm.build_src_filter}
+
+[env:ikoka_stick_nrf_33dbm_repeater]
+extends =
+   ikoka_stick_nrf_e22_33dbm
+   ikoka_stick_nrf_repeater
+build_flags =
+   ${ikoka_stick_nrf_repeater.build_flags}
+   ${ikoka_stick_nrf_e22_33dbm.build_flags}
+build_src_filter =
+   ${ikoka_stick_nrf_repeater.build_src_filter}
+   ${ikoka_stick_nrf_e22_33dbm.build_src_filter}
+
+[env:ikoka_stick_nrf_33dbm_room_server]
+extends =
+   ikoka_stick_nrf_e22_33dbm
+   ikoka_stick_nrf_room_server
+build_flags =
+   ${ikoka_stick_nrf_room_server.build_flags}
+   ${ikoka_stick_nrf_e22_33dbm.build_flags}
+build_src_filter =
+   ${ikoka_stick_nrf_room_server.build_src_filter}
+   ${ikoka_stick_nrf_e22_33dbm.build_src_filter}


### PR DESCRIPTION
The Ebyte S22 module comes in three variants, 22dBm, 30dBm, and 33dBm. Each requires a different TX power max setting to avoid frying the PA frontend.

Breaks out variants and roles by module type.