### PR TITLE
Fix the analogue user button on the new UI by adding a delay to UITask.cpp

### DIFF
--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -650,6 +650,7 @@ void UITask::loop() {
   }
 #endif
 #if defined(PIN_USER_BTN_ANA)
+  delay(10);
   ev = analog_btn.check();
   if (ev == BUTTON_EVENT_CLICK) {
     c = checkDisplayOn(KEY_NEXT);


### PR DESCRIPTION
The polling of the ADC of the user button is too fast and causes bad reads. The delay is required to allow the ADC to settle between reads.