### PR TITLE
Updated CayenneLPP to 1.6.1

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@ lib_deps =
   rweather/Crypto @ ^0.4.0
   adafruit/RTClib @ ^2.1.3
   melopero/Melopero RV3028 @ ^1.1.0
-  electroniccats/CayenneLPP @ 1.4.0
+  electroniccats/CayenneLPP @ 1.6.1
 build_flags = -w -DNDEBUG -DRADIOLIB_STATIC_ONLY=1 -DRADIOLIB_GODMODE=1
   -D LORA_FREQ=869.525
   -D LORA_BW=250


### PR DESCRIPTION
Updated CayenneLPP from 1.4.0 to 1.6.1 which add the negative voltage and current telemetry.