### PR TITLE
Add "Quick Messages" screen to new UI

### DIFF
--- a/examples/companion_radio/ui-new/QuickMsg.cpp
+++ b/examples/companion_radio/ui-new/QuickMsg.cpp
@@ -1,0 +1,127 @@
+#include "QuickMsg.h"
+
+#if UI_QUICK_MSG
+#include "../MyMesh.h"
+
+#ifndef COUNTOF
+  #define COUNTOF(x) sizeof(x) / sizeof(x[0])
+#endif
+
+static constexpr const char* messages[] {
+  "ping", "ack", "yes", "no", "test"
+};
+static constexpr size_t messages_count = COUNTOF(messages);
+
+QuickMsgScreen::QuickMsgScreen(UITask* task)
+  : _task(task) {
+}
+
+int QuickMsgScreen::render(DisplayDriver& display) {
+  display.setColor(DisplayDriver::YELLOW);
+  display.setTextSize(2);
+  display.drawTextCentered(display.width() / 2, 2, "quick messages");
+
+  display.setColor(DisplayDriver::GREEN);
+  display.setTextSize(1);
+  display.setCursor(2, _row_defs[0]);
+  display.print("message:");
+  display.setCursor(42, _row_defs[0]);
+  display.print(getMessageText());
+
+  display.setCursor(2, _row_defs[1]);
+  display.print("channel:");
+  display.setCursor(42, _row_defs[1]);
+  display.print(getChannelName());
+
+  display.drawTextCentered(display.width() / 2, _row_defs[2], "[send]");
+
+  auto cursor_row = _row_defs[_row];
+  display.drawRect(0, cursor_row - 1, display.width(), 12);
+  return 1000;
+}
+
+bool QuickMsgScreen::handleInput(char c) {
+  switch (c) {
+    case KEY_ENTER:
+      _task->gotoHomeScreen();
+      return true;
+
+    // Move cursor
+    case KEY_PREV:
+    case KEY_LEFT:
+      _row = (_row + 1) % Row::Count;
+      return true;
+
+    // Update value/Use button
+    case KEY_NEXT:
+    case KEY_RIGHT:
+      if (_row == Row::MSG)
+        nextMessage();
+      else if (_row == Row::CHANNEL)
+        nextChannel();
+      else if (_row == Row::SEND)
+        sendMessage();
+      else
+        MESH_DEBUG_PRINTLN("Bad row index");
+      return true;
+    
+    default:
+      _task->showAlert(PRESS_LABEL " to exit", 1000);
+      break;
+  }
+
+  return false;
+}
+
+void QuickMsgScreen::nextMessage() {
+  _msg_ix = (_msg_ix + 1) % messages_count;
+}
+
+void QuickMsgScreen::nextChannel() {
+#ifndef MAX_GROUP_CHANNELS
+  _channel_ix = 0;
+  return;
+#else
+  ChannelDetails details;
+  _channel_ix = _channel_ix + 1 % MAX_GROUP_CHANNELS;
+
+  the_mesh.getChannel(_channel_ix, details);
+
+  // Channel slots are static, only cycle through valid entries.
+  if (strlen(details.name) == 0)
+    _channel_ix = 0;
+  else
+    strcpy(_channel_name, details.name);
+#endif
+}
+
+void QuickMsgScreen::sendMessage() {
+  ChannelDetails details;
+  bool sent = false;
+
+  if (the_mesh.getChannel(_channel_ix, details)) {
+    auto now = the_mesh.getRTCClock()->getCurrentTime();
+    auto name = the_mesh.getNodeName();
+    auto text = getMessageText();
+    auto len = strlen(text);
+
+    if (the_mesh.sendGroupMessage(now, details.channel, name, text, len))
+      sent = true;
+  }
+
+  if (sent)
+    _task->showAlert("Message sent!", 1000);
+  else
+    _task->showAlert("Message failed.", 1000);
+}
+
+const char* QuickMsgScreen::getMessageText() {
+  // TODO: special messages like GPS position and node name.
+  return messages[_msg_ix];
+}
+
+const char* QuickMsgScreen::getChannelName() {
+  return _channel_ix == 0 ? "public" : _channel_name;
+}
+
+#endif

