### PR TITLE
Fix Serial and TX LED not working on Heltec Wireless Paper V1.2

### DIFF
--- a/variants/heltec_wireless_paper/platformio.ini
+++ b/variants/heltec_wireless_paper/platformio.ini
@@ -5,7 +5,7 @@ build_flags =
   ${esp32_base.build_flags}
   -I variants/heltec_wireless_paper
   -D HELTEC_WIRELESS_PAPER
-  -D ARDUINO_USB_CDC_ON_BOOT=1      ; need for Serial
+  ;-D ARDUINO_USB_CDC_ON_BOOT=1      ; this breaks Serial
   -D P_LORA_DIO_1=14
   -D P_LORA_NSS=8
   -D P_LORA_RESET=RADIOLIB_NC
@@ -17,8 +17,8 @@ build_flags =
   -D WRAPPER_CLASS=CustomSX1262Wrapper
   -D LORA_TX_POWER=22
   -D P_LORA_TX_LED=18
-  -D PIN_BOARD_SDA=17
-  -D PIN_BOARD_SCL=18
+  ;-D PIN_BOARD_SDA=17
+  ;-D PIN_BOARD_SCL=18               ; same GPIO as P_LORA_TX_LED
   -D PIN_USER_BTN=0
   -D PIN_VEXT_EN=45
   -D PIN_VBAT_READ=20


### PR DESCRIPTION
As described on #1276, tested and working on my heltec wireless paper v1.2