### PR TITLE
Fix Ikoka Stick builds

### DIFF
--- a/variants/ikoka_stick_nrf/platformio.ini
+++ b/variants/ikoka_stick_nrf/platformio.ini
@@ -27,6 +27,7 @@ build_flags = ${nrf52_base.build_flags}
   -D PIN_USER_BTN=0
   -D PIN_WIRE_SCL=7
   -D PIN_WIRE_SDA=6
+  -UENV_INCLUDE_GPS
 lib_deps = ${nrf52_base.lib_deps}
   ${sensor_base.lib_deps}
 


### PR DESCRIPTION
The Ikoka Stick builds are failing on the dev branch. 

A recent change reorganized the Ikoka bits, and the Ikoka nano included `-UENV_INCLUDE_GPS` but the Ikoka Stick did not. Adding it to the Ikoka Stick build flags seems to have fixed the glitch.

**Before**

```
./build.sh build-firmware ikoka_stick_nrf_30dbm_companion_radio_ble
Processing ikoka_stick_nrf_30dbm_companion_radio_ble (board: seeed-xiao-afruitnrf52-nrf52840; platform: nordicnrf52; framework: arduino)

...

*** [.pio/build/ikoka_stick_nrf_30dbm_companion_radio_ble/variants/ikoka_stick_nrf/target.cpp.o] Error 1
src/helpers/sensors/EnvironmentSensorManager.cpp: In member function 'void EnvironmentSensorManager::initBasicGPS()':
src/helpers/sensors/EnvironmentSensorManager.cpp:549:19: error: 'PIN_GPS_TX' was not declared in this scope
   Serial1.setPins(PIN_GPS_TX, PIN_GPS_RX);
                   ^~~~~~~~~~
src/helpers/sensors/EnvironmentSensorManager.cpp:549:19: note: suggested alternative: 'PIN_VBAT'
   Serial1.setPins(PIN_GPS_TX, PIN_GPS_RX);
                   ^~~~~~~~~~
                   PIN_VBAT
src/helpers/sensors/EnvironmentSensorManager.cpp:549:31: error: 'PIN_GPS_RX' was not declared in this scope
   Serial1.setPins(PIN_GPS_TX, PIN_GPS_RX);
                               ^~~~~~~~~~
src/helpers/sensors/EnvironmentSensorManager.cpp:549:31: note: suggested alternative: 'PIN_QSPI_CS'
   Serial1.setPins(PIN_GPS_TX, PIN_GPS_RX);
                               ^~~~~~~~~~
                               PIN_QSPI_CS
*** [.pio/build/ikoka_stick_nrf_30dbm_companion_radio_ble/src/helpers/sensors/EnvironmentSensorManager.cpp.o] Error 1
================================================================================== [FAILED] Took 5.14 seconds ==================================================================================

Environment                                Status    Duration
-----------------------------------------  --------  ------------
ikoka_stick_nrf_30dbm_companion_radio_ble  FAILED    00:00:05.143
```

**After**

```
./build.sh build-firmware ikoka_stick_nrf_30dbm_companion_radio_ble
Processing ikoka_stick_nrf_30dbm_companion_radio_ble (board: seeed-xiao-afruitnrf52-nrf52840; platform: nordicnrf52; framework: arduino)

...


Checking size .pio/build/ikoka_stick_nrf_30dbm_companion_radio_ble/firmware.elf
Building .pio/build/ikoka_stick_nrf_30dbm_companion_radio_ble/firmware.hex
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [======    ]  59.8% (used 142176 bytes from 237568 bytes)
Flash: [======    ]  61.4% (used 435228 bytes from 708608 bytes)
Building .pio/build/ikoka_stick_nrf_30dbm_companion_radio_ble/firmware.zip
Zip created at .pio/build/ikoka_stick_nrf_30dbm_companion_radio_ble/firmware.zip
================================================================================= [SUCCESS] Took 21.91 seconds =================================================================================

Environment                                Status    Duration
-----------------------------------------  --------  ------------
ikoka_stick_nrf_30dbm_companion_radio_ble  SUCCESS   00:00:21.911
================================================================================= 1 succeeded in 00:00:21.911 =================================================================================
Converted to uf2, output size: 870912, start address: 0x27000
Wrote 870912 bytes to .pio/build/ikoka_stick_nrf_30dbm_companion_radio_ble/firmware.uf2
```