### PR TITLE
Add Xiao_S3_WIO WiFi companion env (Xiao_S3_WIO_companion_radio_wifi)

### DIFF
--- a/variants/xiao_s3_wio/platformio.ini
+++ b/variants/xiao_s3_wio/platformio.ini
@@ -195,6 +195,29 @@ lib_deps =
   densaugeo/base64 @ ~1.4.0
   adafruit/Adafruit SSD1306 @ ^2.5.13
 
+[env:Xiao_S3_WIO_companion_radio_wifi]
+extends = Xiao_S3_WIO
+build_src_filter = ${Xiao_S3_WIO.build_src_filter}
+  +<helpers/ui/NullDisplayDriver.cpp>
+  +<helpers/esp32/*.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<../examples/companion_radio/*.cpp>
+build_flags =
+  ${Xiao_S3_WIO.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
+  -D WIFI_DEBUG_LOGGING=1
+  -D WIFI_SSID='"myssid"'
+  -D WIFI_PWD='"password"'
+  ; -D BLE_DEBUG_LOGGING=1
+  ; -D MESH_PACKET_LOGGING=1
+  ; -D MESH_DEBUG=1
+lib_deps =
+  ${Xiao_S3_WIO.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
 [env:Xiao_S3_WIO_sensor]
 extends = Xiao_S3_WIO
 build_src_filter = ${Xiao_S3_WIO.build_src_filter}


### PR DESCRIPTION
This PR introduces a new PlatformIO environment, Xiao_S3_WIO_companion_radio_wifi, enabling ESP32-based XIAO devices to operate as Wi-Fi companion radios.

The environment was compiled for and verified on the Xiao_S3_WIO. Since these devices are commonly shipped without a display, the default SSD1306Display has been replaced with NullDisplayDriver for this configuration, removing the display dependency while preserving compatibility with the existing codebase.
