### PR TITLE
Add WHY2025 badge as a variant

### DIFF
--- a/variants/xiao_c6/platformio.ini
+++ b/variants/xiao_c6/platformio.ini
@@ -121,3 +121,65 @@ build_src_filter = ${Meshimi.build_src_filter}
 lib_deps =
   ${Meshimi.lib_deps}
   densaugeo/base64 @ ~1.4.0
+
+; WHY2025 badge variant
+; requires soldering 2 pins between the esp32-C6 and the lora chip as shown here: https://wiki.why2025.org/Project:Meshtastic_on_the_WHY2025_badge
+; also requires wiping the esp32-P4
+[WHY2025_badge]
+extends = Xiao_C6
+board_build.partitions = default_8MB.csv
+board_upload.flash_size = 8MB
+board_upload.maximum_size = 8388608
+build_flags =
+  ${Xiao_C6.build_flags}
+  -D P_LORA_SCLK=6
+  -D P_LORA_MISO=2
+  -D P_LORA_MOSI=7
+  -D P_LORA_NSS=4
+  -D P_LORA_DIO_1=5
+  -D P_LORA_BUSY=11
+  -D P_LORA_RESET=1
+  -D SX126X_TXEN=3
+  -UPIN_BOARD_SDA
+  -UPIN_BOARD_SCL
+  -UP_LORA_TX_LED
+  -USX126X_RXEN
+  -USX126X_DIO2_AS_RF_SWITCH
+  -USX126X_DIO3_TCXO_VOLTAGE
+
+[env:WHY2025_badge_Repeater]
+extends = WHY2025_badge
+build_src_filter = ${WHY2025_badge.build_src_filter}
+  +<../examples/simple_repeater/main.cpp>
+build_flags =
+  ${WHY2025_badge.build_flags}
+  -D ADVERT_NAME='"WHY2025 Badge Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=8
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+lib_deps =
+  ${WHY2025_badge.lib_deps}
+;  ${esp32_ota.lib_deps}
+
+[env:WHY2025_badge_companion_radio_ble]
+extends = WHY2025_badge
+build_flags = ${WHY2025_badge.build_flags}
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=8
+  -D BLE_PIN_CODE=123456
+  -D BLE_DEBUG_LOGGING=1
+  -D OFFLINE_QUEUE_SIZE=256
+  -D ENABLE_PRIVATE_KEY_IMPORT=1
+  -D ENABLE_PRIVATE_KEY_EXPORT=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${WHY2025_badge.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  -<helpers/esp32/ESPNOWRadio.cpp>
+  +<../examples/companion_radio/*.cpp>
+lib_deps =
+  ${WHY2025_badge.lib_deps}
+  densaugeo/base64 @ ~1.4.0


### PR DESCRIPTION
The WHY2025 badge was a badge distributed at WHYCamp in The Netherlands, roughly 2.5k are out there. https://why2025.org/post/697 It's got an ESP32-C6, an ESP32-P4 and an SX1262. It's also got a sizable screen and a nice keyboard, so it's got potential there as well, though those are obviously not used in this PR.

It's relatively similar to the Xiao_C6 in terms of config and was very easy to port, most of the time I spent was with fighting platformio. I've got LoRa connectivity (connected to half of hamburg's repeaters) and BLE working perfectly, it was honestly very painless.

Let me know if you want me to change anything like the PR title, commit message, variant name, etc.

## Quick instructions for installation for others with this badge

You'll obviously need to solder on the LoRa connector included with your badge. Running your badge with LoRa firmware without an antenna connected may fry the LoRa chip, so don't do that.

You'll also need to solder two pins between GPIO and the lora chip [like shown here](https://wiki.why2025.org/Project:Meshtastic_on_the_WHY2025_badge).

The base firmware on P4 flashes the C6 on boot, so you'll want to wipe the P4 to use this for now (`esptool --chip esp32p4 erase-flash`). There are ideas going around of using the P4 with a modified BadgeVMS so one can have a nice GUI in there for meshcore with all the badge drivers included.

As a note, the lower USB C port is wired to the C6, the upper USB C port is wired to the P4. The C6 is wired to the lora chip, the P4 is wired to the screen and keyboard.

You can build and flash a client with the following command (or through vscode, which is the officially recommended way, see meshcore docs for that): `platformio run -e WHY2025_badge_companion_radio_ble -t upload`