### PR TITLE
Refactor float conversion in CommonCLI

### DIFF
--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -228,8 +228,8 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
       strcpy(tmp, &command[10]);
       const char *parts[5];
       int num = mesh::Utils::parseTextParts(tmp, parts, 5);
-      float freq  = num > 0 ? atof(parts[0]) : 0.0f;
-      float bw    = num > 1 ? atof(parts[1]) : 0.0f;
+      float freq  = num > 0 ? strtof(parts[0], nullptr) : 0.0f;
+      float bw    = num > 1 ? strtof(parts[1], nullptr) : 0.0f;
       uint8_t sf  = num > 2 ? atoi(parts[2]) : 0;
       uint8_t cr  = num > 3 ? atoi(parts[3]) : 0;
       int temp_timeout_mins  = num > 4 ? atoi(parts[4]) : 0;
@@ -284,7 +284,7 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
       } else if (memcmp(config, "radio", 5) == 0) {
         char freq[16], bw[16];
         strcpy(freq, StrHelper::ftoa(_prefs->freq));
-        strcpy(bw, StrHelper::ftoa(_prefs->bw));
+        strcpy(bw, StrHelper::ftoa3(_prefs->bw));
         sprintf(reply, "> %s,%s,%d,%d", freq, bw, (uint32_t)_prefs->sf, (uint32_t)_prefs->cr);
       } else if (memcmp(config, "rxdelay", 7) == 0) {
         sprintf(reply, "> %s", StrHelper::ftoa(_prefs->rx_delay_base));
@@ -407,8 +407,8 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
         strcpy(tmp, &config[6]);
         const char *parts[4];
         int num = mesh::Utils::parseTextParts(tmp, parts, 4);
-        float freq  = num > 0 ? atof(parts[0]) : 0.0f;
-        float bw    = num > 1 ? atof(parts[1]) : 0.0f;
+        float freq  = num > 0 ? strtof(parts[0], nullptr) : 0.0f;
+        float bw    = num > 1 ? strtof(parts[1], nullptr) : 0.0f;
         uint8_t sf  = num > 2 ? atoi(parts[2]) : 0;
         uint8_t cr  = num > 3 ? atoi(parts[3]) : 0;
         if (freq >= 300.0f && freq <= 2500.0f && sf >= 5 && sf <= 12 && cr >= 5 && cr <= 8 && bw >= 7.0f && bw <= 500.0f) {

--- a/src/helpers/TxtDataHelpers.cpp
+++ b/src/helpers/TxtDataHelpers.cpp
@@ -140,6 +140,19 @@ const char* StrHelper::ftoa(float f) {
   return tmp;
 }
 
+const char* StrHelper::ftoa3(float f) {
+  static char s[16];
+  int v = (int)(f * 1000.0f + (f >= 0 ? 0.5f : -0.5f)); // rounded ×1000
+  int w = v / 1000;                                     // whole
+  int d = abs(v % 1000);                                // decimals
+  snprintf(s, sizeof(s), "%d.%03d", w, d);
+  for (int i = strlen(s) - 1; i > 0 && s[i] == '0'; i--)
+      s[i] = 0;
+  int L = strlen(s);
+  if (s[L - 1] == '.') s[L - 1] = 0;
+  return s;
+}
+
 uint32_t StrHelper::fromHex(const char* src) {
   uint32_t n = 0;
   while (*src) {

--- a/src/helpers/TxtDataHelpers.h
+++ b/src/helpers/TxtDataHelpers.h
@@ -12,6 +12,7 @@ public:
   static void strncpy(char* dest, const char* src, size_t buf_sz);
   static void strzcpy(char* dest, const char* src, size_t buf_sz);   // pads with trailing nulls
   static const char* ftoa(float f);
+  static const char* ftoa3(float f); //Converts float to string with 3 decimal places
   static bool isBlank(const char* str);
   static uint32_t fromHex(const char* src);
 };


### PR DESCRIPTION
Use strtof for improved precision and add ftoa3 function for formatting floats with three decimal places in TxtDataHelpers to fix display issue in app and repeater config ui in web

REPO:
1. Flash a repeater
2. Connect over lora
3. Set bw to 42.7 KHZ

It will revert back due to converting a double to a float.

REPO2:
1.Flash Repeater
2. Apply float fix
3. Set to say 20.8
4. try to get value via app or web cli repeater config It wil show blank because it doesnt return a good value. It would be something like 20.7999992 which the app and web apps dont like so the ftoa3 rounds it and returns a 3 decimal point float


The ftoa3 is only applied to the bw string return. I tested all the BW options and they appear and work as they should. Also testing settings different frequencies and it works as it should. 

strtof() is safer and more predictable than atof(), avoids silent parsing bugs, avoids locale issues, is faster, smaller, and gives more accurate float results