### PR TITLE
Add cli command `region list {allowed|denied}`, enable output of region cmd via remote cli

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -1068,8 +1068,8 @@ void MyMesh::handleCommand(uint32_t sender_timestamp, char *command, char *reply
 
     const char* parts[4];
     int n = mesh::Utils::parseTextParts(command, parts, 4, ' ');
-    if (n == 1 && sender_timestamp == 0) {
-      region_map.exportTo(Serial);
+    if (n == 1) {
+      region_map.exportTo(reply, 160);
     } else if (n >= 2 && strcmp(parts[1], "load") == 0) {
       temp_map.resetFrom(region_map);   // rebuild regions in a temp instance
       memset(load_stack, 0, sizeof(load_stack));
@@ -1141,6 +1141,25 @@ void MyMesh::handleCommand(uint32_t sender_timestamp, char *command, char *reply
         }
       } else {
         strcpy(reply, "Err - not found");
+      }
+    } else if (n >= 3 && strcmp(parts[1], "list") == 0) {
+      uint8_t mask = 0;
+      bool invert = false;
+      
+      if (strcmp(parts[2], "allowed") == 0) {
+        mask = REGION_DENY_FLOOD;
+        invert = false;  // list regions that DON'T have DENY flag
+      } else if (strcmp(parts[2], "denied") == 0) {
+        mask = REGION_DENY_FLOOD;
+        invert = true;   // list regions that DO have DENY flag
+      } else {
+        strcpy(reply, "Err - use 'allowed' or 'denied'");
+        return;
+      }
+      
+      int len = region_map.exportNamesTo(reply, 160, mask, invert);
+      if (len == 0) {
+        strcpy(reply, "-none-");
       }
     } else {
       strcpy(reply, "Err - ??");

--- a/src/helpers/RegionMap.h
+++ b/src/helpers/RegionMap.h
@@ -49,7 +49,9 @@ public:
   int getCount() const { return num_regions; }
   const RegionEntry* getByIdx(int i) const { return &regions[i]; }
   const RegionEntry* getRoot() const { return &wildcard; }
-  int exportNamesTo(char *dest, int max_len, uint8_t mask);
+  int exportNamesTo(char *dest, int max_len, uint8_t mask, bool invert = false);
 
-  void exportTo(Stream& out) const;
+  void    exportTo(Stream& out) const;
+  size_t  exportTo(char *dest, size_t max_len) const;
+ 
 };


### PR DESCRIPTION
As of today the `region` command is limited to serial output only. [1]

This PR adds the ability to also access the output of the `region` command via the remote cli.
Many repeaters are in remote and/or inaccessible locations. The need for a physical USB connection to debug region settings of already installed repeaters is far from ideal, IMHO.
As region configuration is unlikely to change frequently this is a trade-off between usability and LoRa data minimalism.

The output is limited to 160 chars for remote cli limiting the data to one LoRa packet. As a consequence more complex region setups might not be printed out completely.

[1] https://github.com/meshcore-dev/MeshCore/wiki/Repeater-&-Room-Server-CLI-Reference