### PR TITLE
Apply #1331 to other WiFi companions

### DIFF
--- a/variants/heltec_tracker_v2/platformio.ini
+++ b/variants/heltec_tracker_v2/platformio.ini
@@ -185,6 +185,7 @@ build_flags =
   -D WIFI_DEBUG_LOGGING=1
   -D WIFI_SSID='"myssid"'
   -D WIFI_PWD='"mypwd"'
+  -D OFFLINE_QUEUE_SIZE=256  
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${Heltec_tracker_v2.build_src_filter}

--- a/variants/heltec_v2/platformio.ini
+++ b/variants/heltec_v2/platformio.ini
@@ -183,6 +183,7 @@ build_flags =
   -D WIFI_DEBUG_LOGGING=1
   -D WIFI_SSID='"myssid"'
   -D WIFI_PWD='"mypwd"'
+  -D OFFLINE_QUEUE_SIZE=256  
 ; -D MESH_PACKET_LOGGING=1
 ; -D MESH_DEBUG=1
 build_src_filter = ${Heltec_lora32_v2.build_src_filter}

--- a/variants/lilygo_tlora_v2_1/platformio.ini
+++ b/variants/lilygo_tlora_v2_1/platformio.ini
@@ -136,6 +136,7 @@ build_flags =
   -D WIFI_SSID='"ssid"'
   -D WIFI_PWD='"password"'
   -D WIFI_DEBUG_LOGGING=1
+  -D OFFLINE_QUEUE_SIZE=256  
 build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<helpers/ui/MomentaryButton.cpp>

--- a/variants/nibble_screen_connect/platformio.ini
+++ b/variants/nibble_screen_connect/platformio.ini
@@ -147,6 +147,7 @@ build_flags =
   -D WIFI_DEBUG_LOGGING=1
   -D WIFI_SSID='"myssid"'
   -D WIFI_PWD='"mypwd"'
+  -D OFFLINE_QUEUE_SIZE=256  
 build_src_filter = ${nibble_screen_connect_base.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<helpers/ui/MomentaryButton.cpp>

--- a/variants/station_g2/platformio.ini
+++ b/variants/station_g2/platformio.ini
@@ -226,6 +226,7 @@ build_flags =
   -D WIFI_DEBUG_LOGGING=1
   -D WIFI_SSID='"myssid"'
   -D WIFI_PWD='"mypwd"'
+  -D OFFLINE_QUEUE_SIZE=256  
 ; -D MESH_PACKET_LOGGING=1
 ; -D MESH_DEBUG=1
 build_src_filter = ${Station_G2.build_src_filter}


### PR DESCRIPTION
This PR applies the OFFLINE_QUEUE_SIZE change from #1331 to the other WiFi companions as well.
The value was compared against the existing BLE environment to ensure it does not differ for specific companions. Some WiFi companions already had the correct value set.