### PR TITLE
Fix: Send device discovery notifications when contact list is full

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -263,7 +263,7 @@ bool MyMesh::isAutoAddEnabled() const {
 
 void MyMesh::onDiscoveredContact(ContactInfo &contact, bool is_new, uint8_t path_len, const uint8_t* path) {
   if (_serial->isConnected()) {
-    if (!isAutoAddEnabled() && is_new) {
+    if (is_new) {
       writeContactRespFrame(PUSH_CODE_NEW_ADVERT, contact);
     } else {
       out_frame[0] = PUSH_CODE_ADVERT;

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -117,7 +117,6 @@ void BaseChatMesh::onAdvertRecv(mesh::Packet* packet, const mesh::Identity& id, 
     } else {
       // Table is full, but still notify app about discovered contact
       // Use a temporary ContactInfo since we can't add to permanent list
-      // (Connection check happens inside onDiscoveredContact, same as manual-add mode)
       ContactInfo ci;
       memset(&ci, 0, sizeof(ci));
       ci.id = id;


### PR DESCRIPTION
## Fix: Send device discovery notifications when contact list is full

### Problem
When the contact list reached MAX_CONTACTS, new device discoveries were ignored and the app was not notified. This behavior is particularly frustrating for new users who miss out on mesh discovery because of a full contacts list.

### Solution
When the table is full, create a temporary `ContactInfo` and call `onDiscoveredContact()` to notify the app, matching manual-add mode behavior and send `PUSH_CODE_NEW_ADVERT` with the full contact info allowing the Discovery List to continue to populate.

### Changes
- `BaseChatMesh::onAdvertRecv()`: When `num_contacts >= MAX_CONTACTS`, create a temporary `ContactInfo` and call `onDiscoveredContact()` instead of returning early.
- `MyMesh::onDiscoveredContact()`: Remove check for `!isAutoAddEnabled()` and send full contact if `is_new` is true.

### Behavior
- Auto-add enabled + table not full: Add contact and notify
- Auto-add enabled + table full: Notify only with temporary `ContactInfo` using `PUSH_CODE_NEW_ADVERT`
- Auto-add disabled: Always notify with `PUSH_CODE_NEW_ADVERT` (existing behavior, unchanged)

Connection checks remain in `onDiscoveredContact()`.