### PR TITLE
Add power button functionality to SenseCAP Solar Node P1

### DIFF
--- a/variants/sensecap_solar/SenseCapSolarBoard.cpp
+++ b/variants/sensecap_solar/SenseCapSolarBoard.cpp
@@ -17,5 +17,9 @@ void SenseCapSolarBoard::begin() {
   digitalWrite(P_LORA_TX_LED, LOW);
 #endif
 
+#ifdef PIN_BUTTON1
+  pinMode(PIN_BUTTON1, INPUT);
+#endif
+
   delay(10);   // give sx1262 some time to power up
 }

--- a/variants/sensecap_solar/SenseCapSolarBoard.h
+++ b/variants/sensecap_solar/SenseCapSolarBoard.h
@@ -31,4 +31,24 @@ public:
   const char* getManufacturerName() const override {
     return "Seeed SenseCap Solar";
   }
+
+  void powerOff() override {
+#ifdef GPS_EN
+    digitalWrite(GPS_EN, LOW);
+#endif
+
+#ifdef LED_GREEN
+    digitalWrite(LED_GREEN, LOW);
+#endif
+#ifdef LED_BLUE
+    digitalWrite(LED_BLUE, LOW);
+#endif
+
+#ifdef PIN_BUTTON1
+    while(digitalRead(PIN_BUTTON1) == LOW);
+    nrf_gpio_cfg_sense_input(digitalPinToInterrupt(g_ADigitalPinMap[PIN_BUTTON1]), NRF_GPIO_PIN_NOPULL, NRF_GPIO_PIN_SENSE_LOW);
+#endif
+
+    sd_power_system_off();
+  }
 };


### PR DESCRIPTION
Implements power button functionality for the SenseCAP Solar Node P1, allowing the device to be powered off and woken up using the button on GPIO1.01.