### PR TITLE
ThinkNode M2: build fix

### DIFF
--- a/variants/thinknode_m2/platformio.ini
+++ b/variants/thinknode_m2/platformio.ini
@@ -145,10 +145,49 @@ build_src_filter = ${ThinkNode_M2.build_src_filter}
   +<helpers/ui/MomentaryButton.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
-
 lib_deps =
   ${ThinkNode_M2.lib_deps}
   densaugeo/base64 @ ~1.4.0
+  end2endzone/NonBlockingRTTTL@^1.3.0
+
+[env:ThinkNode_M2_companion_radio_usb]
+extends = ThinkNode_M2
+build_flags =
+  ${ThinkNode_M2.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
+build_src_filter = ${ThinkNode_M2.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${ThinkNode_M2.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+  end2endzone/NonBlockingRTTTL@^1.3.0
+
+[env:ThinkNode_M2_companion_radio_wifi]
+extends = ThinkNode_M2
+build_flags =
+  ${ThinkNode_M2.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
+  -D WIFI_DEBUG_LOGGING=1
+  -D WIFI_SSID='"myssid"'
+  -D WIFI_PWD='"mypwd"'
+build_src_filter = ${ThinkNode_M2.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${ThinkNode_M2.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+  end2endzone/NonBlockingRTTTL@^1.3.0
 
 [env:ThinkNode_M2_companion_radio_serial]
 extends = ThinkNode_M2


### PR DESCRIPTION
- added missing NonBlockingRTTTL dependency that prevented board to be built
- added USB and WIFI companions