### PR TITLE
No wake up on receiving LoRa packet

### DIFF
--- a/src/helpers/HeltecV3Board.h
+++ b/src/helpers/HeltecV3Board.h
@@ -54,30 +54,36 @@ public:
       long wakeup_source = esp_sleep_get_ext1_wakeup_status();
       if (wakeup_source & (1 << P_LORA_DIO_1)) {  // received a LoRa packet (while in deep sleep)
         startup_reason = BD_STARTUP_RX_PACKET;
+        // DIO1 was configured for wakeup, need to deinit
+        rtc_gpio_deinit((gpio_num_t)P_LORA_DIO_1);
       }
 
+      // NSS hold is always enabled, always need to release it
       rtc_gpio_hold_dis((gpio_num_t)P_LORA_NSS);
-      rtc_gpio_deinit((gpio_num_t)P_LORA_DIO_1);
     }
   }
 
-  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1) {
+  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1, bool enable_wakeup = true) {
     esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
 
-    // Make sure the DIO1 and NSS GPIOs are hold on required levels during deep sleep 
-    rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
-    rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
-
+    // Make sure NSS GPIO is held at required level during deep sleep
     rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
 
-    if (pin_wake_btn < 0) {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet
-    } else {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1) | (1L << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet OR wake btn
-    }
+    if (enable_wakeup)
+    {
+      // Configure DIO1 for wakeup on LoRa packet reception
+      rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
+      rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
 
-    if (secs > 0) {
-      esp_sleep_enable_timer_wakeup(secs * 1000000);
+      if (pin_wake_btn < 0) {
+        esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet
+      } else {
+        esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1) | (1L << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet OR wake btn
+      }
+
+      if (secs > 0) {
+        esp_sleep_enable_timer_wakeup(secs * 1000000);
+      }
     }
 
     // Finally set ESP32 into sleep
@@ -85,7 +91,7 @@ public:
   }
 
   void powerOff() override {
-    enterDeepSleep(0);
+    enterDeepSleep(0, -1, false);  // No wakeup sources - only RESET button can wake
   }
 
   uint16_t getBattMilliVolts() override {


### PR DESCRIPTION
In fact, it puts the device into a complete sleep. :)

The problem is that the current implementation allows the device to wake up with any LoRa packet, even one that isn't related to the node. Therefore, any activity in the mesh network causes the device to turn on, and then it simply drains the battery, since the device remains on and active. 

The presented changes remove wakeup on LoRa activity.

The discussion here https://github.com/meshcore-dev/MeshCore/issues/388#issuecomment-3240836807