### PR TITLE
Adding the ability to configure whether or not to wake up from a LoRa packet for the companion firmware

### DIFF
--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -225,6 +225,7 @@ void DataStore::loadPrefsInt(const char *filename, NodePrefs& _prefs, double& no
     file.read((uint8_t *)&_prefs.multi_acks, sizeof(_prefs.multi_acks));                   // 77
     file.read(pad, 2);                                                                     // 78
     file.read((uint8_t *)&_prefs.ble_pin, sizeof(_prefs.ble_pin));                         // 80
+    file.read((uint8_t *)&_prefs.enable_wakeup, sizeof(_prefs.enable_wakeup));             // 84
 
     file.close();
   }
@@ -256,6 +257,7 @@ void DataStore::savePrefs(const NodePrefs& _prefs, double node_lat, double node_
     file.write((uint8_t *)&_prefs.multi_acks, sizeof(_prefs.multi_acks));                   // 77
     file.write(pad, 2);                                                                     // 78
     file.write((uint8_t *)&_prefs.ble_pin, sizeof(_prefs.ble_pin));                         // 80
+    file.write((uint8_t *)&_prefs.enable_wakeup, sizeof(_prefs.enable_wakeup));             // 84
 
     file.close();
   }

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -664,6 +664,10 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
   dirty_contacts_expiry = 0;
   memset(advert_paths, 0, sizeof(advert_paths));
 
+  // Auto-sleep initialization
+  auto_sleep_timer = 0;
+  auto_sleep_enabled = false;
+
   // defaults
   memset(&_prefs, 0, sizeof(_prefs));
   _prefs.airtime_factor = 1.0; // one half
@@ -673,6 +677,7 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
   _prefs.bw = LORA_BW;
   _prefs.cr = LORA_CR;
   _prefs.tx_power_dbm = LORA_TX_POWER;
+  _prefs.enable_wakeup = 0;  // not allow wakeup by default
   //_prefs.rx_delay_base = 10.0f;  enable once new algo fixed
 }
 
