### PR TITLE
fix: revert ENV_PIN_SDA for Wio Tracker L1 non-eink

### DIFF
--- a/variants/wio-tracker-l1/platformio.ini
+++ b/variants/wio-tracker-l1/platformio.ini
@@ -15,8 +15,6 @@ build_flags = ${nrf52_base.build_flags}
   -D SX126X_RX_BOOSTED_GAIN=1
   -D PIN_OLED_RESET=-1
   -D GPS_BAUD_RATE=9600
-  -D ENV_PIN_SDA=PIN_WIRE1_SDA
-  -D ENV_PIN_SCL=PIN_WIRE1_SCL
 build_src_filter = ${nrf52_base.build_src_filter}
   +<WioTrackerL1Board.cpp>
   +<../variants/wio-tracker-l1>


### PR DESCRIPTION
With ENV_PIN_SDA defined on the on the OLED Wio Tracker L1 the device gets stuck on "Loading...", BLE is advertising and you can "connect" but the device never sends any data.