### PR TITLE
Add admin packet priority for remote repeater management during congestion

### DIFF
--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -146,6 +146,8 @@ protected:
     return _prefs.multi_acks;
   }
 
+  uint8_t getForwardPriority(const mesh::Packet* packet, uint8_t default_priority) override;
+
 #if ENV_INCLUDE_GPS == 1
   void applyGpsPrefs() {
     sensors.setSettingValue("gps", _prefs.gps_enabled?"1":"0");

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -71,6 +71,14 @@ protected:
   virtual uint8_t getExtraAckTransmitCount() const;
 
   /**
+   * \brief  Override to adjust packet forwarding priority
+   * \param  packet  packet being routed
+   * \param  default_priority  priority from base routing (lower = higher priority)
+   * \returns  adjusted priority
+   */
+  virtual uint8_t getForwardPriority(const Packet* packet, uint8_t default_priority);
+
+  /**
    * \brief  Perform search of local DB of peers/contacts.
    * \returns  Number of peers with matching hash
    */


### PR DESCRIPTION
Prioritizes packets from ACL admins during network congestion to enable reliable remote repeater management.

### Changes
- Added virtual `getForwardPriority()` method to Mesh class for priority customization
- Repeater checks sender against ACL and assigns priority 0 to admin packets (REQ, RESPONSE, TXT_MSG, PATH types)

### Technical Details
Admin packets now get the same priority as direct-routed traffic (highest forwarding priority). The check happens during routing by comparing packet src_hash against ACL entries. Non-admin packets use default priority (unchanged).