### PR TITLE
Changed INA3221 I2C address for sensor

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -61,7 +61,7 @@ static SensirionI2cSht4x SHT4X;
 #endif
 
 #if ENV_INCLUDE_INA3221
-#define TELEM_INA3221_ADDRESS   0x42      // INA3221 3 channel current sensor I2C address
+#define TELEM_INA3221_ADDRESS   0x40      // INA3221 3 channel current sensor I2C address. https://learn.adafruit.com/adafruit-ina3221-breakout/pinouts
 #define TELEM_INA3221_SHUNT_VALUE 0.100 // most variants will have a 0.1 ohm shunts
 #define TELEM_INA3221_NUM_CHANNELS 3
 #include <Adafruit_INA3221.h>


### PR DESCRIPTION
Updated INA3221 I2C address from 0x42 to 0x40, which is the default. https://learn.adafruit.com/adafruit-ina3221-breakout?view=all#pinouts