### PR TITLE
fix: bump max contacts for heltec v3 companion usb

### DIFF
--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -323,7 +323,7 @@ lib_deps =
 extends = Heltec_lora32_v3
 build_flags =
   ${Heltec_lora32_v3.build_flags}
-  -D MAX_CONTACTS=140
+  -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
 ; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
 ; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1


### PR DESCRIPTION
while changing usb companion's MAX_CONTACTS to 350, this one was left behind, so adding it now.