### PR TITLE
New workaround for LR1110 shift issue

### DIFF
--- a/src/helpers/radiolib/CustomLR1110.h
+++ b/src/helpers/radiolib/CustomLR1110.h
@@ -10,72 +10,17 @@ class CustomLR1110 : public LR1110 {
   public:
     CustomLR1110(Module *mod) : LR1110(mod) { }
 
-    uint8_t shiftCount = 0;
-
-    int16_t standby() override {
-      // tx resets the shift, standby is called on tx completion
-      // this might not actually be what resets it, but it seems to work
-      // more investigation needed
-      this->shiftCount = 0;
-      return LR1110::standby();
-    }
-
     size_t getPacketLength(bool update) override {
       size_t len = LR1110::getPacketLength(update);
-      if (len == 0) {
-        uint32_t irq = getIrqStatus();
-        if (irq & RADIOLIB_LR11X0_IRQ_HEADER_ERR) {
-          MESH_DEBUG_PRINTLN("LR1110: got header err, assuming shift");
-          this->shiftCount += 4; // uint8 will loop around to 0 at 256, perfect as rx buffer is 256 bytes
-        } else {
-          MESH_DEBUG_PRINTLN("LR1110: got zero-length packet without header err irq");
-        }
+      if (len == 0 && getIrqStatus() & RADIOLIB_LR11X0_IRQ_HEADER_ERR) {
+        // we've just recieved a corrupted packet
+        // this may have triggered a bug causing subsequent packets to be shifted
+        // call standby() to return radio to known-good state
+        // recvRaw will call startReceive() to restart rx
+        MESH_DEBUG_PRINTLN("LR1110: got header err, calling standby()");
+        standby();
       }
       return len;
-    }
-
-    int16_t readData(uint8_t *data, size_t len) override {
-      // check active modem
-      uint8_t modem = RADIOLIB_LR11X0_PACKET_TYPE_NONE;
-      int16_t state = getPacketType(&modem);
-      RADIOLIB_ASSERT(state);
-      if((modem != RADIOLIB_LR11X0_PACKET_TYPE_LORA) && 
-        (modem != RADIOLIB_LR11X0_PACKET_TYPE_GFSK)) {
-        return(RADIOLIB_ERR_WRONG_MODEM);
-      }
-
-      // check integrity CRC
-      uint32_t irq = getIrqStatus();
-      int16_t crcState = RADIOLIB_ERR_NONE;
-      // Report CRC mismatch when there's a payload CRC error, or a header error and no valid header (to avoid false alarm from previous packet)
-      if((irq & RADIOLIB_LR11X0_IRQ_CRC_ERR) || ((irq & RADIOLIB_LR11X0_IRQ_HEADER_ERR) && !(irq & RADIOLIB_LR11X0_IRQ_SYNC_WORD_HEADER_VALID))) {
-        crcState = RADIOLIB_ERR_CRC_MISMATCH;
-      }
-
-      // get packet length
-      // the offset is needed since LR11x0 seems to move the buffer base by 4 bytes on every packet
-      uint8_t offset = 0;
-      size_t length = LR1110::getPacketLength(true, &offset);
-      if((len != 0) && (len < length)) {
-        // user requested less data than we got, only return what was requested
-        length = len;
-      }
-
-      // read packet data
-      state = readBuffer8(data, length, (uint8_t)(offset + this->shiftCount));  // add shiftCount to offset - only change from radiolib
-      RADIOLIB_ASSERT(state);
-
-      // clear the Rx buffer
-      state = clearRxBuffer();
-      RADIOLIB_ASSERT(state);
-
-      // clear interrupt flags
-      state = clearIrqState(RADIOLIB_LR11X0_IRQ_ALL);
-
-      // check if CRC failed - this is done after reading data to give user the option to keep them
-      RADIOLIB_ASSERT(crcState);
-
-      return(state);
     }
 
     RadioLibTime_t getTimeOnAir(size_t len) override {


### PR DESCRIPTION
My previous workaround in PR #953 worked by assuming all subsequent packets would be shifted 4 bytes to the right after a packet with the header error IRQ set so compensated by reading 4 bytes to the right in the radio's RX buffer. Unfortunately, after further testing, it seems that a small percentage of header errors do not result in a shift, thus packets could be shifted 4 bytes to the left after the workaround wrongly assumed a shift had occurred. This makes the issue worse for repeaters: before the workaround, all packets would have a header of 0x00 so the repeater would always retransmit, resetting the shift, whereas if a packet is shifted 4 bytes to the left, it is unlikely that the repeater would retransmit the packet due to the garbage data at the start, therefore taking much longer for the repeater to become operational again.

This new workaround simply calls reset() after a header error, returning the radio to a known-good state.