### PR TITLE
companion: suspend radio when hibernating

### DIFF
--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -650,6 +650,7 @@ void UITask::shutdown(bool restart){
     _board->reboot();
   } else {
     _display->turnOff();
+    radio_driver.powerOff();
     _board->powerOff();
   }
 }

--- a/src/helpers/radiolib/CustomSX1262Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1262Wrapper.h
@@ -15,6 +15,8 @@ public:
   float getLastRSSI() const override { return ((CustomSX1262 *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomSX1262 *)_radio)->getSNR(); }
 
+  virtual void powerOff() override { ((CustomSX1262 *)_radio)->sleep(false); }
+
   float packetScore(float snr, int packet_len) override {
     int sf = ((CustomSX1262 *)_radio)->spreadingFactor;
     return packetScoreInt(snr, sf, packet_len);

--- a/src/helpers/radiolib/RadioLibWrappers.h
+++ b/src/helpers/radiolib/RadioLibWrappers.h
@@ -50,6 +50,8 @@ public:
   virtual float getLastRSSI() const override;
   virtual float getLastSNR() const override;
 
+  virtual void powerOff() { /* no op */ }
+
   float packetScore(float snr, int packet_len) override { return packetScoreInt(snr, 10, packet_len); }  // assume sf=10
 };
 

--- a/variants/heltec_t114/T114Board.h
+++ b/variants/heltec_t114/T114Board.h
@@ -48,6 +48,13 @@ public:
   }
 
   void powerOff() override {
+    #ifdef LED_PIN
+    digitalWrite(LED_PIN, HIGH);
+    #endif
+    #if ENV_INCLUDE_GPS == 1
+    pinMode(GPS_EN, OUTPUT);
+    digitalWrite(GPS_EN, LOW);
+    #endif
     sd_power_system_off();
   }
 


### PR DESCRIPTION
This should significantly reduce power consumption in the hibernation.

Also explicitly shutdown peripherals (GPS, LED) on Heltec T114.

Fixes: #1014