### PR TITLE
Fix RAK4631 GPS Detection

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -615,6 +615,7 @@ void EnvironmentSensorManager::rakGPSInit(){
     MESH_DEBUG_PRINTLN("No GPS found");
     gps_active = false;
     gps_detected = false;
+    Serial1.end();
     return;
   }
 
@@ -663,6 +664,8 @@ bool EnvironmentSensorManager::gpsIsAwake(uint8_t ioPin){
     gps_detected = true;
     return true;
   }
+
+  pinMode(ioPin, INPUT);
   MESH_DEBUG_PRINTLN("GPS did not init with this IO pin... try the next");
   return false;
 }


### PR DESCRIPTION
This solves https://github.com/meshcore-dev/MeshCore/issues/1234 and allows to save around 1.5 mA of excessive power consumption on boards like the Solar Mesh Baseboard (using RAK4631).