### PR TITLE
all nrf52 devices: force framework-arduinoadafruitnrf52 version to 1.10700.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -76,6 +76,8 @@ platform = https://github.com/pioarduino/platform-espressif32/releases/download/
 [nrf52_base]
 extends = arduino_base
 platform = nordicnrf52
+platform_packages =
+  framework-arduinoadafruitnrf52 @ 1.10700.0
 extra_scripts = create-uf2.py
 build_flags = ${arduino_base.build_flags}
   -D NRF52_PLATFORM


### PR DESCRIPTION
There are multiple fixes in newer framework-arduinoadafruitnrf52 1.10700.0, but the platformio/nordicnrf52 requires version 1.10601.0 - this PR forces usage of newer version.

thanks @oltaco and @MikesAllotment(and all other people on discord) for testing this