### PR TITLE
Add null checks for PMU allocation in TBeamBoard

### DIFF
--- a/src/helpers/esp32/TBeamBoard.cpp
+++ b/src/helpers/esp32/TBeamBoard.cpp
@@ -131,7 +131,7 @@ bool TBeamBoard::power_init()
     #else
       PMU = new XPowersAXP2101(PMU_WIRE_PORT, PIN_BOARD_SDA, PIN_BOARD_SCL, I2C_PMU_ADD);
     #endif
-    if (!PMU->init()) {
+    if (!PMU || !PMU->init()) {
         MESH_DEBUG_PRINTLN("Warning: Failed to find AXP2101 power management");
         delete PMU;
         PMU = NULL;
@@ -141,7 +141,7 @@ bool TBeamBoard::power_init()
   }
   if (!PMU) {
     PMU = new XPowersAXP192(PMU_WIRE_PORT, PIN_BOARD_SDA, PIN_BOARD_SCL, I2C_PMU_ADD);
-     if (!PMU->init()) {
+     if (!PMU || !PMU->init()) {
         MESH_DEBUG_PRINTLN("Warning: Failed to find AXP192 power management");
         delete PMU;
         PMU = NULL;


### PR DESCRIPTION
## Summary
Add null safety checks after `new` operations for PMU initialization in TBeamBoard.cpp.

## Changes
- Check if `new XPowersAXP2101()` succeeded before calling `init()`
- Check if `new XPowersAXP192()` succeeded before calling `init()`

## Why
In embedded systems with limited RAM, `new` can fail and return nullptr. Dereferencing nullptr causes a crash. This adds defensive null checks to prevent potential crashes.

```cpp
// Before
if (!PMU->init()) {

// After  
if (!PMU || !PMU->init()) {
```