### PR TITLE
Introduce Heltec_WSL3_companion_radio_wifi target

### DIFF
--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -325,6 +325,24 @@ lib_deps =
   ${Heltec_lora32_v3.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
+[env:Heltec_WSL3_companion_radio_wifi]
+extends = Heltec_lora32_v3
+build_flags =
+  ${Heltec_lora32_v3.build_flags}
+  -D MAX_CONTACTS=300
+  -D MAX_GROUP_CHANNELS=8
+  -D WIFI_DEBUG_LOGGING=1
+  -D WIFI_SSID='"myssid"'
+  -D WIFI_PWD='"mypwd"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_lora32_v3.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<../examples/companion_radio/*.cpp>
+lib_deps =
+  ${Heltec_lora32_v3.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
 [env:Heltec_WSL3_sensor]
 extends = Heltec_lora32_v3
 build_flags =


### PR DESCRIPTION
This MR adds a new PlatformIO build environment for the Heltec WSL3 WiFi companion firmware: `Heltec_WSL3_companion_radio_wifi`. It's a modified copy of the WSL3 BLE target.