### PR TITLE
Fix capitalization in T1000-E manufacturer string

### DIFF
--- a/variants/t1000-e/T1000eBoard.h
+++ b/variants/t1000-e/T1000eBoard.h
@@ -36,7 +36,7 @@ public:
   uint8_t getStartupReason() const override { return startup_reason; }
 
   const char* getManufacturerName() const override {
-    return "Seeed Tracker T1000-e";
+    return "Seeed Tracker T1000-E";
   }
 
   int buttonStateChanged() {


### PR DESCRIPTION
Silly PR but they do use the capital "E" consistently in their marketing.