### PR TITLE
Backwards Compatibility: Legacy Neighbours CLI

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -706,9 +706,24 @@ void MyMesh::formatNeighborsReply(char *reply) {
   char *dp = reply;
 
 #if MAX_NEIGHBOURS
-  for (int i = 0; i < MAX_NEIGHBOURS && dp - reply < 134; i++) {
-    NeighbourInfo *neighbour = &neighbours[i];
-    if (neighbour->heard_timestamp == 0) continue; // skip empty slots
+  // create copy of neighbours list, skipping empty entries so we can sort it separately from main list
+  int16_t neighbours_count = 0;
+  NeighbourInfo* sorted_neighbours[MAX_NEIGHBOURS];
+  for (int i = 0; i < MAX_NEIGHBOURS; i++) {
+    auto neighbour = &neighbours[i];
+    if (neighbour->heard_timestamp > 0) {
+      sorted_neighbours[neighbours_count] = neighbour;
+      neighbours_count++;
+    }
+  }
+
+  // sort neighbours newest to oldest
+  std::sort(sorted_neighbours, sorted_neighbours + neighbours_count, [](const NeighbourInfo* a, const NeighbourInfo* b) {
+    return a->heard_timestamp > b->heard_timestamp; // desc
+  });
+
+  for (int i = 0; i < neighbours_count && dp - reply < 134; i++) {
+    NeighbourInfo *neighbour = sorted_neighbours[i];
 
     // add new line if not first item
     if (i > 0) *dp++ = '\n';


### PR DESCRIPTION
This PR sorts the neighbour list by newest to oldest before responding to the old admin cli command `neighbors`.

With the introduction of the new binary request/response for paginated neighbours, and the future increase to `MAX_NEIGHBOURS` count, the old cli command would return the first 8 entries, which may not include the most recently heard.

This is because we add new neighbour records to the first empty slot, or update the existing neighbour entry if it's from the same node.

Sorting before replying ensures we always return the most recent neighbours, to maintain backwards compatibility for older clients fetching neighbours from newer repeater firmware.