### PR TITLE
Only add adverts that have location

### DIFF
--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -104,13 +104,20 @@ void BaseChatMesh::onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, 
       return;
     }
 
+    if (isAutoAddLocEnabled() && !parser.hasLatLon()) { return; } // Ignore advert if it has no Location
+
     is_new = true;
     if (num_contacts < MAX_CONTACTS) {
       from = &contacts[num_contacts++];
       from->id = id;
       from->out_path_len = -1;  // initially out_path is unknown
-      from->gps_lat = 0;   // initially unknown GPS loc
-      from->gps_lon = 0;
+      if (!parser.hasLatLon()) {
+        from->gps_lat = 0;   // initially unknown GPS loc
+        from->gps_lon = 0;
+      } else {
+        from->gps_lat = parser.getIntLat();   // if the advert has Lat/Lon add it
+        from->gps_lon = parser.getIntLon();
+      }
       from->sync_since = 0;
 
       // only need to calculate the shared_secret once, for better performance

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -92,6 +92,7 @@ protected:
 
   // 'UI' concepts, for sub-classes to implement
   virtual bool isAutoAddEnabled() const { return true; }
+  virtual bool isAutoAddLocEnabled() const { return true; }
   virtual void onDiscoveredContact(ContactInfo& contact, bool is_new, uint8_t path_len, const uint8_t* path) = 0;
   virtual ContactInfo* processAck(const uint8_t *data) = 0;
   virtual void onContactPathUpdated(const ContactInfo& contact) = 0;


### PR DESCRIPTION
disclaimer: im not a c developer

Friend of mine (silentlightning of the VIC mesh) does lots of repeater installs and is running into issues with contact limits. To reduce this he suggested to only add repeaters with a location, and i've built and tested this on a t114 in companion mode and it does seem to work, I only received adverts from repeaters (and clients actually) that had locations.

Note that this code enables this functionality by default (because i think the app needs to be told of the function, and this was a quick thing, so i just set it to true to flash it and test it)

let me know if you need anything else :)

edit: i dont know how far you guys would take this, but you could also have an option for example to accept zero-hop adverts, but not repeated adverts to allow people to discover each other easier without getting full contact lists. At that point you could even make a "filter ruleset" that filters incoming adverts based on name (contains, prefix, suffix), if it has a location or not, its path and path length, etc.