### PR TITLE
No wake up on receiving LoRa packet on companion firmware

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -110,6 +110,10 @@ void setup() {
 
   board.begin();
 
+  // Companion radio doesn't need to wake up for listening packets after shutdown
+  // since it doesn't perform retransmission functions
+  board.setEnableWakeup(false);
+  
 #ifdef DISPLAY_CLASS
   DisplayDriver* disp = NULL;
   if (display.begin()) {

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -41,6 +41,7 @@ public:
   virtual void onAfterTransmit() { }
   virtual void reboot() = 0;
   virtual void powerOff() { /* no op */ }
+  virtual void setEnableWakeup(bool enable) { /* no op - override in subclasses that support wakeup control */ }
   virtual uint32_t getGpio() { return 0; }
   virtual void setGpio(uint32_t values) {}
   virtual uint8_t getStartupReason() const = 0;

--- a/src/helpers/HeltecV3Board.h
+++ b/src/helpers/HeltecV3Board.h
@@ -31,11 +31,12 @@
 class HeltecV3Board : public ESP32Board {
 private:
   bool adc_active_state;
+  bool enable_wakeup;
 
 public:
   RefCountedDigitalPin periph_power;
 
-  HeltecV3Board() : periph_power(PIN_VEXT_EN) { }
+  HeltecV3Board() : periph_power(PIN_VEXT_EN), enable_wakeup(true) { }
 
   void begin() {
     ESP32Board::begin();
@@ -54,38 +55,48 @@ public:
       long wakeup_source = esp_sleep_get_ext1_wakeup_status();
       if (wakeup_source & (1 << P_LORA_DIO_1)) {  // received a LoRa packet (while in deep sleep)
         startup_reason = BD_STARTUP_RX_PACKET;
+        // DIO1 was configured for wakeup, need to deinit
+        rtc_gpio_deinit((gpio_num_t)P_LORA_DIO_1);
       }
 
+      // NSS hold is always enabled, always need to release it
       rtc_gpio_hold_dis((gpio_num_t)P_LORA_NSS);
-      rtc_gpio_deinit((gpio_num_t)P_LORA_DIO_1);
     }
   }
 
-  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1) {
+  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1, bool enable_wakeup = true) {
     esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
 
-    // Make sure the DIO1 and NSS GPIOs are hold on required levels during deep sleep 
-    rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
-    rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
-
+    // Make sure NSS GPIO is held at required level during deep sleep
     rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
 
-    if (pin_wake_btn < 0) {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet
-    } else {
-      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1) | (1L << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet OR wake btn
-    }
+    if (enable_wakeup)
+    {
+      // Configure DIO1 for wakeup on LoRa packet reception
+      rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
+      rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
 
-    if (secs > 0) {
-      esp_sleep_enable_timer_wakeup(secs * 1000000);
+      if (pin_wake_btn < 0) {
+        esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet
+      } else {
+        esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1) | (1L << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH);  // wake up on: recv LoRa packet OR wake btn
+      }
+
+      if (secs > 0) {
+        esp_sleep_enable_timer_wakeup(secs * 1000000);
+      }
     }
 
     // Finally set ESP32 into sleep
     esp_deep_sleep_start();   // CPU halts here and never returns!
   }
 
+  void setEnableWakeup(bool enable) override {
+    this->enable_wakeup = enable;
+  }
+
   void powerOff() override {
-    enterDeepSleep(0);
+    enterDeepSleep(0, -1, this->enable_wakeup);
   }
 
   uint16_t getBattMilliVolts() override {


### PR DESCRIPTION
In fact, it puts the device into a complete sleep in companion firmware. :)

The problem is that the current implementation allows the device to wake up with any LoRa packet, even one that isn't related to the node. Therefore, any activity in the mesh network causes the device to turn on, and then it simply drains the battery, since the device remains on and active. 

The presented changes remove wakeup on LoRa activity for **companion firmware**.

The discussion here https://github.com/meshcore-dev/MeshCore/issues/388#issuecomment-3240836807

@IoTThinks Here is a new proposal :)