### PR TITLE
heltec wireless tracker: use `-D ARDUINO_USB_CDC_ON_BOOT=1` with all envs

### DIFF
--- a/variants/heltec_tracker/platformio.ini
+++ b/variants/heltec_tracker/platformio.ini
@@ -5,6 +5,7 @@ build_flags =
   ${esp32_base.build_flags}
   -I variants/heltec_tracker
   -D HELTEC_LORA_V3
+  -D ARDUINO_USB_CDC_ON_BOOT=1      ; need for Serial
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper
   -D LORA_TX_POWER=22
@@ -40,7 +41,6 @@ build_flags =
   ${Heltec_tracker_base.build_flags}
   -I src/helpers/ui
   -I examples/companion_radio/ui-new
-  -D ARDUINO_USB_CDC_ON_BOOT=1      ; need for Serial
   -D DISPLAY_ROTATION=1
   -D DISPLAY_CLASS=ST7735Display
   -D MAX_CONTACTS=300


### PR DESCRIPTION
repeater and room server envs did not have arduino cdc flag enabled which resulted in broken serial.

thanks jimmay1968 @ discord for finding the bug and fixing it.