### PR TITLE
Add PIN_GPS_EN build flag for wismesh tag companion

### DIFF
--- a/variants/rak_wismesh_tag/platformio.ini
+++ b/variants/rak_wismesh_tag/platformio.ini
@@ -94,6 +94,7 @@ build_flags =
   -D BLE_PIN_CODE=123456
   -D BLE_DEBUG_LOGGING=1
   -D OFFLINE_QUEUE_SIZE=256
+  -D PIN_GPS_EN=34
 ;  -D MESH_PACKET_LOGGING=1
   -D MESH_DEBUG=1
 build_src_filter = ${rak_wismesh_tag.build_src_filter}


### PR DESCRIPTION
This pin value is defined in the variant.h, but those definitions are not accessible to the sensor code. Defining the pin value as a build flag allows the GPS toggle to work for the Wismesh Tag.