### PR TITLE
Set correct new MAX_CONTACTS and MAX_GROUP_CHANNELS for some NRF devices

### DIFF
--- a/variants/heltec_t114/platformio.ini
+++ b/variants/heltec_t114/platformio.ini
@@ -161,8 +161,8 @@ extends = Heltec_t114_with_display
 build_flags =
   ${Heltec_t114_with_display.build_flags}
   -I examples/companion_radio/ui-new
-  -D MAX_CONTACTS=100
-  -D MAX_GROUP_CHANNELS=8
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
   -D BLE_PIN_CODE=123456
 ;  -D BLE_DEBUG_LOGGING=1
   -D OFFLINE_QUEUE_SIZE=256
@@ -181,8 +181,8 @@ extends = Heltec_t114_with_display
 build_flags =
   ${Heltec_t114_with_display.build_flags}
   -I examples/companion_radio/ui-new
-  -D MAX_CONTACTS=100
-  -D MAX_GROUP_CHANNELS=8
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
 ;  -D BLE_PIN_CODE=123456
 ;  -D BLE_DEBUG_LOGGING=1
 ;  -D MESH_PACKET_LOGGING=1

--- a/variants/lilygo_techo/platformio.ini
+++ b/variants/lilygo_techo/platformio.ini
@@ -105,8 +105,8 @@ build_flags =
   ${LilyGo_T-Echo.build_flags}
   -I src/helpers/ui
   -I examples/companion_radio/ui-new
-  -D MAX_CONTACTS=100
-  -D MAX_GROUP_CHANNELS=8
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
   -D OFFLINE_QUEUE_SIZE=256
   -D UI_RECENT_LIST_SIZE=9
   -D AUTO_SHUTDOWN_MILLIVOLTS=3300

--- a/variants/mesh_pocket/platformio.ini
+++ b/variants/mesh_pocket/platformio.ini
@@ -70,8 +70,8 @@ extends = Mesh_pocket
 build_flags =
   ${Mesh_pocket.build_flags}
   -I examples/companion_radio/ui-new
-  -D MAX_CONTACTS=100
-  -D MAX_GROUP_CHANNELS=8
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
   -D BLE_PIN_CODE=123456
   -D OFFLINE_QUEUE_SIZE=256
   -D AUTO_OFF_MILLIS=0
@@ -92,8 +92,8 @@ extends = Mesh_pocket
 build_flags =
   ${Mesh_pocket.build_flags}
   -I examples/companion_radio/ui-new
-  -D MAX_CONTACTS=100
-  -D MAX_GROUP_CHANNELS=8
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
   -D AUTO_OFF_MILLIS=0
 ;  -D BLE_PIN_CODE=123456
 ;  -D BLE_DEBUG_LOGGING=1


### PR DESCRIPTION
Some NRF devices missed the increase to MAX_CONTACTS and MAX_GROUP_CHANNELS, mostly USB targets.