### PR TITLE
RP2040 Update SX126X_DIO3_TCXO_VOLTAGE to 1.8 V

### DIFF
--- a/variants/waveshare_rp2040_lora/platformio.ini
+++ b/variants/waveshare_rp2040_lora/platformio.ini
@@ -19,7 +19,7 @@ build_flags = ${rp2040_base.build_flags}
   -D P_LORA_MOSI=15
   -D P_LORA_TX_LED=25
   -D SX126X_DIO2_AS_RF_SWITCH=true
-  -D SX126X_DIO3_TCXO_VOLTAGE=0
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
   -D SX126X_RX_BOOSTED_GAIN=1
   -D LORA_TX_POWER=22
 ; Debug options


### PR DESCRIPTION
Radiolib no longer accepts TCXO voltage of 0.
Radio fails to start, silently.
Changed to 1.6 volts. Fixes #1109 
Tested by @kszymkowiak