### PR TITLE
Fix typos in README and source comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Please submit PR's using 'dev' as the base branch!
 For minor changes just submit your PR and I'll try to review it, but for anything more 'impactful' please open an Issue first and start a discussion. Is better to sound out what it is you want to achieve first, and try to come to a consensus on what the best approach is, especially when it impacts the structure or architecture of this codebase.
 
 Here are some general principals you should try to adhere to:
-* Keep it simple. Please, don't think like a high-level lang programmer. Think embedded, and keep code concise, without any unecessary layers.
+* Keep it simple. Please, don't think like a high-level lang programmer. Think embedded, and keep code concise, without any unnecessary layers.
 * No dynamic memory allocation, except during setup/begin functions.
 * Use the same brace and indenting style that's in the core source modules. (A .clang-format is prob going to be added soon, but please do NOT retroactively re-format existing code. This just creates unnecessary diffs that make finding problems harder)
 
@@ -106,7 +106,7 @@ There are a number of fairly major features in the pipeline, with no particular 
 - [ ] Core + Apps: support for LZW message compression
 - [ ] Core: dynamic CR (Coding Rate) for weak vs strong hops
 - [ ] Core: new framework for hosting multiple virtual nodes on one physical device
-- [ ] V2 protocol spec: discussion and concensus around V2 packet protocol, including path hashes, new encryption specs, etc
+- [ ] V2 protocol spec: discussion and consensus around V2 packet protocol, including path hashes, new encryption specs, etc
 
 ## 📞 Get Support
 

--- a/src/helpers/radiolib/CustomLR1110.h
+++ b/src/helpers/radiolib/CustomLR1110.h
@@ -10,7 +10,7 @@ class CustomLR1110 : public LR1110 {
     size_t getPacketLength(bool update) override {
       size_t len = LR1110::getPacketLength(update);
       if (len == 0 && getIrqStatus() & RADIOLIB_LR11X0_IRQ_HEADER_ERR) {
-        // we've just recieved a corrupted packet
+        // we've just received a corrupted packet
         // this may have triggered a bug causing subsequent packets to be shifted
         // call standby() to return radio to known-good state
         // recvRaw will call startReceive() to restart rx


### PR DESCRIPTION
## Summary
- Fix "unecessary" → "unnecessary" in README.md
- Fix "concensus" → "consensus" in README.md
- Fix "recieved" → "received" in CustomLR1110.h