### PR TITLE
adding support for RP2040-MiniPill-LoRa Board

### DIFF
--- a/variants/rp2040_minipill_lora/RP2040MiniPillLoRaBoard.cpp
+++ b/variants/rp2040_minipill_lora/RP2040MiniPillLoRaBoard.cpp
@@ -1,0 +1,28 @@
+#include <Arduino.h>
+#include <Wire.h>
+
+#include "RP2040MiniPillLoRaBoard.h"
+
+
+void RP2040MiniPillLoRaBoard::begin() {
+  // for future use, sub-classes SHOULD call this from their begin()
+  startup_reason = BD_STARTUP_NORMAL;
+  pinMode(PIN_VBAT_READ, INPUT);
+#ifdef PIN_USER_BTN
+  pinMode(PIN_USER_BTN, INPUT_PULLUP);
+#endif
+
+#if defined(PIN_BOARD_SDA) && defined(PIN_BOARD_SCL)
+  Wire.setPins(PIN_BOARD_SDA, PIN_BOARD_SCL);
+#endif
+
+  Wire.begin();
+
+  //pinMode(SX126X_POWER_EN, OUTPUT);
+  //digitalWrite(SX126X_POWER_EN, HIGH);
+  delay(10);   // give sx1262 some time to power up
+}
+
+bool RP2040MiniPillLoRaBoard::startOTAUpdate(const char* id, char reply[]) {
+  return false;
+}

--- a/variants/rp2040_minipill_lora/RP2040MiniPillLoRaBoard.h
+++ b/variants/rp2040_minipill_lora/RP2040MiniPillLoRaBoard.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <MeshCore.h>
+#include <Arduino.h>
+
+// built-ins
+#define  PIN_VBAT_READ    28
+#define  ADC_MULTIPLIER   (3.1f * 3.3f * 1000) // MT Uses 3.1
+#define  PIN_LED_BUILTIN  LED_BUILTIN
+
+class RP2040MiniPillLoRaBoard : public mesh::MainBoard {
+protected:
+  uint8_t startup_reason;
+
+public:
+  void begin();
+  uint8_t getStartupReason() const override { return startup_reason; }
+
+  void onBeforeTransmit() override {
+    digitalWrite(LED_BUILTIN, HIGH);   // turn TX LED on
+  }
+
+  void onAfterTransmit() override {
+    digitalWrite(LED_BUILTIN, LOW);   // turn TX LED off
+  }
+
+  #define BATTERY_SAMPLES 8
+
+  uint16_t getBattMilliVolts() override {
+    analogReadResolution(12);
+
+    uint32_t raw = 0;
+    for (int i = 0; i < BATTERY_SAMPLES; i++) {
+      raw += analogRead(PIN_VBAT_READ);
+    }
+    raw = raw / BATTERY_SAMPLES;
+
+    return (ADC_MULTIPLIER * raw) / 4096;
+  }
+
+  const char* getManufacturerName() const override {
+    return "RP2040 Minipill LoRa";
+  }
+
+  void reboot() override {
+    //NVIC_SystemReset();
+    rp2040.reboot();
+  }
+
+  bool startOTAUpdate(const char* id, char reply[]) override;
+};

