### PR TITLE
Refactor the saveIdentity method 

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -882,8 +882,8 @@ void MyMesh::formatPacketStatsReply(char *reply) {
                                        getNumRecvFlood(), getNumRecvDirect());
 }
 
-void MyMesh::saveIdentity(const mesh::LocalIdentity &new_id) {
-  self_id = new_id;
+void MyMesh::saveIdentity(const mesh::LocalIdentity &new_id, bool apply_now) {
+  if (apply_now) self_id = new_id;
 #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
   IdentityStore store(*_fs, "");
 #elif defined(ESP32)
@@ -893,7 +893,7 @@ void MyMesh::saveIdentity(const mesh::LocalIdentity &new_id) {
 #else
 #error "need to define saveIdentity()"
 #endif
-  store.save("_main", self_id);
+  store.save("_main", new_id);
 }
 
 void MyMesh::clearStats() {

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -201,7 +201,14 @@ public:
 
   mesh::LocalIdentity& getSelfId() override { return self_id; }
 
-  void saveIdentity(const mesh::LocalIdentity& new_id) override;
+  void saveIdentity(const mesh::LocalIdentity& new_id, bool apply_now = true) override;
+  mesh::LocalIdentity generateNewIdentity() override { return radio_new_identity(); }
+  bool hasNeighborWithHash(uint8_t hash) override {
+    for (int i = 0; i < MAX_NEIGHBOURS; i++) {
+      if (neighbours[i].heard_timestamp > 0 && neighbours[i].id.pub_key[0] == hash) return true;
+    }
+    return false;
+  }
   void clearStats() override;
   void handleCommand(uint32_t sender_timestamp, char* command, char* reply);
   void loop();

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -719,8 +719,8 @@ void MyMesh::setTxPower(uint8_t power_dbm) {
   radio_set_tx_power(power_dbm);
 }
 
-void MyMesh::saveIdentity(const mesh::LocalIdentity &new_id) {
-  self_id = new_id;
+void MyMesh::saveIdentity(const mesh::LocalIdentity &new_id, bool apply_now) {
+  if (apply_now) self_id = new_id;
 #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
   IdentityStore store(*_fs, "");
 #elif defined(ESP32)
@@ -730,7 +730,7 @@ void MyMesh::saveIdentity(const mesh::LocalIdentity &new_id) {
 #else
 #error "need to define saveIdentity()"
 #endif
-  store.save("_main", self_id);
+  store.save("_main", new_id);
 }
 
 void MyMesh::clearStats() {

--- a/examples/simple_room_server/MyMesh.h
+++ b/examples/simple_room_server/MyMesh.h
@@ -201,7 +201,8 @@ public:
 
   static bool saveFilter(ClientInfo* client);
 
-  void saveIdentity(const mesh::LocalIdentity& new_id) override;
+  void saveIdentity(const mesh::LocalIdentity& new_id, bool apply_now = true) override;
+  mesh::LocalIdentity generateNewIdentity() override { return radio_new_identity(); }
   void clearStats() override;
   void handleCommand(uint32_t sender_timestamp, char* command, char* reply);
   void loop();

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -764,8 +764,8 @@ bool SensorMesh::formatFileSystem() {
 #endif
 }
 
-void SensorMesh::saveIdentity(const mesh::LocalIdentity& new_id) {
-  self_id = new_id;
+void SensorMesh::saveIdentity(const mesh::LocalIdentity& new_id, bool apply_now) {
+  if (apply_now) self_id = new_id;
 #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
   IdentityStore store(*_fs, "");
 #elif defined(ESP32)
@@ -775,7 +775,7 @@ void SensorMesh::saveIdentity(const mesh::LocalIdentity& new_id) {
 #else
   #error "need to define saveIdentity()"
 #endif
-  store.save("_main", self_id);
+  store.save("_main", new_id);
 }
 
 void SensorMesh::applyTempRadioParams(float freq, float bw, uint8_t sf, uint8_t cr, int timeout_mins) {

--- a/examples/simple_sensor/SensorMesh.h
+++ b/examples/simple_sensor/SensorMesh.h
@@ -74,7 +74,8 @@ public:
   void formatRadioStatsReply(char *reply) override;
   void formatPacketStatsReply(char *reply) override;
   mesh::LocalIdentity& getSelfId() override { return self_id; }
-  void saveIdentity(const mesh::LocalIdentity& new_id) override;
+  void saveIdentity(const mesh::LocalIdentity& new_id, bool apply_now = true) override;
+  mesh::LocalIdentity generateNewIdentity() override { return radio_new_identity(); }
   void clearStats() override { }
   void applyTempRadioParams(float freq, float bw, uint8_t sf, uint8_t cr, int timeout_mins) override;
 

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -72,7 +72,9 @@ public:
   virtual void formatRadioStatsReply(char *reply) = 0;
   virtual void formatPacketStatsReply(char *reply) = 0;
   virtual mesh::LocalIdentity& getSelfId() = 0;
-  virtual void saveIdentity(const mesh::LocalIdentity& new_id) = 0;
+  virtual void saveIdentity(const mesh::LocalIdentity& new_id, bool apply_now = true) = 0;
+  virtual mesh::LocalIdentity generateNewIdentity() = 0;
+  virtual bool hasNeighborWithHash(uint8_t hash) { return false; }
   virtual void clearStats() = 0;
   virtual void applyTempRadioParams(float freq, float bw, uint8_t sf, uint8_t cr, int timeout_mins) = 0;
 


### PR DESCRIPTION
This change will allow uses to use these two new commands: 

regen key
Auto mode generates a new identity avoiding collisions with neighbors and reserved hashes (00, FF).
`regen key`
Response: OK - new ID: A3 (reboot to apply)


regen key XX
Vanity mode generates a new identity with a specific hash prefix (2 hex characters).
```
regen key A3
regen key 7F
regen key b2
```

Response: OK - new ID: A3 (reboot to apply)
If the target hash collides with a neighbor:
Response: WARNING: collision! new ID: A3 (reboot to apply)



The purpose of this is to reduce those annoying collisions that happen in the app and also to resolve times where repeaters with the same hash end up repeating a message that was intended for another repeater thus increasing airtime. 