### PR TITLE
fix: Heltec Vision Master E290: rename companion target

### DIFF
--- a/variants/heltec_vision_master_e290/platformio.ini
+++ b/variants/heltec_vision_master_e290/platformio.ini
@@ -27,7 +27,7 @@ lib_deps =
   ${esp32_base.lib_deps}
   https://github.com/Quency-D/heltec-eink-modules/archive/563dd41fd850a1bc3039b8723da4f3a20fe1c800.zip
 
-[env:Heltec_Vision_Master_E290_radio_ble]
+[env:Heltec_Vision_Master_E290_companion_radio_ble]
 extends = Heltec_Vision_Master_E290_base
 build_flags =
   ${Heltec_Vision_Master_E290_base.build_flags}


### PR DESCRIPTION
The companion radio target didn't have companion in the name, so it wasn't getting picked up by github actions for building.