--- a/variants/rp2040_minipill_lora/platformio.ini
+++ b/variants/rp2040_minipill_lora/platformio.ini
@@ -1,0 +1,108 @@
+[rp2040_minipill_lora]
+extends = rp2040_base
+board = pico
+board_build.filesystem_size = 0.5m
+build_flags = ${rp2040_base.build_flags}
+  -I variants/rp2040_minipill_lora
+;  -D HW_SPI1_DEVICE
+  -D RADIO_CLASS=CustomSX1276
+  -D WRAPPER_CLASS=CustomSX1276Wrapper
+  -D SX127X_CURRENT_LIMIT=120
+  -D LORA_TX_POWER=16
+  -D P_LORA_DIO_0=1
+  -D P_LORA_DIO_1=RADIOLIB_NC
+  -D P_LORA_RESET=RADIOLIB_NC
+  -D P_LORA_NSS=5 ; CS
+  -D P_LORA_SCLK=2
+  -D P_LORA_MOSI=3
+  -D P_LORA_MISO=4
+  -D LED_BUILTIN=23
+; Debug options
+  ; -D DEBUG_RP2040_WIRE=1
+  ; -D DEBUG_RP2040_SPI=1
+  ; -D DEBUG_RP2040_CORE=1
+  ; -D RADIOLIB_DEBUG_SPI=1
+  ; -D DEBUG_RP2040_PORT=Serial
+build_src_filter = ${rp2040_base.build_src_filter}
+  +<RP2040MiniPillLoRaBoard.cpp>
+  +<../variants/rp2040_minipill_lora>
+lib_deps = ${rp2040_base.lib_deps}
+
+[env:RP2040MiniPillLoRa_repeater]
+extends = rp2040_minipill_lora
+build_flags = ${rp2040_minipill_lora.build_flags}
+  -D ADVERT_NAME='"RP2040-MiniPill-LoRa Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${rp2040_minipill_lora.build_src_filter}
+  +<../examples/simple_repeater>
+
+[env:RP2040MiniPillLoRa_room_server]
+extends = rp2040_minipill_lora
+build_flags = ${rp2040_minipill_lora.build_flags}
+  -D ADVERT_NAME='"Test Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${rp2040_minipill_lora.build_src_filter}
+  +<../examples/simple_room_server>
+
+[env:RP2040MiniPillLoRa_companion_radio_usb]
+extends = rp2040_minipill_lora
+build_flags = ${rp2040_minipill_lora.build_flags}
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=8
+; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
+; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
+build_src_filter = ${rp2040_minipill_lora.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+lib_deps = ${rp2040_minipill_lora.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+; [env:PicoW_companion_radio_ble]
+; extends = rp2040_minipill_lora
+; build_flags = ${rp2040_minipill_lora.build_flags}
+;   -D MAX_CONTACTS=100
+;   -D MAX_GROUP_CHANNELS=8
+;   -D BLE_PIN_CODE=123456
+;   -D BLE_DEBUG_LOGGING=1
+; ;  -D MESH_PACKET_LOGGING=1
+; ;  -D MESH_DEBUG=1
+; build_src_filter = ${rp2040_minipill_lora.build_src_filter}
+;   +<../examples/companion_radio/*.cpp>
+; lib_deps = ${rp2040_minipill_lora.lib_deps}
+;   densaugeo/base64 @ ~1.4.0
+
+; [env:PicoW_companion_radio_wifi]
+; extends = rp2040_minipill_lora
+; build_flags = ${rp2040_minipill_lora.build_flags}
+;   -D MAX_CONTACTS=100
+;   -D MAX_GROUP_CHANNELS=8
+;   -D WIFI_DEBUG_LOGGING=1
+;   -D WIFI_SSID='"myssid"'
+;   -D WIFI_PWD='"mypwd"'
+; ;  -D MESH_PACKET_LOGGING=1
+; ;  -D MESH_DEBUG=1
+; build_src_filter = ${rp2040_minipill_lora.build_src_filter}
+;   +<../examples/companion_radio/*.cpp>
+; lib_deps = ${rp2040_minipill_lora.lib_deps}
+;   densaugeo/base64 @ ~1.4.0
+
+[env:RP2040MiniPillLoRa_terminal_chat]
+extends = rp2040_minipill_lora
+build_flags = ${rp2040_minipill_lora.build_flags}
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${rp2040_minipill_lora.build_src_filter}
+  +<../examples/simple_secure_chat/main.cpp>
+lib_deps = ${rp2040_minipill_lora.lib_deps}
+  densaugeo/base64 @ ~1.4.0

--- a/variants/rp2040_minipill_lora/target.cpp
+++ b/variants/rp2040_minipill_lora/target.cpp
@@ -1,0 +1,49 @@
+#include <Arduino.h>
+#include <helpers/ArduinoHelpers.h>
+
+#include "target.h"
+
+RP2040MiniPillLoRaBoard board;
+
+RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_0, P_LORA_RESET, P_LORA_DIO_1, SPI);
+WRAPPER_CLASS radio_driver(radio, board);
+
+VolatileRTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+SensorManager sensors;
+
+bool radio_init() {
+  rtc_clock.begin(Wire);
+
+  SPI.setSCK(P_LORA_SCLK);
+  SPI.setTX(P_LORA_MOSI);
+  SPI.setRX(P_LORA_MISO);
+
+  pinMode(P_LORA_NSS, OUTPUT);
+  digitalWrite(P_LORA_NSS, HIGH);
+
+  SPI.begin(false);
+  
+  //passing NULL skips init of SPI
+  return radio.std_init(NULL);
+}
+
+uint32_t radio_get_rng_seed() {
+  return radio.random(0x7FFFFFFF);
+}
+
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr) {
+  radio.setFrequency(freq);
+  radio.setSpreadingFactor(sf);
+  radio.setBandwidth(bw);
+  radio.setCodingRate(cr);
+}
+
+void radio_set_tx_power(uint8_t dbm) {
+  radio.setOutputPower(dbm);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);  // create new random identity
+}

--- a/variants/rp2040_minipill_lora/target.h
+++ b/variants/rp2040_minipill_lora/target.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+
+#include <RadioLib.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <RP2040MiniPillLoRaBoard.h>
+#include <helpers/radiolib/CustomSX1276Wrapper.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/SensorManager.h>
+
+extern RP2040MiniPillLoRaBoard board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern SensorManager sensors;
+
+bool radio_init();
+uint32_t radio_get_rng_seed();
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr);
+void radio_set_tx_power(uint8_t dbm);
+mesh::LocalIdentity radio_new_identity();


### PR DESCRIPTION
We have developed a board in the community based on the popular Raspberry Pi Pico in to be able to develop simple and straightforward LoRa applications. At the beginning , we added MicroPython modules for the integration of LoRaWAN (see our [HACKADAY.IO](https://hackaday.io/project/196814-rp2040-minipill-lora) post). Now we have successfully tested many Meshtasitc as well as MeshCore functions.  

<img width="1910" height="666" alt="attatchment BjAEGX" src="https://github.com/user-attachments/assets/bb7bddbd-267a-4a19-a69f-554e01601181" />


