### PR TITLE
Heltec v4: Add cli command to toggle GPIO

### DIFF
--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -264,6 +264,15 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
     } else if (memcmp(command, "clear stats", 11) == 0) {
       _callbacks->clearStats();
       strcpy(reply, "(OK - stats reset)");
+    #ifdef PIN_GPIO
+    } else if (memcmp(command, "gpio 1", 6) == 0) {
+        digitalWrite(PIN_GPIO, HIGH);
+        strcpy(reply, "(OK - gpio HIGH)");
+    } else if (memcmp(command, "gpio 0", 6) == 0) {
+        digitalWrite(PIN_GPIO, LOW);   
+        strcpy(reply, "(OK - gpio LOW)");
+
+    #endif
     /*
      * GET commands
      */

--- a/variants/heltec_v4/HeltecV4Board.cpp
+++ b/variants/heltec_v4/HeltecV4Board.cpp
@@ -16,6 +16,10 @@ void HeltecV4Board::begin() {
     pinMode(P_LORA_PA_TX_EN, OUTPUT);
     digitalWrite(P_LORA_PA_TX_EN,LOW);
 
+    #ifdef PIN_GPIO
+    pinMode(PIN_GPIO, OUTPUT);
+    digitalWrite(PIN_GPIO, LOW);
+    #endif
 
     periph_power.begin();
 

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -40,6 +40,7 @@ build_flags =
   -D ENV_INCLUDE_GPS=1
   -D PIN_ADC_CTRL=37
   -D PIN_VBAT_READ=1
+  -D PIN_GPIO=48
 build_src_filter = ${esp32_base.build_src_filter}
   +<../variants/heltec_v4>
   +<helpers/sensors>


### PR DESCRIPTION
This PR adds the capability to control a gpio pin defined in the target's `platformio.ini` by `-D PIN_GPIO` via command line.

`gpio 1` will set the pin HIGH
`gpio 0` will set the pin LOW

States are not persisted, rebooting resets the pin to LOW.
This could be useful to control other hardware next to the repeater, like e.g. starting a RPi next to the repeater.
Implementation should be straightforward for other targets. 
