### PR TITLE
Add battery voltage within battery icon in companion ui 

### DIFF
--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -111,9 +111,15 @@ class HomeScreen : public UIScreen {
     // battery "cap"
     display.fillRect(iconX + iconWidth, iconY + (iconHeight / 4), 3, iconHeight / 2);
 
-    // fill the battery based on the percentage
+    // fill the battery based on the percentage as a small bar
     int fillWidth = (batteryPercentage * (iconWidth - 4)) / 100;
-    display.fillRect(iconX + 2, iconY + 2, fillWidth, iconHeight - 4);
+    display.fillRect(iconX + 2, iconY + 8, fillWidth, iconHeight - 8);
+
+    // write the voltage
+    char voltStr[10];
+    snprintf(voltStr, sizeof(voltStr), "%.1fV", batteryMilliVolts / 1000.0f);
+    display.drawTextCentered(iconX + (iconWidth / 2), iconY, voltStr);
+
   }
 
   CayenneLPP sensors_lpp;


### PR DESCRIPTION
- Add battery voltage within battery icon in companion ui for the new ui.
- Reduce the size of the battery full bar so that it is below the text.
- I have tested this on my Heltec t114, but since I don't have a device that uses the orig-ui I haven't changed that code. I have the code prepared if it was to be included as well.
- Since it seems like #413  hasn't be merged, this may be a good interim solution. Especially since some may argue the voltage is more important to see than the percentage.

![IMG_3944](https://github.com/user-attachments/assets/cc3ee590-9987-4a1c-9d37-0cf552ec3060)