--- a/examples/companion_radio/ui-new/QuickMsg.cpp
+++ b/examples/companion_radio/ui-new/QuickMsg.cpp
@@ -48,8 +48,7 @@ bool QuickMsgScreen::handleInput(char c) {
       return true;
 
     // Move cursor
-    case KEY_PREV:
-    case KEY_LEFT:
+    case KEY_SELECT:
       _row = (_row + 1) % Row::Count;
       return true;
 
@@ -67,7 +66,8 @@ bool QuickMsgScreen::handleInput(char c) {
       return true;
 
     // Prev value
-    case KEY_SELECT:
+    case KEY_PREV:
+    case KEY_LEFT:
       if (_row == Row::MSG)
         nextMessage(/*fwd=*/false);
       else if (_row == Row::CHANNEL)
@@ -113,8 +113,10 @@ void QuickMsgScreen::nextChannel(bool fwd) {
   the_mesh.getChannel(_channel_ix, details);
 
   if (fwd) {
-    // Moving forward. Reset to 0 on first invalid channel.
-    if (details.name[0] == 0)
+    // Moving forward. Find next valid channel or 0.
+    while (_channel_ix < MAX_GROUP_CHANNELS && details.name[0] == 0)
+      the_mesh.getChannel(++_channel_ix, details);
+    if (_channel_ix >= MAX_GROUP_CHANNELS)
       _channel_ix = 0;
   } else {
     // Moving backward. Find a valid channel or 0.

--- a/examples/companion_radio/ui-new/QuickMsg.cpp
+++ b/examples/companion_radio/ui-new/QuickMsg.cpp
@@ -80,10 +80,13 @@ void QuickMsgScreen::nextMessage() {
   ++_msg_ix;
 
 #if ENV_INCLUDE_GPS
-  // Add a fake index for GPS at the end if enabled.
-  if (_msg_ix == msg_count && _task->getGPSState()) {
+  if (_task->getGPSState()) {
+    // Index at end of messages, add fake GPS entry.
+    if (_msg_ix == msg_count)
+      _kind = MsgKind::GPS;
+
+    // Account for the fake entry.
     msg_count += 1;
-    _kind = MsgKind::GPS;
   }
 #endif
 

--- a/examples/companion_radio/ui-new/QuickMsg.h
+++ b/examples/companion_radio/ui-new/QuickMsg.h
@@ -14,12 +14,23 @@ class QuickMsgScreen : public UIScreen {
     Count
   };
 
+  enum MsgKind {
+    TEXT,
+#if ENV_INCLUDE_GPS
+    GPS,
+#endif
+  };
+
   UITask* _task;
   uint8_t _msg_ix = 0;
   uint8_t _channel_ix = 0;
+  uint8_t _kind = MsgKind::TEXT;
   uint8_t _row = 0;
   uint8_t _row_defs[Row::Count] { 20, 35, 50 };
   char _channel_name[32];  // see ChannelDetails.h
+#if ENV_INCLUDE_GPS
+  char _msg_text[32];  // Buffer for dynamic messages.
+#endif
 
   void nextMessage();
   void nextChannel();

--- a/examples/companion_radio/ui-new/QuickMsg.h
+++ b/examples/companion_radio/ui-new/QuickMsg.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "UITask.h"
+
+#if UI_QUICK_MSG
+#include <helpers/ChannelDetails.h>
+#include <helpers/ui/UIScreen.h>
+
+class QuickMsgScreen : public UIScreen {
+  enum Row {
+    MSG,
+    CHANNEL,
+    SEND,
+    Count
+  };
+
+  UITask* _task;
+  uint8_t _msg_ix = 0;
+  uint8_t _channel_ix = 0;
+  uint8_t _row = 0;
+  uint8_t _row_defs[Row::Count] { 20, 35, 50 };
+  char _channel_name[32];  // see ChannelDetails.h
+
+  void nextMessage();
+  void nextChannel();
+  void sendMessage();
+
+  const char* getMessageText();
+  const char* getChannelName();
+
+public:
+  QuickMsgScreen(UITask* task);
+  int render(DisplayDriver& display) override;
+  bool handleInput(char c) override;
+};
+
+#endif

--- a/examples/companion_radio/ui-new/QuickMsg.h
+++ b/examples/companion_radio/ui-new/QuickMsg.h
@@ -32,8 +32,8 @@ class QuickMsgScreen : public UIScreen {
   char _msg_text[32];  // Buffer for dynamic messages.
 #endif
 
-  void nextMessage();
-  void nextChannel();
+  void nextMessage(bool fwd = true);
+  void nextChannel(bool fwd = true);
   void sendMessage();
 
   const char* getMessageText();

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -3,6 +3,10 @@
 #include "../MyMesh.h"
 #include "target.h"
 
+#if UI_QUICK_MSG
+#include "QuickMsg.h"
+#endif
+
 #ifndef AUTO_OFF_MILLIS
   #define AUTO_OFF_MILLIS     15000   // 15 seconds
 #endif
@@ -18,12 +22,6 @@
 
 #ifndef UI_RECENT_LIST_SIZE
   #define UI_RECENT_LIST_SIZE 4
-#endif
-
-#if UI_HAS_JOYSTICK
-  #define PRESS_LABEL "press Enter"
-#else
-  #define PRESS_LABEL "long press"
 #endif
 
 #include "icons.h"
@@ -84,6 +82,9 @@ class HomeScreen : public UIScreen {
 #endif
 #if UI_SENSORS_PAGE == 1
     SENSORS,
+#endif
+#if UI_QUICK_MSG
+    QUICK_MSG,
 #endif
     SHUTDOWN,
     Count    // keep as last
@@ -357,6 +358,14 @@ public:
       if (sensors_scroll) sensors_scroll_offset = (sensors_scroll_offset+1)%sensors_nb;
       else sensors_scroll_offset = 0;
 #endif
+#if UI_QUICK_MSG
+    } else if (_page == HomePage::QUICK_MSG) {
+      display.setColor(DisplayDriver::YELLOW);
+      display.setTextSize(2);
+      display.drawTextCentered(display.width() / 2, 24, "quick messages");
+      display.setTextSize(1);
+      display.drawTextCentered(display.width() / 2, 40, "enter/exit: " PRESS_LABEL);
+#endif
     } else if (_page == HomePage::SHUTDOWN) {
       display.setColor(DisplayDriver::GREEN);
       display.setTextSize(1);
@@ -364,7 +373,7 @@ public:
         display.drawTextCentered(display.width() / 2, 34, "hibernating...");
       } else {
         display.drawXbm((display.width() - 32) / 2, 18, power_icon, 32, 32);
-        display.drawTextCentered(display.width() / 2, 64 - 11, "hibernate:" PRESS_LABEL);
+        display.drawTextCentered(display.width() / 2, 64 - 11, "hibernate: " PRESS_LABEL);
       }
     }
     return 5000;   // next render after 5000 ms
@@ -409,6 +418,12 @@ public:
     if (c == KEY_ENTER && _page == HomePage::SENSORS) {
       _task->toggleGPS();
       next_sensors_refresh=0;
+      return true;
+    }
+#endif
+#if UI_QUICK_MSG
+    if (c == KEY_ENTER && _page == HomePage::QUICK_MSG) {
+      _task->gotoQuickMsgScreen();
       return true;
     }
 #endif
@@ -544,6 +559,9 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   splash = new SplashScreen(this);
   home = new HomeScreen(this, &rtc_clock, sensors, node_prefs);
   msg_preview = new MsgPreviewScreen(this, &rtc_clock);
+#if UI_QUICK_MSG
+  quick_msg = new QuickMsgScreen(this);
+#endif
   setCurrScreen(splash);
 }
 

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -4,7 +4,7 @@
 #include "target.h"
 
 #ifndef AUTO_OFF_MILLIS
-  #define AUTO_OFF_MILLIS    15000  // 15 seconds
+  #define AUTO_OFF_MILLIS     15000   // 15 seconds
 #endif
 #define BOOT_SCREEN_MILLIS   3000   // 3 seconds
 

--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -782,16 +782,20 @@ void UITask::loop() {
 #endif
 }
 
-char UITask::checkDisplayOn(char c) {
+bool UITask::checkDisplayOn() {
+  // ensures that the display is on and the timer is reset
+  // returns false if the display was previously off
+  bool display_on = false;
   if (_display != NULL) {
     if (!_display->isOn()) {
-      _display->turnOn();  // turn display on and consume event
-      c = 0;
+      _display->turnOn();  // turn display on
+    } else {
+      display_on = true;
     }
     _auto_off = millis() + AUTO_OFF_MILLIS;  // extend auto-off timer
     _next_refresh = 0;  // trigger refresh
   }
-  return c;
+  return display_on;
 }
 
 void UITask::handleLongPress(char c) {
@@ -820,9 +824,9 @@ void UITask::handleTripleClick(char c) {
 
 bool UITask::uiHandleKey(char c) {
   bool handled = false;
-  c = checkDisplayOn(c);
+  bool display_on = checkDisplayOn();
 
-  if (c != 0 && curr) {
+  if (c != 0 && display_on && curr) {
     handled = curr->handleInput(c);
     _auto_off = millis() + AUTO_OFF_MILLIS; // extend auto-off timer
     _next_refresh = 100;  // trigger refresh

--- a/examples/companion_radio/ui-new/UITask.h
+++ b/examples/companion_radio/ui-new/UITask.h
@@ -15,6 +15,12 @@
   #include <helpers/ui/GenericVibration.h>
 #endif
 
+#if UI_HAS_JOYSTICK
+  #define PRESS_LABEL "press Enter"
+#else
+  #define PRESS_LABEL "long press"
+#endif
+
 #include "../AbstractUITask.h"
 #include "../NodePrefs.h"
 
@@ -43,6 +49,9 @@ class UITask : public AbstractUITask {
   UIScreen* splash;
   UIScreen* home;
   UIScreen* msg_preview;
+#if UI_QUICK_MSG
+  UIScreen* quick_msg;
+#endif
   UIScreen* curr;
 
   void userLedHandler();
@@ -67,6 +76,9 @@ public:
   void begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* node_prefs);
 
   void gotoHomeScreen() { setCurrScreen(home); }
+#if UI_QUICK_MSG
+  void gotoQuickMsgScreen() { setCurrScreen(quick_msg); }
+#endif
   void showAlert(const char* text, int duration_millis);
   int  getMsgCount() const { return _msgcount; }
   bool hasDisplay() const { return _display != NULL; }
@@ -75,7 +87,6 @@ public:
   void toggleBuzzer();
   bool getGPSState();
   void toggleGPS();
-
 
   // from AbstractUITask
   void msgRead(int msgcount) override;

--- a/examples/companion_radio/ui-new/UITask.h
+++ b/examples/companion_radio/ui-new/UITask.h
@@ -49,9 +49,11 @@ class UITask : public AbstractUITask {
   
   // Button action handlers
   char checkDisplayOn(char c);
-  char handleLongPress(char c);
-  char handleDoubleClick(char c);
-  char handleTripleClick(char c);
+  void handleLongPress(char c);
+  void handleSingleClick(char c);
+  void handleDoubleClick(char c);
+  void handleTripleClick(char c);
+  bool uiHandleKey(char c);
 
   void setCurrScreen(UIScreen* c);
 

--- a/examples/companion_radio/ui-new/UITask.h
+++ b/examples/companion_radio/ui-new/UITask.h
@@ -48,7 +48,7 @@ class UITask : public AbstractUITask {
   void userLedHandler();
   
   // Button action handlers
-  char checkDisplayOn(char c);
+  bool checkDisplayOn();
   void handleLongPress(char c);
   void handleSingleClick(char c);
   void handleDoubleClick(char c);

--- a/variants/heltec_t114/platformio.ini
+++ b/variants/heltec_t114/platformio.ini
@@ -171,6 +171,7 @@ build_flags =
   -D MAX_GROUP_CHANNELS=40
   -D BLE_PIN_CODE=123456
   -D ENV_INCLUDE_GPS=1   ; enable the GPS page in UI
+  -D UI_QUICK_MSG=1  ; enable quick messages in UI
 ;  -D BLE_DEBUG_LOGGING=1
   -D OFFLINE_QUEUE_SIZE=256
 ;  -D MESH_PACKET_LOGGING=1


### PR DESCRIPTION
This allows users to send a canned message to a channel directly from a companion radio without using the app.
This is useful for when using the radio standalone and when testing with multiple radios.

This PR includes changes the necessary changes from #1032. I'd prefer if #1032 went in separately.
Implementation is hidden behind a build flag that I've enabled only for the Heltec T114 for now.
The set of messages is hard coded.

Usage:
When on the page, long press/Enter to enter the Quick Messages screen.
- double click/Left moves between fields.
- single click/Right cycles forward through the values.
- triple click cycles backward through the values.
- single click on "[send]" will send the message to the selected channel.
- long press will exit the Quick Messages screen.
- If GPS is enabled, one of the message options will be to send your current position.

Tested on T114.

Future ideas:
- allow message set to be configured from the app.

<img width="500" height="500" alt="feature in use" src="https://github.com/user-attachments/assets/86e941d5-37e3-400f-a12a-9757ca25b395" />
