### PR TITLE
heltec v2 cleanup

### DIFF
--- a/variants/heltec_v2/HeltecV2Board.h
+++ b/variants/heltec_v2/HeltecV2Board.h
@@ -1,21 +1,11 @@
 #pragma once
 
 #include <Arduino.h>
-
-// LoRa radio module pins for Heltec V2
-#define  P_LORA_DIO_1   26    // DIO0
-#define  P_LORA_NSS     18
-#define  P_LORA_RESET   RADIOLIB_NC  // 14
-#define  P_LORA_BUSY    RADIOLIB_NC
-#define  P_LORA_SCLK     5
-#define  P_LORA_MISO    19
-#define  P_LORA_MOSI    27
+#include <helpers/ESP32Board.h>
 
 // built-ins
 #define  PIN_VBAT_READ   37
 #define  PIN_LED_BUILTIN 25
-
-#include "ESP32Board.h"
 
 #include <driver/rtc_io.h>
 
@@ -39,7 +29,7 @@ public:
   void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1) {
     esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
 
-    // Make sure the DIO1 and NSS GPIOs are hold on required levels during deep sleep 
+    // Make sure the DIO1 and NSS GPIOs are hold on required levels during deep sleep
     rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
     rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
 

--- a/variants/heltec_v2/platformio.ini
+++ b/variants/heltec_v2/platformio.ini
@@ -7,13 +7,20 @@ build_flags =
   -D HELTEC_LORA_V2
   -D RADIO_CLASS=CustomSX1276
   -D WRAPPER_CLASS=CustomSX1276Wrapper
+  -D P_LORA_DIO_1=26
+  -D P_LORA_NSS=18
+  -D P_LORA_RESET=RADIOLIB_NC
+  -D P_LORA_BUSY=RADIOLIB_NC
+  -D P_LORA_SCLK=5
+  -D P_LORA_MISO=19
+  -D P_LORA_MOSI=27
+  -D P_LORA_TX_LED=25
   -D SX127X_CURRENT_LIMIT=120
   -D LORA_TX_POWER=20
   -D PIN_BOARD_SDA=4
   -D PIN_BOARD_SCL=15
   -D PIN_USER_BTN=0
   -D PIN_OLED_RESET=16
-  -D P_LORA_TX_LED=25
 build_src_filter = ${esp32_base.build_src_filter}
   +<../variants/heltec_v2>
 lib_deps =
@@ -112,7 +119,7 @@ lib_deps =
 extends = Heltec_lora32_v2
 build_flags =
   ${Heltec_lora32_v2.build_flags}
-  -D MAX_CONTACTS=170
+  -D MAX_CONTACTS=160
   -D MAX_GROUP_CHANNELS=1
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
@@ -128,7 +135,7 @@ build_flags =
   ${Heltec_lora32_v2.build_flags}
   -I examples/companion_radio/ui-new
   -D DISPLAY_CLASS=SSD1306Display
-  -D MAX_CONTACTS=170
+  -D MAX_CONTACTS=160
   -D MAX_GROUP_CHANNELS=8
 ; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
 ; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
@@ -148,13 +155,36 @@ build_flags =
   ${Heltec_lora32_v2.build_flags}
   -I examples/companion_radio/ui-new
   -D DISPLAY_CLASS=SSD1306Display
-  -D MAX_CONTACTS=170
+  -D MAX_CONTACTS=160
   -D MAX_GROUP_CHANNELS=8
   -D BLE_PIN_CODE=123456
   -D BLE_DEBUG_LOGGING=1
   -D OFFLINE_QUEUE_SIZE=256
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_lora32_v2.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${Heltec_lora32_v2.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:Heltec_v2_companion_radio_wifi]
+extends = Heltec_lora32_v2
+build_flags =
+  ${Heltec_lora32_v2.build_flags}
+  -I examples/companion_radio/ui-new
+  -D DISPLAY_CLASS=SSD1306Display
+  -D MAX_CONTACTS=160
+  -D MAX_GROUP_CHANNELS=8
+  -D WIFI_DEBUG_LOGGING=1
+  -D WIFI_SSID='"myssid"'
+  -D WIFI_PWD='"mypwd"'
+; -D MESH_PACKET_LOGGING=1
+; -D MESH_DEBUG=1
 build_src_filter = ${Heltec_lora32_v2.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<helpers/ui/SSD1306Display.cpp>

--- a/variants/heltec_v2/target.h
+++ b/variants/heltec_v2/target.h
@@ -3,7 +3,7 @@
 #define RADIOLIB_STATIC_ONLY 1
 #include <RadioLib.h>
 #include <helpers/radiolib/RadioLibWrappers.h>
-#include <helpers/HeltecV2Board.h>
+#include <HeltecV2Board.h>
 #include <helpers/radiolib/CustomSX1276Wrapper.h>
 #include <helpers/AutoDiscoverRTCClock.h>
 #include <helpers/SensorManager.h>


### PR DESCRIPTION
- moved HeltecV2Board.h from helpers to variants
- moved radio pindefs from HeltecV2Board to platformio.ini
- reduced max_contacts to 160 because of the RAM size linker errors