### PR TITLE
T1000e revert gps resetb

### DIFF
--- a/variants/t1000-e/T1000eBoard.h
+++ b/variants/t1000-e/T1000eBoard.h
@@ -57,8 +57,6 @@ public:
         digitalWrite(GPS_SLEEP_INT, LOW);
         digitalWrite(GPS_RTC_INT, LOW);
         digitalWrite(GPS_EN, LOW);
-        pinMode(GPS_RESETB, OUTPUT);
-        digitalWrite(GPS_RESETB, LOW);
     #endif
 
     #ifdef BUZZER_EN

--- a/variants/t1000-e/variant.cpp
+++ b/variants/t1000-e/variant.cpp
@@ -69,7 +69,7 @@ void initVariant()
   pinMode(BATTERY_PIN, INPUT);
   pinMode(EXT_CHRG_DETECT, INPUT);
   pinMode(EXT_PWR_DETECT, INPUT);
-  pinMode(GPS_RESETB, OUTPUT);
+  pinMode(GPS_RESETB, INPUT);
   pinMode(PIN_BUTTON1, INPUT);
 
   pinMode(PIN_3V3_EN, OUTPUT);
@@ -92,6 +92,5 @@ void initVariant()
   digitalWrite(GPS_VRTC_EN, LOW);
   digitalWrite(GPS_SLEEP_INT, HIGH);
   digitalWrite(GPS_RTC_INT, LOW);
-  digitalWrite(GPS_RESETB, LOW);
   digitalWrite(LED_PIN, LOW);
 }


### PR DESCRIPTION
GPS_RESETB has been changed to an OUTPUT (and it was already forced as output in the board class)

But it turns out it's an input that signals reset is over ...

see: https://github.com/Seeed-Studio/Seeed-Tracker-T1000-E-for-LoRaWAN-dev-board/blob/4e8668ebd25100cfecb400894c760b8e2c7c5f61/t1000_e/peripherals/src/ag3335.c#L243

This PR reverts the pin to the good state