### PR TITLE
fix nano g2 notification

### DIFF
--- a/variants/nano_g2_ultra/nano-g2.h
+++ b/variants/nano_g2_ultra/nano-g2.h
@@ -52,8 +52,8 @@ public:
   void powerOff() override {
     // put GPS chip to sleep
     digitalWrite(PIN_GPS_STANDBY, LOW);
-// unset buzzer to prevent notification circuit activating on hibernate
-#undef PIN_BUZZER
+    // TODO: unset buzzer to prevent notification circuit activating on hibernate
+    // needs to be set as silent or somehow stop using macros for pins
 
     nrf_gpio_cfg_sense_input(digitalPinToInterrupt(PIN_USER_BTN), NRF_GPIO_PIN_NOPULL,
                              NRF_GPIO_PIN_SENSE_LOW);


### PR DESCRIPTION
revert change to disable buzzer before hibernate

needs more work as the buzzer pin is a macro and can't be changed at runtime

closes #764 