### PR TITLE
fix output from LPS22HB sensor: convert barometric pressure from kPa to hPa

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -399,7 +399,7 @@ bool EnvironmentSensorManager::querySensors(uint8_t requester_permissions, Cayen
     #if ENV_INCLUDE_LPS22HB
     if (LPS22HB_initialized) {
       telemetry.addTemperature(TELEM_CHANNEL_SELF, BARO.readTemperature());
-      telemetry.addBarometricPressure(TELEM_CHANNEL_SELF, BARO.readPressure());
+      telemetry.addBarometricPressure(TELEM_CHANNEL_SELF, BARO.readPressure() * 10); // convert kPa to hPa
     }
     #endif
 


### PR DESCRIPTION
[NerdHerder in discord](https://discord.com/channels/1343693475589263471/1391681655911088241/1447352958151950469) reports:

> Hello Guys.
> I have a telemetry sensor issue to report.
> RAK sensor board 1901 is ok.  RAK sensor board 1906 is ok.  However RAK sensor board 1902 reads only 1/10 of the barometric pressure as compared to the actual reading and that read by the 1906.
> Also, it is OK to place the 1091 board in the top slot and 1092 on the bottom - they are both read by the iOS app in telemetry.

After peeking at the LPS22HB library and [code examples](https://github.com/RAKWireless/WisBlock/tree/master/examples/common/sensors/RAK1902_Pressure_LPS22HB), it became clear that the [library returns kPa](https://docs.arduino.cc/libraries/arduino_lps22hb/) instead of hPa as expected. This little change returns telemetry as hPa to be consistent with other outputs.