### PR TITLE
[BUG] Wio Tracker L1 freezes during startup

### DIFF
--- a/variants/wio-tracker-l1/platformio.ini
+++ b/variants/wio-tracker-l1/platformio.ini
@@ -15,8 +15,8 @@ build_flags = ${nrf52_base.build_flags}
   -D SX126X_RX_BOOSTED_GAIN=1
   -D PIN_OLED_RESET=-1
   -D GPS_BAUD_RATE=9600
-  -D ENV_PIN_SDA=PIN_WIRE1_SDA
-  -D ENV_PIN_SCL=PIN_WIRE1_SCL
+  ; -D ENV_PIN_SDA=PIN_WIRE1_SDA
+  ; -D ENV_PIN_SCL=PIN_WIRE1_SCL
 build_src_filter = ${nrf52_base.build_src_filter}
   +<WioTrackerL1Board.cpp>
   +<../variants/wio-tracker-l1>


### PR DESCRIPTION
The changes from [commit `4aa58ad`](https://github.com/meshcore-dev/MeshCore/commit/4aa58ade8a32f9c5a3e65d400b64610fb702a03d) cause the L1 variant to fail at boot.

To fix the issue, comment out the `ENV_PIN_SDA` and `ENV_PIN_SCL` definitions in `platformio.ini`.