### PR TITLE
Update xiao rp2040 to use new radio standard init

### DIFF
--- a/variants/xiao_rp2040/target.cpp
+++ b/variants/xiao_rp2040/target.cpp
@@ -20,34 +20,12 @@ SensorManager sensors;
 bool radio_init() {
   rtc_clock.begin(Wire);
 
-#ifdef SX126X_DIO3_TCXO_VOLTAGE
-  float tcxo = SX126X_DIO3_TCXO_VOLTAGE;
+#if defined(P_LORA_SCLK)
+  spi.begin(P_LORA_SCLK, P_LORA_MISO, P_LORA_MOSI);
+  return radio.std_init(&spi);
 #else
-  float tcxo = 1.6f;
+  return radio.std_init();
 #endif
-  int status = radio.begin(LORA_FREQ, LORA_BW, LORA_SF, LORA_CR, RADIOLIB_SX126X_SYNC_WORD_PRIVATE, LORA_TX_POWER, 8, tcxo);
-
-  if (status != RADIOLIB_ERR_NONE) {
-    Serial.print("ERROR: radio init failed: ");
-    Serial.println(status);
-    return false; // fail
-  }
-
-  radio.setCRC(1);
-
-#ifdef SX126X_CURRENT_LIMIT
-  radio.setCurrentLimit(SX126X_CURRENT_LIMIT);
-#endif
-
-#ifdef SX126X_DIO2_AS_RF_SWITCH
-  radio.setDio2AsRfSwitch(SX126X_DIO2_AS_RF_SWITCH);
-#endif
-
-#ifdef SX126X_RX_BOOSTED_GAIN
-  radio.setRxBoostedGainMode(SX126X_RX_BOOSTED_GAIN);
-#endif
-
-  return true; // success
 }
 
 uint32_t radio_get_rng_seed() {


### PR DESCRIPTION
- Contributes to the efforts of #425
- Fixes -707 radio initialisation issues caused by TCXO being set to 0.0f