### PR TITLE
esp32c6: disable releases because of issues with pioarduino(arduino 3.0)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -67,6 +67,7 @@ lib_deps =
   file://arch/esp32/AsyncElegantOTA
 
 ; esp32c6 uses arduino framework 3.x
+; WARNING: experimental. pioarduino on esp32c6 needs work - it's not considered stable and has issues.
 [esp32c6_base]
 extends = esp32_base
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.12/platform-espressif32.zip

--- a/variants/lilygo_tlora_c6/platformio.ini
+++ b/variants/lilygo_tlora_c6/platformio.ini
@@ -30,7 +30,7 @@ build_flags =
 build_src_filter = ${esp32c6_base.build_src_filter}
   +<../variants/lilygo_tlora_c6>
 
-[env:LilyGo_Tlora_C6_repeater]
+[env:LilyGo_Tlora_C6_repeater_]
 extends = tlora_c6
 build_src_filter = ${tlora_c6.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
@@ -47,7 +47,7 @@ lib_deps =
   ${tlora_c6.lib_deps}
 ;  ${esp32_ota.lib_deps}
 
-[env:LilyGo_Tlora_C6_room_server]
+[env:LilyGo_Tlora_C6_room_server_]
 extends = tlora_c6
 build_src_filter = ${tlora_c6.build_src_filter}
   +<../examples/simple_room_server>
@@ -64,7 +64,7 @@ lib_deps =
   ${tlora_c6.lib_deps}
 ;  ${esp32_ota.lib_deps}
 
-[env:LilyGo_Tlora_C6_companion_radio_ble]
+[env:LilyGo_Tlora_C6_companion_radio_ble_]
 extends = tlora_c6
 build_flags = ${tlora_c6.build_flags}
   -D MAX_CONTACTS=300

--- a/variants/xiao_c6/platformio.ini
+++ b/variants/xiao_c6/platformio.ini
@@ -30,7 +30,7 @@ build_src_filter = ${esp32c6_base.build_src_filter}
   +<../variants/xiao_c6>
   +<XiaoC6Board.cpp>
 
-[env:Xiao_C6_repeater]
+[env:Xiao_C6_repeater_]
 extends = Xiao_C6
 build_src_filter = ${Xiao_C6.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
@@ -47,7 +47,7 @@ lib_deps =
   ${Xiao_C6.lib_deps}
 ;  ${esp32_ota.lib_deps}
 
-[env:Xiao_C6_companion_radio_ble]
+[env:Xiao_C6_companion_radio_ble_]
 extends = Xiao_C6
 build_flags = ${Xiao_C6.build_flags}
   -D MAX_CONTACTS=300
@@ -90,10 +90,10 @@ build_flags =
   -D SX126X_RX_BOOSTED_GAIN=1
   -D USE_XIAO_ESP32C6_EXTERNAL_ANTENNA=1
 
-[env:Meshimi_repeater]
+[env:Meshimi_repeater_]
 extends = Meshimi
 build_src_filter = ${Meshimi.build_src_filter}
-                   +<../examples/simple_repeater/*.cpp>
+  +<../examples/simple_repeater/*.cpp>
 build_flags =
   ${Meshimi.build_flags}
   -D ADVERT_NAME='"Meshimi Repeater"'
@@ -104,7 +104,7 @@ build_flags =
 lib_deps =
   ${Meshimi.lib_deps}
 
-[env:Meshimi_companion_radio_ble]
+[env:Meshimi_companion_radio_ble_]
 extends = Meshimi
 build_flags = ${Meshimi.build_flags}
   -D MAX_CONTACTS=300
@@ -115,9 +115,9 @@ build_flags = ${Meshimi.build_flags}
   -D ENABLE_PRIVATE_KEY_IMPORT=1
   -D ENABLE_PRIVATE_KEY_EXPORT=1
 build_src_filter = ${Meshimi.build_src_filter}
-                   +<helpers/esp32/*.cpp>
-                   -<helpers/esp32/ESPNOWRadio.cpp>
-                   +<../examples/companion_radio/*.cpp>
+  +<helpers/esp32/*.cpp>
+  -<helpers/esp32/ESPNOWRadio.cpp>
+  +<../examples/companion_radio/*.cpp>
 lib_deps =
   ${Meshimi.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -147,7 +147,7 @@ build_flags =
   -USX126X_DIO2_AS_RF_SWITCH
   -USX126X_DIO3_TCXO_VOLTAGE
 
-[env:WHY2025_badge_repeater]
+[env:WHY2025_badge_repeater_]
 extends = WHY2025_badge
 build_src_filter = ${WHY2025_badge.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
@@ -164,7 +164,7 @@ lib_deps =
   ${WHY2025_badge.lib_deps}
 ;  ${esp32_ota.lib_deps}
 
-[env:WHY2025_badge_companion_radio_ble]
+[env:WHY2025_badge_companion_radio_ble_]
 extends = WHY2025_badge
 build_flags = ${WHY2025_badge.build_flags}
   -D MAX_CONTACTS=300


### PR DESCRIPTION
* renamed esp32c6 variants, so they are not included in build/release
* added disclaimer about esp32c6 pioarduino builds