### PR TITLE
Add sync flag reset to prevent zombie sync job

### DIFF
--- a/src/helpers/sensors/LocationProvider.h
+++ b/src/helpers/sensors/LocationProvider.h
@@ -19,7 +19,7 @@ public:
     virtual void sendSentence(const char * sentence);
     virtual void reset() = 0;
     virtual void begin() = 0;
-    virtual void stop() = 0;
+    virtual void stop() { _time_sync_needed = false; }
     virtual void loop() = 0;
     virtual bool isEnabled() = 0;
 };

--- a/src/helpers/sensors/MicroNMEALocationProvider.h
+++ b/src/helpers/sensors/MicroNMEALocationProvider.h
@@ -79,7 +79,8 @@ public :
         if (_pin_en != -1) {
             digitalWrite(_pin_en, !PIN_GPS_EN_ACTIVE);
         }
-        if (_peripher_power) _peripher_power->release();  
+        if (_peripher_power) _peripher_power->release();
+        LocationProvider::stop();
     }
 
     bool isEnabled() override {


### PR DESCRIPTION
now if I start gps sync but there is no fix and I stop the GPS , the sync job runs indefinitely with switched off GPS