### PR TITLE
Add CLI command to regenerate key pair

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -807,17 +807,16 @@ void MyMesh::clearStats() {
   ((SimpleMeshTables *)getTables())->resetStats();
 }
 
-void MyMesh::regenerateKeys() {
-  MESH_DEBUG_PRINTLN("Generating new keypair");
-  mesh::LocalIdentity new_id = radio_new_identity();
-  
-  int count = 0;
-  while (count < 10 && (new_id.pub_key[0] == 0x00 || new_id.pub_key[0] == 0xFF)) {
-    new_id = radio_new_identity();
-    count++;
+void MyMesh::regenerateKeys(uint8_t byte) { 
+  if (byte >0 && byte < 0xff){
+    MESH_DEBUG_PRINTLN("Generating new keypair");
+    mesh::LocalIdentity new_id = radio_new_identity();
+    
+    while (new_id.pub_key[0] != byte) {
+      new_id = radio_new_identity();
+    }
+    saveIdentity(new_id);
   }
-  
-  saveIdentity(new_id);
 }
 
 void MyMesh::handleCommand(uint32_t sender_timestamp, char *command, char *reply) {

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -188,7 +188,7 @@ public:
 
   void saveIdentity(const mesh::LocalIdentity& new_id) override;
   void clearStats() override;
-  void regenerateKeys() override;  
+  void regenerateKeys(uint8_t byte);  
   void handleCommand(uint32_t sender_timestamp, char* command, char* reply);
   void loop();
 

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -245,11 +245,29 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
     } else if (memcmp(command, "clear stats", 11) == 0) {
       _callbacks->clearStats();
       strcpy(reply, "(OK - stats reset)");
-    } else if (memcmp(command, "regeneratekeys", 14) == 0) {
+    } else if (memcmp(command, "regeneratekeys ", 15) == 0) {
+      // Parse first hex digit
+      int value = 0;
+      if (command[15] >= '0' && command[15] <= '9')
+          value = (command[15] - '0') << 4;
+      else if (command[15] >= 'a' && command[15] <= 'f')
+          value = (command[15] - 'a' + 10) << 4;
+      else if (command[15] >= 'A' && command[15] <= 'F')
+          value = (command[15] - 'A' + 10) << 4;
+      // Parse second hex digit
+      if (command[16] >= '0' && command[16] <= '9')
+          value |= (command[16] - '0');
+      else if (command[16] >= 'a' && command[16] <= 'f')
+          value |= (command[16] - 'a' + 10);
+      else if (command[16] >= 'A' && command[16] <= 'F')
+          value |= (command[16] - 'A' + 10);
       // regenerate key pair
       MESH_DEBUG_PRINTLN("Generating new keypair");
-      _callbacks->regenerateKeys();
-      _board->reboot();  // doesn't return
+      if ((value > 0) && (value < 0xff)){
+        _callbacks->regenerateKeys(value);
+        _board->reboot();  // doesn't return
+      }
+      sprintf(reply, "> ERROR");
     /*
      * GET commands
      */

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -69,7 +69,7 @@ public:
   virtual mesh::LocalIdentity& getSelfId() = 0;
   virtual void saveIdentity(const mesh::LocalIdentity& new_id) = 0;
   virtual void clearStats() = 0;
-  virtual void regenerateKeys() = 0; 
+  virtual void regenerateKeys(uint8_t byte) = 0; 
   virtual void applyTempRadioParams(float freq, float bw, uint8_t sf, uint8_t cr, int timeout_mins) = 0;
 
   virtual void setBridgeState(bool enable) {


### PR DESCRIPTION
In a situation where repeaters face zero hop key prefix collisions, keys will have to be regenerated.
Doing this via the `set prv.key` command is only possible via physical connection to the repeater - for good reasons.

Now, in order to be able to solve a prefix collision without having to climb on roof tops with your notebook in your backpack this PR will add the `regeneratekeys` command to enable remote regenerating of the key pair.
By applying the command the repeater will reboot immediately and by doing so will also send an advert so that the device will show up a couple of seconds later in the contacts list with a new public key.

This fixes https://github.com/meshcore-dev/MeshCore/issues/241