### PR TITLE
Use correct macro for GPS logging test

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -632,7 +632,7 @@ void EnvironmentSensorManager::start_gps() {
   _location->begin();
   _location->reset();
 
-#ifndef PIN_GPS_RESET
+#ifndef PIN_GPS_EN
   MESH_DEBUG_PRINTLN("Start GPS is N/A on this board. Actual GPS state unchanged");
 #endif
 }


### PR DESCRIPTION
The rest of the GPS tests in this file use `#ifdef PIN_GPS_EN` for this logging check. The logged message implies that the GPS can’t be enabled and in the location class, there are two tests. One for EN and one for RESET so they have different meanings.

For devices that have EN but not RESET pin, this log entry is incorrect.