### PR TITLE
Add devcontainer configuration for vscode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,10 +9,12 @@
 		}
 	},
 	"runArgs": [
-		"--network=host",
 		"--privileged",
-		"--volume",
-		"/dev/bus/usb:/dev/bus/usb"
+		// arch tty* is owned by uucp (986)
+		// debian tty* is owned by uucp (20) - no change needed
+		"--group-add=986",
+		"--network=host",
+		"--volume=/dev/bus/usb:/dev/bus/usb:ro"
 	],
 	"postCreateCommand": {
 		"platformio": "pipx install platformio"


### PR DESCRIPTION
This pull request introduces the configuration for a basic functional MeshCore workspace, which could serve as a foundational for further standardisation (such as code formatting, settings, etc.) down the line, if needed. Devcontainers offer a stable and consistent development environment for multiple users; this pull request has no impact on non-VS Code users or those who choose not to use them.