### PR TITLE
Changes retransmit delay to no longer use buckets

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -396,12 +396,27 @@ int MyMesh::calcRxDelay(float score, uint32_t air_time) const {
 }
 
 uint32_t MyMesh::getRetransmitDelay(const mesh::Packet *packet) {
+  if(_prefs.tx_delay_factor == 0) {
+    MESH_DEBUG_PRINTLN("getRetransmitDelay: Total tx delay: %d", _prefs.tx_delay_factor);
+    return 5;
+  }
+  
   uint32_t t = (_radio->getEstAirtimeFor(packet->path_len + packet->payload_len + 2) * _prefs.tx_delay_factor);
-  return getRNG()->nextInt(0, 6) * t;
+  uint32_t total_delay = getRNG()->nextInt(5, t);
+  MESH_DEBUG_PRINTLN("getRetransmitDelay: Total tx delay: %d", total_delay);
+  return total_delay;
 }
+
 uint32_t MyMesh::getDirectRetransmitDelay(const mesh::Packet *packet) {
+  if(_prefs.direct_tx_delay_factor == 0) {
+    MESH_DEBUG_PRINTLN("getDirectRetransmitDelay: Total tx delay: %d", _prefs.direct_tx_delay_factor);
+    return 5;
+  }
+
   uint32_t t = (_radio->getEstAirtimeFor(packet->path_len + packet->payload_len + 2) * _prefs.direct_tx_delay_factor);
-  return getRNG()->nextInt(0, 6) * t;
+  uint32_t total_delay = getRNG()->nextInt(5, t);
+  MESH_DEBUG_PRINTLN("getDirectRetransmitDelay: Total tx delay: %d", total_delay);
+  return total_delay;
 }
 
 void MyMesh::onAnonDataRecv(mesh::Packet *packet, const uint8_t *secret, const mesh::Identity &sender,

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -17,7 +17,9 @@ bool Mesh::allowPacketForward(const mesh::Packet* packet) {
 uint32_t Mesh::getRetransmitDelay(const mesh::Packet* packet) { 
   uint32_t t = (_radio->getEstAirtimeFor(packet->getRawLength()) * 52 / 50) / 2;
 
-  return _rng->nextInt(0, 5)*t;
+  uint32_t total_delay = getRNG()->nextInt(5, t);
+  MESH_DEBUG_PRINTLN("getRetransmitDelay: Total tx delay: %d", total_delay);
+  return total_delay;
 }
 uint32_t Mesh::getDirectRetransmitDelay(const Packet* packet) {
   return 0;  // by default, no delay


### PR DESCRIPTION
This change would give the "listen before send" code a better chance to detect if another nearby repeater is transmitting.