### PR TITLE
Refactor LBT to use explicit CAD and RSSI channel checks

### DIFF
--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -69,10 +69,11 @@ public:
 
   virtual bool isInRecvMode() const = 0;
 
-  /**
-   * \returns  true if the radio is currently mid-receive of a packet.
-  */
-  virtual bool isReceiving() { return false; }
+  virtual bool isReceivingPacket() { return false; }
+
+  virtual int scanChannelActivity() { return 0; }
+
+  virtual bool isChannelActive() { return false; }
 
   virtual float getLastRSSI() const { return 0; }
   virtual float getLastSNR() const { return 0; }

--- a/src/helpers/radiolib/CustomLLCC68.h
+++ b/src/helpers/radiolib/CustomLLCC68.h
@@ -84,4 +84,12 @@ class CustomLLCC68 : public LLCC68 {
       bool detected = (irq & SX126X_IRQ_HEADER_VALID) || (irq & SX126X_IRQ_PREAMBLE_DETECTED);
       return detected;
     }
+
+    int16_t scanCAD() {
+      int16_t state = scanChannel();
+      if (state == RADIOLIB_LORA_DETECTED) {
+        return 1;
+      }
+      return 0;
+    }
 };

--- a/src/helpers/radiolib/CustomLLCC68Wrapper.h
+++ b/src/helpers/radiolib/CustomLLCC68Wrapper.h
@@ -6,12 +6,19 @@
 class CustomLLCC68Wrapper : public RadioLibWrapper {
 public:
   CustomLLCC68Wrapper(CustomLLCC68& radio, mesh::MainBoard& board) : RadioLibWrapper(radio, board) { }
+
   bool isReceivingPacket() override { 
     return ((CustomLLCC68 *)_radio)->isReceiving();
   }
+
+  int scanChannelActivity() override {
+    return ((CustomLLCC68 *)_radio)->scanCAD();
+  }
+
   float getCurrentRSSI() override {
     return ((CustomLLCC68 *)_radio)->getRSSI(false);
   }
+
   float getLastRSSI() const override { return ((CustomLLCC68 *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomLLCC68 *)_radio)->getSNR(); }
 

--- a/src/helpers/radiolib/CustomLR1110.h
+++ b/src/helpers/radiolib/CustomLR1110.h
@@ -25,4 +25,12 @@ class CustomLR1110 : public LR1110 {
       bool detected = ((irq & RADIOLIB_LR11X0_IRQ_SYNC_WORD_HEADER_VALID) || (irq & RADIOLIB_LR11X0_IRQ_PREAMBLE_DETECTED));
       return detected;
     }
+
+    int16_t scanCAD() {
+      int16_t state = scanChannel();
+      if (state == RADIOLIB_LORA_DETECTED) {
+        return 1;
+      }
+      return 0;
+    }
 };

