### PR TITLE
Support for RAK11310 WisBlock

### DIFF
--- a/variants/rak11310/RAK11310Board.cpp
+++ b/variants/rak11310/RAK11310Board.cpp
@@ -1,0 +1,30 @@
+#include "RAK11310Board.h"
+
+#include <Arduino.h>
+#include <Wire.h>
+
+void RAK11310Board::begin() {
+  // for future use, sub-classes SHOULD call this from their begin()
+  startup_reason = BD_STARTUP_NORMAL;
+
+#ifdef P_LORA_TX_LED
+  pinMode(P_LORA_TX_LED, OUTPUT);
+#endif
+
+#ifdef PIN_VBAT_READ
+  pinMode(PIN_VBAT_READ, INPUT);
+#endif
+
+#if defined(PIN_BOARD_SDA) && defined(PIN_BOARD_SCL)
+  Wire.setSDA(PIN_BOARD_SDA);
+  Wire.setSCL(PIN_BOARD_SCL);
+#endif
+
+  Wire.begin();
+
+  delay(10); // give sx1262 some time to power up
+}
+
+bool RAK11310Board::startOTAUpdate(const char *id, char reply[]) {
+  return false;
+}

--- a/variants/rak11310/RAK11310Board.h
+++ b/variants/rak11310/RAK11310Board.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <Arduino.h>
+#include <MeshCore.h>
+
+// from https://github.com/RAKWireless/RAK11300-AT-Command-Firmware/blob/9c48409a43620a828d653501d536473200aa33af/RAK11300-AT-Arduino/batt.cpp#L17-L19
+#define VBAT_MV_PER_LSB (0.806F)   // 3.0V ADC range and 12 - bit ADC resolution = 3300mV / 4096
+#define VBAT_DIVIDER (0.6F)		   // 1.5M + 1M voltage divider on VBAT = (1.5M / (1M + 1.5M))
+#define VBAT_DIVIDER_COMP (1.846F) //  // Compensation factor for the VBAT divider
+
+#define PIN_VBAT_READ            26
+#define BATTERY_SAMPLES          8
+#define ADC_MULTIPLIER           (VBAT_DIVIDER_COMP * VBAT_MV_PER_LSB)
+
+class RAK11310Board : public mesh::MainBoard {
+protected:
+  uint8_t startup_reason;
+
+public:
+  void begin();
+  uint8_t getStartupReason() const override { return startup_reason; }
+
+#ifdef P_LORA_TX_LED
+  void onBeforeTransmit() override { digitalWrite(P_LORA_TX_LED, HIGH); }
+  void onAfterTransmit() override { digitalWrite(P_LORA_TX_LED, LOW); }
+#endif
+
+  uint16_t getBattMilliVolts() override {
+#if defined(PIN_VBAT_READ) && defined(ADC_MULTIPLIER)
+    analogReadResolution(12);
+
+    uint32_t raw = 0;
+    for (int i = 0; i < BATTERY_SAMPLES; i++) {
+      raw += analogRead(PIN_VBAT_READ);
+    }
+    raw = raw / BATTERY_SAMPLES;
+
+    return (ADC_MULTIPLIER * raw);
+#else
+    return 0;
+#endif
+  }
+
+  const char *getManufacturerName() const override { return "RAK 11310"; }
+
+  void reboot() override { rp2040.reboot(); }
+
+  bool startOTAUpdate(const char *id, char reply[]) override;
+};

