### PR TITLE
Refactor DataStore to use openRead() and openWrite()

### DIFF
--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -515,7 +515,7 @@ uint8_t DataStore::getBlobByKey(const uint8_t key[], int key_len, uint8_t dest_b
 bool DataStore::putBlobByKey(const uint8_t key[], int key_len, const uint8_t src_buf[], uint8_t len) {
   if (len < PUB_KEY_SIZE+4+SIGNATURE_SIZE || len > MAX_ADVERT_PKT_LEN) return false;
   checkAdvBlobFile();
-  File file = openWrite(_getContactsChannelsFS(), "/adv_blobs");
+  File file = _getContactsChannelsFS()->open("/adv_blobs", FILE_O_WRITE);
   if (file) {
     uint32_t pos = 0, found_pos = 0;
     uint32_t min_timestamp = 0xFFFFFFFF;


### PR DESCRIPTION
refactored loadPrefsInt(), loadContacts(), loadChannels(), getBlobByKey() and putBlobByKey() to use openRead() and openWrite()

This gets rid of a few of the architecture ifdefs since that's already handled for us in openRead and openWrite.

Tested on nRF52 and ESP32, but should be fine for STM32 and RP2040 since it was already done this way elsewhere in DataStore (saveContacts for example already used openWrite with no arch ifdefs).