### PR TITLE
Revert Heltec T114 power savings

### DIFF
--- a/variants/heltec_t114/T114Board.cpp
+++ b/variants/heltec_t114/T114Board.cpp
@@ -24,45 +24,6 @@ void T114Board::begin() {
 
   pinMode(PIN_VBAT_READ, INPUT);
 
-  // Enable SoftDevice low-power mode
-  sd_power_mode_set(NRF_POWER_MODE_LOWPWR);
-
-  // Enable DC/DC converter for better efficiency (REG1 stage)
-  NRF_POWER->DCDCEN = 1;
-
-  // Power down unused communication peripherals
-  // UART1 - Not used on T114
-  NRF_UARTE1->ENABLE = 0;
-
-  // SPIM2/SPIS2 - Not used (SPI is on SPIM0)
-  NRF_SPIM2->ENABLE = 0;
-  NRF_SPIS2->ENABLE = 0;
-
-  // TWI1 (I2C1) - Not used (I2C is on TWI0)
-  NRF_TWIM1->ENABLE = 0;
-  NRF_TWIS1->ENABLE = 0;
-
-  // PWM modules - Not used for standard T114 functions
-  NRF_PWM1->ENABLE = 0;
-  NRF_PWM2->ENABLE = 0;
-  NRF_PWM3->ENABLE = 0;
-
-  // PDM (Digital Microphone Interface) - Not used
-  NRF_PDM->ENABLE = 0;
-
-  // I2S - Not used
-  NRF_I2S->ENABLE = 0;
-
-  // QSPI - Not used (no external flash)
-  NRF_QSPI->ENABLE = 0;
-
-  // Disable unused analog peripherals
-  // SAADC channels - only keep what's needed for battery monitoring
-  NRF_SAADC->ENABLE = 0; // Re-enable only when needed for measurements
-
-  // COMP - Comparator not used
-  NRF_COMP->ENABLE = 0;
-
 #if defined(PIN_BOARD_SDA) && defined(PIN_BOARD_SCL)
   Wire.setPins(PIN_BOARD_SDA, PIN_BOARD_SCL);
 #endif

--- a/variants/heltec_t114/T114Board.h
+++ b/variants/heltec_t114/T114Board.h
@@ -27,9 +27,6 @@ public:
 
   uint16_t getBattMilliVolts() override {
     int adcvalue = 0;
-
-    NRF_SAADC->ENABLE = 1;
-
     analogReadResolution(12);
     analogReference(AR_INTERNAL_3_0);
     pinMode(PIN_BAT_CTL, OUTPUT);          // battery adc can be read only ctrl pin 6 set to high
@@ -38,8 +35,6 @@ public:
     delay(10);
     adcvalue = analogRead(PIN_VBAT_READ);
     digitalWrite(6, 0);
-
-    NRF_SAADC->ENABLE = 0;
 
     return (uint16_t)((float)adcvalue * MV_LSB * 4.9);
   }


### PR DESCRIPTION
As discussed with @recrof on discord, people are having issues possibly due to these changes.

See https://github.com/meshcore-dev/MeshCore/issues/746

This reverts commit a16e011bd21cf3070f04b3513d562add0d090838.