### PR TITLE
T114: Allow GPS to sleep

### DIFF
--- a/variants/heltec_t114/target.cpp
+++ b/variants/heltec_t114/target.cpp
@@ -63,8 +63,10 @@ bool T114SensorManager::begin() {
   Serial1.begin(9600);
 
   // Try to detect if GPS is physically connected to determine if we should expose the setting
+  pinMode(VEXT_EN, OUTPUT);
   pinMode(GPS_EN, OUTPUT);
-  digitalWrite(GPS_EN, HIGH);  // Power on GPS
+  digitalWrite(VEXT_EN, HIGH);  // Power on GPS
+  digitalWrite(GPS_EN, HIGH); // GPS_EN is GPS_WAKEUP
 
   // Give GPS a moment to power up and send data
   delay(1500);
@@ -76,6 +78,7 @@ bool T114SensorManager::begin() {
     MESH_DEBUG_PRINTLN("GPS detected");
   } else {
     MESH_DEBUG_PRINTLN("No GPS detected");
+    digitalWrite(VEXT_EN, LOW);
   }
   digitalWrite(GPS_EN, LOW);  // Power off GPS until the setting is changed
 

--- a/variants/heltec_t114/variant.h
+++ b/variants/heltec_t114/variant.h
@@ -115,8 +115,14 @@
 ////////////////////////////////////////////////////////////////////////////////
 // GPS
 
-#define GPS_EN                  (21)
+#define VEXT_EN                 (21)
+
 #define GPS_RESET               (38)
+#define GPS_WAKE_UP             (34)
+#define GPS_PPS                 (36)
+
+// Send GPS to sleep, Vext off still has GPS active
+#define GPS_EN                  GPS_WAKE_UP
 
 ////////////////////////////////////////////////////////////////////////////////
 // TFT


### PR DESCRIPTION
Allow GPS to go to sleep on T114, VEXT needs to be active to control sleep modes of GPS module. If VEXT is turned off with GPS connected, GPS will be always active. Therefore use GPS_WAKEUP to enable/disable GPS instead of VEXT. This commit sets GPS_EN to GPS_WAKEUP.