### PR TITLE
Enable USB CDC on boot for Heltec V4

### DIFF
--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -7,6 +7,7 @@ build_flags =
   -I variants/heltec_v4
   -D HELTEC_LORA_V4
   -D ESP32_CPU_FREQ=80
+  -D ARDUINO_USB_CDC_ON_BOOT=1    
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper
   -D P_LORA_TX_LED=35


### PR DESCRIPTION
With this change the device will automatically reboot after flashing and start running the meshcore firmware.