### PR TITLE
Xiao NRF52: Enable pullup on button input

### DIFF
--- a/variants/xiao_nrf52/XiaoNrf52Board.cpp
+++ b/variants/xiao_nrf52/XiaoNrf52Board.cpp
@@ -38,7 +38,7 @@ void XiaoNrf52Board::begin() {
   digitalWrite(VBAT_ENABLE, HIGH);
 
 #ifdef PIN_USER_BTN
-  pinMode(PIN_USER_BTN, INPUT);
+  pinMode(PIN_USER_BTN, INPUT_PULLUP);
 #endif
 
 #if defined(PIN_WIRE_SDA) && defined(PIN_WIRE_SCL)


### PR DESCRIPTION
Some versions of the Wio-SX1262 board don't have the button and the pullup resistor populated. Enable the internal pullup to prevent a floating pin and spurious button presses on those boards.

This fixes #1173.