### PR TITLE
fix: avoid redundant redefinition of SX126X_DIO3_TCXO_VOLTAGE

### DIFF
--- a/src/helpers/radiolib/CustomLLCC68.h
+++ b/src/helpers/radiolib/CustomLLCC68.h
@@ -45,8 +45,7 @@ class CustomLLCC68 : public LLCC68 {
       int status = begin(LORA_FREQ, LORA_BW, LORA_SF, cr, RADIOLIB_SX126X_SYNC_WORD_PRIVATE, LORA_TX_POWER, 16, tcxo);
       // if radio init fails with -707/-706, try again with tcxo voltage set to 0.0f
       if (status == RADIOLIB_ERR_SPI_CMD_FAILED || status == RADIOLIB_ERR_SPI_CMD_INVALID) {
-        #define SX126X_DIO3_TCXO_VOLTAGE (0.0f);
-        tcxo = SX126X_DIO3_TCXO_VOLTAGE;
+        tcxo = 0.0f;
         status = begin(LORA_FREQ, LORA_BW, LORA_SF, cr, RADIOLIB_SX126X_SYNC_WORD_PRIVATE, LORA_TX_POWER, 16, tcxo);
       }
       if (status != RADIOLIB_ERR_NONE) {

--- a/src/helpers/radiolib/CustomSX1262.h
+++ b/src/helpers/radiolib/CustomSX1262.h
@@ -45,8 +45,7 @@ class CustomSX1262 : public SX1262 {
       int status = begin(LORA_FREQ, LORA_BW, LORA_SF, cr, RADIOLIB_SX126X_SYNC_WORD_PRIVATE, LORA_TX_POWER, 16, tcxo);
       // if radio init fails with -707/-706, try again with tcxo voltage set to 0.0f
       if (status == RADIOLIB_ERR_SPI_CMD_FAILED || status == RADIOLIB_ERR_SPI_CMD_INVALID) {
-        #define SX126X_DIO3_TCXO_VOLTAGE (0.0f);
-        tcxo = SX126X_DIO3_TCXO_VOLTAGE;
+        tcxo = 0.0f;
         status = begin(LORA_FREQ, LORA_BW, LORA_SF, cr, RADIOLIB_SX126X_SYNC_WORD_PRIVATE, LORA_TX_POWER, 16, tcxo);
       }
       if (status != RADIOLIB_ERR_NONE) {

--- a/src/helpers/radiolib/CustomSX1268.h
+++ b/src/helpers/radiolib/CustomSX1268.h
@@ -45,8 +45,7 @@ class CustomSX1268 : public SX1268 {
       int status = begin(LORA_FREQ, LORA_BW, LORA_SF, cr, RADIOLIB_SX126X_SYNC_WORD_PRIVATE, LORA_TX_POWER, 16, tcxo);
       // if radio init fails with -707/-706, try again with tcxo voltage set to 0.0f
       if (status == RADIOLIB_ERR_SPI_CMD_FAILED || status == RADIOLIB_ERR_SPI_CMD_INVALID) {
-        #define SX126X_DIO3_TCXO_VOLTAGE (0.0f);
-        tcxo = SX126X_DIO3_TCXO_VOLTAGE;
+        tcxo = 0.0f;
         status = begin(LORA_FREQ, LORA_BW, LORA_SF, cr, RADIOLIB_SX126X_SYNC_WORD_PRIVATE, LORA_TX_POWER, 16, tcxo);
       }
       if (status != RADIOLIB_ERR_NONE) {


### PR DESCRIPTION
SX126X_DIO3_TCXO_VOLTAGE was repeatedly defined in header files when
multiple headers were included, leading to unintended TCXO voltage
override.

Ensure the macro is defined only once.

```
#include <helpers/radiolib/CustomSX1262Wrapper.h>   <- ok
#include <helpers/radiolib/CustomSX1268Wrapper.h>   <- ng
```