@@ -737,6 +742,15 @@ void MyMesh::begin(bool has_display) {
 
   radio_set_params(_prefs.freq, _prefs.bw, _prefs.sf, _prefs.cr);
   radio_set_tx_power(_prefs.tx_power_dbm);
+
+  // Enable auto-sleep if woken up by LoRa packet reception
+  auto_sleep_enabled = (board.getStartupReason() == BD_STARTUP_RX_PACKET);
+  if (auto_sleep_enabled) {
+    auto_sleep_timer = futureMillis(AUTO_SLEEP_TIMEOUT_MS);
+  }
+
+  // Apply wakeup preference to board
+  board.setEnableWakeup(_prefs.enable_wakeup != 0);
 }
 
 const char *MyMesh::getNodeName() {
@@ -1520,6 +1534,21 @@ void MyMesh::checkCLIRescueCmd() {
         _prefs.ble_pin = atoi(&config[4]);
         savePrefs();
         Serial.printf("  > pin is now %06d\n", _prefs.ble_pin);
+      } else if (memcmp(config, "wakeup ", 7) == 0) {
+        const char* value = &config[7];
+        if (strcmp(value, "on") == 0 || strcmp(value, "1") == 0) {
+          _prefs.enable_wakeup = 1;
+          savePrefs();
+          board.setEnableWakeup(true);  // apply immediately
+          Serial.println("  > wakeup enabled (LoRa can wake device)");
+        } else if (strcmp(value, "off") == 0 || strcmp(value, "0") == 0) {
+          _prefs.enable_wakeup = 0;
+          savePrefs();
+          board.setEnableWakeup(false);  // apply immediately
+          Serial.println("  > wakeup disabled (only RESET button can wake)");
+        } else {
+          Serial.printf("  Error: invalid value '%s', use 'on' or 'off'\n", value);
+        }
       } else {
         Serial.printf("  Error: unknown config: %s\n", config);
       }
@@ -1661,8 +1690,19 @@ void MyMesh::checkCLIRescueCmd() {
 
     } else if (strcmp(cli_command, "reboot") == 0) {
       board.reboot();  // doesn't return
+    } else if (strcmp(cli_command, "help") == 0 || strcmp(cli_command, "?") == 0) {
+      Serial.println("Available commands:");
+      Serial.println("  set pin <code>       - change BLE PIN code");
+      Serial.println("  set wakeup on/off    - enable/disable wakeup from LoRa");
+      Serial.println("  rebuild              - erase and rebuild filesystem");
+      Serial.println("  erase                - erase filesystem");
+      Serial.println("  ls [path]            - list files (UserData/ or ExtraFS/)");
+      Serial.println("  cat <path>           - show file content (hex)");
+      Serial.println("  rm <path>            - remove file");
+      Serial.println("  reboot               - reboot device");
+      Serial.println("  help or ?            - show this help");
     } else {
-      Serial.println("  Error: unknown command");
+      Serial.println("  Error: unknown command (type 'help' for commands)");
     }
 
     cli_command[0] = 0;  // reset command buffer
@@ -1711,9 +1751,25 @@ void MyMesh::loop() {
     dirty_contacts_expiry = 0;
   }
 
+  // check auto-sleep timer
+  if (auto_sleep_enabled && millisHasNowPassed(auto_sleep_timer)) {
+    MESH_DEBUG_PRINTLN("[MyMesh] Auto-sleep timeout, entering deep sleep");
+    board.powerOff();  // enter deep sleep with LoRa wakeup
+  }
+
 #ifdef DISPLAY_CLASS
   if (_ui) _ui->setHasConnection(_serial->isConnected());
 #endif
+}
+
+mesh::DispatcherAction MyMesh::onRecvPacket(mesh::Packet* pkt) {
+  // reset timer on any packet activity
+  if (auto_sleep_enabled) {
+    MESH_DEBUG_PRINTLN("[MyMesh] Packet received, resetting auto-sleep timer");
+    auto_sleep_timer = futureMillis(AUTO_SLEEP_TIMEOUT_MS);
+  }
+
+  return BaseChatMesh::onRecvPacket(pkt);  // call parent implementation
 }
 
 bool MyMesh::advert() {

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -75,6 +75,9 @@
 #define REQ_TYPE_KEEP_ALIVE             0x02
 #define REQ_TYPE_GET_TELEMETRY_DATA     0x03
 
+/*------------ Auto-sleep Configuration --------------*/
+#define AUTO_SLEEP_TIMEOUT_MS 5000  // 5 seconds
+
 struct AdvertPath {
   uint8_t pubkey_prefix[7];
   uint8_t path_len;
@@ -102,6 +105,7 @@ public:
   int  getRecentlyHeard(AdvertPath dest[], int max_num);
 
 protected:
+  mesh::DispatcherAction onRecvPacket(mesh::Packet* pkt) override;
   float getAirtimeBudgetFactor() const override;
   int getInterferenceThreshold() const override;
   int calcRxDelay(float score, uint32_t air_time) const override;
@@ -215,6 +219,10 @@ private:
 
   #define ADVERT_PATH_TABLE_SIZE   16
   AdvertPath advert_paths[ADVERT_PATH_TABLE_SIZE]; // circular table
+
+  // Auto-sleep state
+  unsigned long auto_sleep_timer;
+  bool auto_sleep_enabled;
 };
 
 extern MyMesh the_mesh;

--- a/examples/companion_radio/NodePrefs.h
+++ b/examples/companion_radio/NodePrefs.h
@@ -24,4 +24,5 @@ struct NodePrefs {  // persisted to file
   float rx_delay_base;
   uint32_t ble_pin;
   uint8_t  advert_loc_policy;
+  uint8_t  enable_wakeup;  // 1 = allow wakeup from LoRa/timer, 0 = only RESET button
 };

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -111,15 +111,17 @@ void setup() {
   board.begin();
 
 #ifdef DISPLAY_CLASS
-  DisplayDriver* disp = NULL;
-  if (display.begin()) {
-    disp = &display;
-    disp->startFrame();
-  #ifdef ST7789
-    disp->setTextSize(2);
-  #endif
-    disp->drawTextCentered(disp->width() / 2, 28, "Loading...");
-    disp->endFrame();
+    DisplayDriver *disp = NULL;
+  if (board.getStartupReason() != BD_STARTUP_RX_PACKET) {
+    if (display.begin()) {
+      disp = &display;
+      disp->startFrame();
+#ifdef ST7789
+      disp->setTextSize(2);
+#endif
+      disp->drawTextCentered(disp->width() / 2, 28, "Loading...");
+      disp->endFrame();
+    }
   }
 #endif
 

--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -45,6 +45,7 @@ public:
   virtual void setGpio(uint32_t values) {}
   virtual uint8_t getStartupReason() const = 0;
   virtual bool startOTAUpdate(const char* id, char reply[]) { return false; }   // not supported
+  virtual void setEnableWakeup(bool enable) { /* no op - override in subclasses that support wakeup control */ }
 };
 
 /**


### PR DESCRIPTION
## Overview
This PR implements configurable wakeup control for companion radio devices, allowing users to choose whether the device can be woken from deep sleep by LoRa packet reception or only by the RESET button.

## Key Changes

### 1. **Wakeup Configuration**
- Added `enable_wakeup` field to `NodePrefs` structure for persistent storage
- Implemented Rescue Mode command `set wakeup on/off` to control wakeup behavior
- Added `setEnableWakeup()` method to `MainBoard` interface for runtime control

### 2. **Auto-Sleep with Packet Activity Detection**
- Implemented auto-sleep timer (5 seconds) that activates when device wakes from LoRa packet
- Timer resets on any received packet to keep device awake during active communication
- Automatic deep sleep entry when timeout expires with no packet activity
- Overridden `onRecvPacket()` in `MyMesh` to handle timer reset logic

### 3. **Enhanced Deep Sleep Control (HeltecV3Board)**
- Modified `enterDeepSleep()` to accept optional `wakeup` parameter
- Conditional DIO1 configuration: only set up LoRa wakeup when enabled
- NSS pin hold is always maintained regardless of wakeup setting
- Proper GPIO deinitialization on wakeup to prevent conflicts

### 4. **Display Optimization**
- Display initialization now skipped when device wakes from LoRa packet
- Display only initializes on normal boot or user-triggered wakeup

### 5. **Improved CLI User Experience in Rescue Mode**
- Added `help` command listing all available Rescue Mode commands
- Enhanced error messages to guide users to help command
- Immediate feedback when wakeup setting is changed

**Default Behavior:**
- Wakeup is **disabled by default** (only RESET button wakes device)
- Auto-sleep activates only when woken by LoRa packet
- 5-second timeout with automatic reset on packet activity

## Use Cases

1. **Battery Conservation Mode** (`wakeup off`): Device stays in deep sleep until manually reset, maximizing battery life
2. **Active Monitoring Mode** (`wakeup on`): Device wakes on LoRa packets, processes them, and returns to sleep if no further activity

*This PR as a possible alternative implementation of #1061.*
*These changes in the context of the problem:https://github.com/meshcore-dev/MeshCore/issues/388#issuecomment-3240836807*