### PR TITLE
Do not save contacts to FS when nothing has changed

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -358,7 +358,11 @@ void MyMesh::onDiscoveredContact(ContactInfo &contact, bool is_new, uint8_t path
     memcpy(p->path, path, p->path_len);
   }
 
-  if (!is_new) dirty_contacts_expiry = futureMillis(LAZY_CONTACTS_WRITE_DELAY); // only schedule lazy write for contacts that are in contacts[]
+  // Don't save if this is a new contact but auto-add is off (contact not added to list)
+  if (is_new && !isAutoAddEnabled()) {
+    return;
+  }
+  dirty_contacts_expiry = futureMillis(LAZY_CONTACTS_WRITE_DELAY);
 }
 
 static int sort_by_recent(const void *a, const void *b) {


### PR DESCRIPTION
Specifically, when auto-add is off and a new contact is discovered this currently triggers a write. That write has no effect, other than reducing flash life and causing more potential corruption.