--- a/src/helpers/radiolib/CustomLR1110Wrapper.h
+++ b/src/helpers/radiolib/CustomLR1110Wrapper.h
@@ -6,9 +6,15 @@
 class CustomLR1110Wrapper : public RadioLibWrapper {
 public:
   CustomLR1110Wrapper(CustomLR1110& radio, mesh::MainBoard& board) : RadioLibWrapper(radio, board) { }
+
   bool isReceivingPacket() override { 
     return ((CustomLR1110 *)_radio)->isReceiving();
   }
+
+  int scanChannelActivity() override {
+    return ((CustomLR1110 *)_radio)->scanCAD();
+  }
+
   float getCurrentRSSI() override {
     float rssi = -110;
     ((CustomLR1110 *)_radio)->getRssiInst(&rssi);
@@ -17,7 +23,7 @@ public:
 
   void onSendFinished() override {
     RadioLibWrapper::onSendFinished();
-    _radio->setPreambleLength(16); // overcomes weird issues with small and big pkts
+    _radio->setPreambleLength(16);
   }
 
   float getLastRSSI() const override { return ((CustomLR1110 *)_radio)->getRSSI(); }

--- a/src/helpers/radiolib/CustomSTM32WLx.h
+++ b/src/helpers/radiolib/CustomSTM32WLx.h
@@ -14,4 +14,12 @@ class CustomSTM32WLx : public STM32WLx {
       bool detected = (irq & SX126X_IRQ_HEADER_VALID) || (irq & SX126X_IRQ_PREAMBLE_DETECTED);
       return detected;
     }
+
+    int16_t scanCAD() {
+      int16_t state = scanChannel();
+      if (state == RADIOLIB_LORA_DETECTED) {
+        return 1;
+      }
+      return 0;
+    }
 };

--- a/src/helpers/radiolib/CustomSTM32WLxWrapper.h
+++ b/src/helpers/radiolib/CustomSTM32WLxWrapper.h
@@ -7,12 +7,19 @@
 class CustomSTM32WLxWrapper : public RadioLibWrapper {
 public:
   CustomSTM32WLxWrapper(CustomSTM32WLx& radio, mesh::MainBoard& board) : RadioLibWrapper(radio, board) { }
+
   bool isReceivingPacket() override { 
     return ((CustomSTM32WLx *)_radio)->isReceiving();
   }
+
+  int scanChannelActivity() override {
+    return ((CustomSTM32WLx *)_radio)->scanCAD();
+  }
+
   float getCurrentRSSI() override {
     return ((CustomSTM32WLx *)_radio)->getRSSI(false);
   }
+
   float getLastRSSI() const override { return ((CustomSTM32WLx *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomSTM32WLx *)_radio)->getSNR(); }
 

--- a/src/helpers/radiolib/CustomSX1262.h
+++ b/src/helpers/radiolib/CustomSX1262.h
@@ -84,4 +84,12 @@ class CustomSX1262 : public SX1262 {
       bool detected = (irq & SX126X_IRQ_HEADER_VALID) || (irq & SX126X_IRQ_PREAMBLE_DETECTED);
       return detected;
     }
+
+    int16_t scanCAD() {
+      int16_t state = scanChannel();
+      if (state == RADIOLIB_LORA_DETECTED) {
+        return 1;
+      }
+      return 0;
+    }
 };

--- a/src/helpers/radiolib/CustomSX1262Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1262Wrapper.h
@@ -6,12 +6,19 @@
 class CustomSX1262Wrapper : public RadioLibWrapper {
 public:
   CustomSX1262Wrapper(CustomSX1262& radio, mesh::MainBoard& board) : RadioLibWrapper(radio, board) { }
+
   bool isReceivingPacket() override { 
     return ((CustomSX1262 *)_radio)->isReceiving();
   }
+
+  int scanChannelActivity() override {
+    return ((CustomSX1262 *)_radio)->scanCAD();
+  }
+
   float getCurrentRSSI() override {
     return ((CustomSX1262 *)_radio)->getRSSI(false);
   }
+
   float getLastRSSI() const override { return ((CustomSX1262 *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomSX1262 *)_radio)->getSNR(); }
 
@@ -19,6 +26,7 @@ public:
     int sf = ((CustomSX1262 *)_radio)->spreadingFactor;
     return packetScoreInt(snr, sf, packet_len);
   }
+
   virtual void powerOff() override {
     ((CustomSX1262 *)_radio)->sleep(false);
   }

--- a/src/helpers/radiolib/CustomSX1268.h
+++ b/src/helpers/radiolib/CustomSX1268.h
@@ -84,4 +84,12 @@ class CustomSX1268 : public SX1268 {
       bool detected = (irq & SX126X_IRQ_HEADER_VALID) || (irq & SX126X_IRQ_PREAMBLE_DETECTED);
       return detected;
     }
+
+    int16_t scanCAD() {
+      int16_t state = scanChannel();
+      if (state == RADIOLIB_LORA_DETECTED) {
+        return 1;
+      }
+      return 0;
+    }
 };

