### PR TITLE
Add RS232 bridge environment configuration for ProMicro

### DIFF
--- a/variants/promicro/platformio.ini
+++ b/variants/promicro/platformio.ini
@@ -53,6 +53,31 @@ build_flags =
 lib_deps = ${Promicro.lib_deps}
   adafruit/RTClib @ ^2.1.3
 
+[env:ProMicro_repeater_bridge_rs232_serial1]
+extends = Promicro
+build_src_filter = ${Promicro.build_src_filter}
+  +<../examples/simple_repeater>
+  +<helpers/ui/SSD1306Display.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<helpers/bridges/RS232Bridge.cpp>
+build_flags =
+  ${Promicro.build_flags}
+  -D ADVERT_NAME='"RS232 Bridge"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D DISPLAY_CLASS=SSD1306Display
+  -D WITH_RS232_BRIDGE=Serial1
+  -D WITH_RS232_BRIDGE_RX=PIN_SERIAL1_RX
+  -D WITH_RS232_BRIDGE_TX=PIN_SERIAL1_TX
+  -UENV_INCLUDE_GPS
+;  -D BRIDGE_DEBUG=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+lib_deps = ${Promicro.lib_deps}
+  adafruit/RTClib @ ^2.1.3
+
 [env:ProMicro_room_server]
 extends = Promicro
 build_src_filter = ${Promicro.build_src_filter}


### PR DESCRIPTION
This pull request adds a new build environment configuration for the Pro Micro platform, specifically targeting a repeater bridge with RS232 support using Serial1. The new environment includes custom build flags and source files to enable and configure RS232 bridging functionality.

New build environment for RS232 repeater bridge:

* Added `[env:ProMicro_repeater_bridge_rs232_serial1]` section to `platformio.ini`, extending the base `Promicro` environment and including additional source files for RS232 bridge, display, and button helpers.
* Configured build flags to set device name, location, admin password, maximum neighbors, display class, and enabled RS232 bridge over `Serial1` with specific RX/TX pins. Also disables GPS inclusion for this build.