--- a/variants/rak11310/platformio.ini
+++ b/variants/rak11310/platformio.ini
@@ -1,0 +1,132 @@
+; RAK11310
+; Pinout from https://github.com/beegee-tokyo/SX126x-Arduino/blob/6be1f87b84ad4d445a38ec53d65be4425f2383f3/src/boards/mcu/board.cpp#L259
+
+[rak11310]
+extends = rp2040_base
+board = rakwireless_rak11300
+board_build.filesystem_size = 0.5m
+build_flags = ${rp2040_base.build_flags}
+  -I variants/rak11310
+  -D ARDUINO_RAKWIRELESS_RAK11300=1
+  -D SX126X_CURRENT_LIMIT=140
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D P_LORA_DIO_1=29
+  -D P_LORA_NSS=13 ; CS
+  -D P_LORA_RESET=14
+  -D P_LORA_BUSY=15
+  -D P_LORA_SCLK=10
+  -D P_LORA_MISO=12
+  -D P_LORA_MOSI=11
+  -D P_LORA_TX_LED=24 ; green led = 23, blue led = 24
+  -D SX126X_DIO2_AS_RF_SWITCH=true
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
+  -D SX126X_RX_BOOSTED_GAIN=1
+  -D LORA_TX_POWER=22
+; Debug options
+  ; -D DEBUG_RP2040_WIRE=1
+  ; -D DEBUG_RP2040_SPI=1
+  ; -D DEBUG_RP2040_CORE=1
+  ; -D RADIOLIB_DEBUG_SPI=1
+  ; -D DEBUG_RP2040_PORT=Serial
+build_src_filter = ${rp2040_base.build_src_filter}
+  +<RAK11310Board.cpp>
+  +<../variants/rak11310>
+lib_deps = ${rp2040_base.lib_deps}
+
+[env:rak11310_repeater]
+extends = rak11310
+build_flags = ${rak11310.build_flags}
+  -D ADVERT_NAME='"RAK11310 Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${rak11310.build_src_filter}
+  +<../examples/simple_repeater>
+
+[env:rak11310_repeater_bridge_rs232]
+extends = rak11310
+build_flags = ${rak11310.build_flags}
+  -D ADVERT_NAME='"RS232 Bridge"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WITH_RS232_BRIDGE=Serial2
+  -D WITH_RS232_BRIDGE_RX=9
+  -D WITH_RS232_BRIDGE_TX=8
+;  -D BRIDGE_DEBUG=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${rak11310.build_src_filter}
+  +<helpers/bridges/RS232Bridge.cpp>
+  +<../examples/simple_repeater>
+
+[env:rak11310_room_server]
+extends = rak11310
+build_flags = ${rak11310.build_flags}
+  -D ADVERT_NAME='"RAK11310 Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${rak11310.build_src_filter}
+  +<../examples/simple_room_server>
+
+[env:rak11310_companion_radio_usb]
+extends = rak11310
+build_flags = ${rak11310.build_flags}
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=8
+; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
+; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
+build_src_filter = ${rak11310.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+lib_deps = ${rak11310.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+; [env:rak11310_companion_radio_ble]
+; extends = rak11310
+; build_flags = ${rak11310.build_flags}
+;   -D MAX_CONTACTS=100
+;   -D MAX_GROUP_CHANNELS=8
+;   -D BLE_PIN_CODE=123456
+;   -D BLE_DEBUG_LOGGING=1
+; ;  -D MESH_PACKET_LOGGING=1
+; ;  -D MESH_DEBUG=1
+; build_src_filter = ${rak11310.build_src_filter}
+;   +<../examples/companion_radio/*.cpp>
+; lib_deps = ${rak11310.lib_deps}
+;   densaugeo/base64 @ ~1.4.0
+
+; [env:rak11310_companion_radio_wifi]
+; extends = rak11310
+; build_flags = ${rak11310.build_flags}
+;   -D MAX_CONTACTS=100
+;   -D MAX_GROUP_CHANNELS=8
+;   -D WIFI_DEBUG_LOGGING=1
+;   -D WIFI_SSID='"myssid"'
+;   -D WIFI_PWD='"mypwd"'
+; ;  -D MESH_PACKET_LOGGING=1
+; ;  -D MESH_DEBUG=1
+; build_src_filter = ${rak11310.build_src_filter}
+;   +<../examples/companion_radio/*.cpp>
+; lib_deps = ${rak11310.lib_deps}
+;   densaugeo/base64 @ ~1.4.0
+
+[env:rak11310_terminal_chat]
+extends = rak11310
+build_flags = ${rak11310.build_flags}
+  -D MAX_CONTACTS=100
+  -D MAX_GROUP_CHANNELS=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${rak11310.build_src_filter}
+  +<../examples/simple_secure_chat/main.cpp>
+lib_deps = ${rak11310.lib_deps}
+  densaugeo/base64 @ ~1.4.0

--- a/variants/rak11310/target.cpp
+++ b/variants/rak11310/target.cpp
@@ -1,0 +1,39 @@
+#include <Arduino.h>
+#include "target.h"
+#include <helpers/ArduinoHelpers.h>
+
+RAK11310Board board;
+
+RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, SPI1);
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+VolatileRTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+SensorManager sensors;
+
+bool radio_init() {
+  rtc_clock.begin(Wire);
+  
+  return radio.std_init(&SPI1);
+}
+
+uint32_t radio_get_rng_seed() {
+  return radio.random(0x7FFFFFFF);
+}
+
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr) {
+  radio.setFrequency(freq);
+  radio.setSpreadingFactor(sf);
+  radio.setBandwidth(bw);
+  radio.setCodingRate(cr);
+}
+
+void radio_set_tx_power(uint8_t dbm) {
+  radio.setOutputPower(dbm);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);  // create new random identity
+}

--- a/variants/rak11310/target.h
+++ b/variants/rak11310/target.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/radiolib/CustomSX1262Wrapper.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <helpers/SensorManager.h>
+#include <RAK11310Board.h>
+
+extern RAK11310Board board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern SensorManager sensors;
+
+bool radio_init();
+uint32_t radio_get_rng_seed();
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr);
+void radio_set_tx_power(uint8_t dbm);
+mesh::LocalIdentity radio_new_identity();


### PR DESCRIPTION
This is basically a copy of the `rpi_picow` and `waveshare_rp2040_lora` variants, spiced with some pinouts and voltage divider constants found in https://github.com/RAKWireless/RAK11300-AT-Command-Firmware and https://github.com/beegee-tokyo/SX126x-Arduino (both MIT license).