--- a/src/helpers/radiolib/CustomSX1268Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1268Wrapper.h
@@ -6,12 +6,19 @@
 class CustomSX1268Wrapper : public RadioLibWrapper {
 public:
   CustomSX1268Wrapper(CustomSX1268& radio, mesh::MainBoard& board) : RadioLibWrapper(radio, board) { }
+
   bool isReceivingPacket() override { 
     return ((CustomSX1268 *)_radio)->isReceiving();
   }
+
+  int scanChannelActivity() override {
+    return ((CustomSX1268 *)_radio)->scanCAD();
+  }
+
   float getCurrentRSSI() override {
     return ((CustomSX1268 *)_radio)->getRSSI(false);
   }
+
   float getLastRSSI() const override { return ((CustomSX1268 *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomSX1268 *)_radio)->getSNR(); }
 

--- a/src/helpers/radiolib/CustomSX1276.h
+++ b/src/helpers/radiolib/CustomSX1276.h
@@ -72,19 +72,11 @@ class CustomSX1276 : public SX1276 {
         | RH_RF95_MODEM_STATUS_HEADER_INFO_VALID)) != 0;
     }
 
-    int tryScanChannel() {
-      // start CAD
-      int16_t state = startChannelScan();
-      RADIOLIB_ASSERT(state);
-
-      // wait for channel activity detected or timeout
-      unsigned long timeout = millis() + 16;
-      while(!this->mod->hal->digitalRead(this->mod->getIrq()) && millis() < timeout) {
-        this->mod->hal->yield();
-        if(this->mod->hal->digitalRead(this->mod->getGpio())) {
-          return(RADIOLIB_PREAMBLE_DETECTED);
-        }
+    int16_t scanCAD() {
+      int16_t state = scanChannel();
+      if (state == RADIOLIB_LORA_DETECTED) {
+        return 1;
       }
-      return 0; // timed out
+      return 0;
     }
 };

--- a/src/helpers/radiolib/CustomSX1276Wrapper.h
+++ b/src/helpers/radiolib/CustomSX1276Wrapper.h
@@ -6,12 +6,19 @@
 class CustomSX1276Wrapper : public RadioLibWrapper {
 public:
   CustomSX1276Wrapper(CustomSX1276& radio, mesh::MainBoard& board) : RadioLibWrapper(radio, board) { }
+
   bool isReceivingPacket() override { 
     return ((CustomSX1276 *)_radio)->isReceiving();
   }
+
+  int scanChannelActivity() override {
+    return ((CustomSX1276 *)_radio)->scanCAD();
+  }
+
   float getCurrentRSSI() override {
     return ((CustomSX1276 *)_radio)->getRSSI(false);
   }
+
   float getLastRSSI() const override { return ((CustomSX1276 *)_radio)->getRSSI(); }
   float getLastSNR() const override { return ((CustomSX1276 *)_radio)->getSNR(); }
 

--- a/src/helpers/radiolib/RadioLibWrappers.h
+++ b/src/helpers/radiolib/RadioLibWrappers.h
@@ -15,7 +15,6 @@ protected:
   void idle();
   void startRecv();
   float packetScoreInt(float snr, int sf, int packet_len);
-  virtual bool isReceivingPacket() =0;
 
 public:
   RadioLibWrapper(PhysicalLayer& radio, mesh::MainBoard& board) : _radio(&radio), _board(&board) { n_recv = n_sent = 0; }
@@ -28,13 +27,10 @@ public:
   bool isSendComplete() override;
   void onSendFinished() override;
   bool isInRecvMode() const override;
-  bool isChannelActive();
+  bool isChannelActive() override;
 
-  bool isReceiving() override { 
-    if (isReceivingPacket()) return true;
-
-    return isChannelActive();
-  }
+  bool isReceivingPacket() override =0;
+  int scanChannelActivity() override =0;
 
   virtual float getCurrentRSSI() =0;
 


### PR DESCRIPTION
Refactors LBT into three explicit checks before transmitting:
- Check if radio is mid-receive (IRQ flags)
- Run active CAD scan
- Check RSSI vs noise floor threshold