### PR TITLE
Add NVS partition reset to ESP factory reset

### DIFF
--- a/examples/companion_radio/DataStore.cpp
+++ b/examples/companion_radio/DataStore.cpp
@@ -65,6 +65,7 @@ void DataStore::begin() {
 
 #if defined(ESP32)
   #include <SPIFFS.h>
+  #include <nvs_flash.h>
 #elif defined(RP2040_PLATFORM)
   #include <LittleFS.h>
 #elif defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
@@ -172,7 +173,9 @@ bool DataStore::formatFileSystem() {
 #elif defined(RP2040_PLATFORM)
   return LittleFS.format();
 #elif defined(ESP32)
-  return ((fs::SPIFFSFS *)_fs)->format();
+  bool fs_success = ((fs::SPIFFSFS *)_fs)->format();
+  esp_err_t nvs_err = nvs_flash_erase(); // no need to reinit, will be done by reboot
+  return fs_success && (nvs_err == ESP_OK);
 #else
   #error "need to implement format()"
 #endif

--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1613,6 +1613,10 @@ void MyMesh::handleCmdFrame(size_t len) {
       writeErrFrame(ERR_CODE_ILLEGAL_ARG); // invalid stats sub-type
     }
   } else if (cmd_frame[0] == CMD_FACTORY_RESET && memcmp(&cmd_frame[1], "reset", 5) == 0) {
+    if (_serial) {
+      MESH_DEBUG_PRINTLN("Factory reset: disabling serial interface to prevent reconnects (BLE/WiFi)");
+      _serial->disable(); // Phone app disconnects before we can send OK frame so it's safe here
+    }
     bool success = _store->formatFileSystem();
     if (success) {
       writeOKFrame();


### PR DESCRIPTION
NVS partition is not touched by software initiated factory reset, so clearing out bluetooth bonding files can be only done with a flash erase now.

We should format NVS partition too to clear out everything, to match nRF factory reset behaviour.

Also disable serial interface when issuing factory reset command, because now the code re-start advertising when the phone app disconnects (so we are advertising during format)

Full debug from a xiao c3 from issuing the factory reset command to reboot:

[2025-12-31 13:29:07.2412 BLE: readBytes: sz=6, hdr=51
[2025-12-31 13:29:07.2415 DEBUG: Factory reset: disabling serial interface to prevent reconnects (BLE/WiFi)
[2025-12-31 13:29:07.2416 BLE: SerialBLEInterface: disable
[2025-12-31 13:29:07.2430 [310655][E][esp32-hal-misc.c:128] disableCore0WDT(): Failed to remove Core 0 IDLE task from WDT
[2025-12-31 13:29:07.2915 BLE: SerialBLEInterface: disconnected conn_handle=1 reason=0x216 (initiated by remote)
[2025-12-31 13:29:22.9804 ESP-ROM:esp32c3-api1-20210207