### PR TITLE
To reset time for ESP32 boards back to 15 May 2024 after software reboot in MeshCore App

### DIFF
--- a/src/helpers/ESP32Board.h
+++ b/src/helpers/ESP32Board.h
@@ -94,7 +94,7 @@ public:
   ESP32RTCClock() { }
   void begin() {
     esp_reset_reason_t reason = esp_reset_reason();
-    if (reason == ESP_RST_POWERON) {
+    if (reason == ESP_RST_POWERON || reason == ESP_RST_SW) {
       // start with some date/time in the recent past
       struct timeval tv;
       tv.tv_sec = 1715770351;  // 15 May 2024, 8:50pm


### PR DESCRIPTION
To reset time for ESP32 boards back to 15 May 2024 after software reboot in MeshCore App
- This is to be consistent with NRF52. NRF52 (RAK4631) resets time when doing software reboot in MeshCore App. ESP32 still keeps the time after a software reboot.
- And this is to allow to a workaround to sync time again when the time in a repeater is a future time.