### PR TITLE
Add heltec v4-tft code.

### DIFF
--- a/src/helpers/ui/SSD1306Display.cpp
+++ b/src/helpers/ui/SSD1306Display.cpp
@@ -7,6 +7,10 @@ bool SSD1306Display::i2c_probe(TwoWire& wire, uint8_t addr) {
 }
 
 bool SSD1306Display::begin() {
+  if (!_isOn) {
+    if (_peripher_power) _peripher_power->claim();
+    _isOn = true;
+  }
   #ifdef DISPLAY_ROTATION
   display.setRotation(DISPLAY_ROTATION);
   #endif
@@ -15,12 +19,18 @@ bool SSD1306Display::begin() {
 
 void SSD1306Display::turnOn() {
   display.ssd1306_command(SSD1306_DISPLAYON);
-  _isOn = true;
+  if (!_isOn) {
+    if (_peripher_power) _peripher_power->claim();
+    _isOn = true;
+  }
 }
 
 void SSD1306Display::turnOff() {
   display.ssd1306_command(SSD1306_DISPLAYOFF);
-  _isOn = false;
+  if (_isOn) {
+    if (_peripher_power) _peripher_power->release();
+    _isOn = false;
+  }
 }
 
 void SSD1306Display::clear() {

--- a/src/helpers/ui/SSD1306Display.h
+++ b/src/helpers/ui/SSD1306Display.h
@@ -5,6 +5,7 @@
 #include <Adafruit_GFX.h>
 #define SSD1306_NO_SPLASH
 #include <Adafruit_SSD1306.h>
+#include <helpers/RefCountedDigitalPin.h>
 
 #ifndef PIN_OLED_RESET
   #define PIN_OLED_RESET        21 // Reset pin # (or -1 if sharing Arduino reset pin)
@@ -18,10 +19,16 @@ class SSD1306Display : public DisplayDriver {
   Adafruit_SSD1306 display;
   bool _isOn;
   uint8_t _color;
+  RefCountedDigitalPin* _peripher_power;
 
   bool i2c_probe(TwoWire& wire, uint8_t addr);
 public:
-  SSD1306Display() : DisplayDriver(128, 64), display(128, 64, &Wire, PIN_OLED_RESET) { _isOn = false; }
+  SSD1306Display(RefCountedDigitalPin* peripher_power=NULL) : DisplayDriver(128, 64), 
+      display(128, 64, &Wire, PIN_OLED_RESET),
+      _peripher_power(peripher_power)
+  {
+    _isOn = false; 
+  }
   bool begin();
 
   bool isOn() override { return _isOn; }

--- a/src/helpers/ui/ST7789LCDDisplay.cpp
+++ b/src/helpers/ui/ST7789LCDDisplay.cpp
@@ -28,11 +28,14 @@ bool ST7789LCDDisplay::begin() {
       digitalWrite(PIN_TFT_LEDA_CTL, HIGH);
     }
     if (PIN_TFT_RST != -1) {
+      pinMode(PIN_TFT_RST, OUTPUT);
+      digitalWrite(PIN_TFT_RST, LOW); 
+      delay(10);
       digitalWrite(PIN_TFT_RST, HIGH);
     }
 
     // Im not sure if this is just a t-deck problem or not, if your display is slow try this.
-    #ifdef LILYGO_TDECK
+    #if defined(LILYGO_TDECK) || defined(HELTEC_LORA_V4_TFT)
       displaySPI.begin(PIN_TFT_SCL, -1, PIN_TFT_SDA, PIN_TFT_CS);
     #endif
 

--- a/src/helpers/ui/ST7789LCDDisplay.h
+++ b/src/helpers/ui/ST7789LCDDisplay.h
@@ -8,7 +8,7 @@
 #include <helpers/RefCountedDigitalPin.h>
 
 class ST7789LCDDisplay : public DisplayDriver {
-  #ifdef LILYGO_TDECK
+  #if defined(LILYGO_TDECK) || defined(HELTEC_LORA_V4_TFT)
     SPIClass displaySPI;
   #endif
   Adafruit_ST7789 display;
@@ -25,7 +25,7 @@ public:
   {
     _isOn = false;
   }
-#elif LILYGO_TDECK
+#elif defined(LILYGO_TDECK) || defined(HELTEC_LORA_V4_TFT)
   ST7789LCDDisplay(RefCountedDigitalPin* peripher_power=NULL) : DisplayDriver(128, 64),
       displaySPI(HSPI),
       display(&displaySPI, PIN_TFT_CS, PIN_TFT_DC, PIN_TFT_RST),

--- a/variants/heltec_v4/HeltecV4Board.cpp
+++ b/variants/heltec_v4/HeltecV4Board.cpp
@@ -86,5 +86,9 @@ void HeltecV4Board::begin() {
   }
 
   const char* HeltecV4Board::getManufacturerName() const {
-    return "Heltec V4";
+  #ifdef HELTEC_LORA_V4_TFT
+    return "Heltec V4 TFT";
+  #else
+    return "Heltec V4 OLED";
+  #endif
   }

--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -20,11 +20,9 @@ build_flags =
   -D P_LORA_PA_POWER=7   ;power en
   -D P_LORA_PA_EN=2
   -D P_LORA_PA_TX_EN=46  ;enable tx
-  -D PIN_BOARD_SDA=17
-  -D PIN_BOARD_SCL=18
   -D PIN_USER_BTN=0
   -D PIN_VEXT_EN=36
-  -D PIN_VEXT_EN_ACTIVE=HIGH
+  -D PIN_VEXT_EN_ACTIVE=LOW
   -D LORA_TX_POWER=10 ;If it is configured as 10 here, the final output will be 22 dbm.
   -D MAX_LORA_TX_POWER=22 ; Max SX1262 output
   -D SX126X_DIO2_AS_RF_SWITCH=true
@@ -47,10 +45,44 @@ lib_deps =
   ${esp32_base.lib_deps}
   ${sensor_base.lib_deps}
 
-[env:heltec_v4_repeater]
+[heltec_v4_oled]
 extends = Heltec_lora32_v4
 build_flags =
   ${Heltec_lora32_v4.build_flags}
+  -D HELTEC_LORA_V4_OLED
+  -D PIN_BOARD_SDA=17
+  -D PIN_BOARD_SCL=18
+  -D ENV_PIN_SDA=4
+  -D ENV_PIN_SCL=3
+build_src_filter= ${Heltec_lora32_v4.build_src_filter}
+lib_deps = ${Heltec_lora32_v4.lib_deps}
+
+[heltec_v4_tft]
+extends = Heltec_lora32_v4
+build_flags =
+  ${Heltec_lora32_v4.build_flags}
+  -D HELTEC_LORA_V4_TFT
+  -D PIN_BOARD_SDA=4
+  -D PIN_BOARD_SCL=3
+  -D DISPLAY_SCALE_X=2.5
+  -D DISPLAY_SCALE_Y=3.75
+  -D PIN_TFT_RST=18
+  -D PIN_TFT_VDD_CTL=-1
+  -D PIN_TFT_LEDA_CTL=21
+  -D PIN_TFT_LEDA_CTL_ACTIVE=HIGH
+  -D PIN_TFT_CS=15
+  -D PIN_TFT_DC=16
+  -D PIN_TFT_SCL=17
+  -D PIN_TFT_SDA=33
+build_src_filter= ${Heltec_lora32_v4.build_src_filter}
+lib_deps = 
+  ${Heltec_lora32_v4.lib_deps}
+  adafruit/Adafruit ST7735 and ST7789 Library @ ^1.11.0
+
+[env:heltec_v4_repeater]
+extends = heltec_v4_oled
+build_flags =
+  ${heltec_v4_oled.build_flags}
   -D DISPLAY_CLASS=SSD1306Display
   -D ADVERT_NAME='"Heltec Repeater"'
   -D ADVERT_LAT=0.0
@@ -59,18 +91,18 @@ build_flags =
   -D MAX_NEIGHBOURS=50
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
-build_src_filter = ${Heltec_lora32_v4.build_src_filter}
+build_src_filter = ${heltec_v4_oled.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_repeater>
 lib_deps =
-  ${Heltec_lora32_v4.lib_deps}
+  ${heltec_v4_oled.lib_deps}
   ${esp32_ota.lib_deps}
   bakercp/CRC32 @ ^2.0.0
 
 [env:heltec_v4_repeater_bridge_espnow]
-extends = Heltec_lora32_v4
+extends = heltec_v4_oled
 build_flags =
-  ${Heltec_lora32_v4.build_flags}
+  ${heltec_v4_oled.build_flags}
   -D DISPLAY_CLASS=SSD1306Display
   -D ADVERT_NAME='"ESPNow Bridge"'
   -D ADVERT_LAT=0.0
@@ -81,18 +113,18 @@ build_flags =
 ;  -D BRIDGE_DEBUG=1
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
-build_src_filter = ${Heltec_lora32_v4.build_src_filter}
+build_src_filter = ${heltec_v4_oled.build_src_filter}
   +<helpers/bridges/ESPNowBridge.cpp>
   +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_repeater>
 lib_deps =
-  ${Heltec_lora32_v4.lib_deps}
+  ${heltec_v4_oled.lib_deps}
   ${esp32_ota.lib_deps}
 
 [env:heltec_v4_room_server]
-extends = Heltec_lora32_v4
+extends = heltec_v4_oled
 build_flags =
-  ${Heltec_lora32_v4.build_flags}
+  ${heltec_v4_oled.build_flags}
   -D DISPLAY_CLASS=SSD1306Display
   -D ADVERT_NAME='"Heltec Room"'
   -D ADVERT_LAT=0.0
@@ -101,50 +133,50 @@ build_flags =
   -D ROOM_PASSWORD='"hello"'
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
-build_src_filter = ${Heltec_lora32_v4.build_src_filter}
+build_src_filter = ${heltec_v4_oled.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_room_server>
 lib_deps =
-  ${Heltec_lora32_v4.lib_deps}
+  ${heltec_v4_oled.lib_deps}
   ${esp32_ota.lib_deps}
 
 [env:heltec_v4_terminal_chat]
-extends = Heltec_lora32_v4
+extends = heltec_v4_oled
 build_flags =
-  ${Heltec_lora32_v4.build_flags}
+  ${heltec_v4_oled.build_flags}
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=1
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
-build_src_filter = ${Heltec_lora32_v4.build_src_filter}
+build_src_filter = ${heltec_v4_oled.build_src_filter}
   +<../examples/simple_secure_chat/main.cpp>
 lib_deps =
-  ${Heltec_lora32_v4.lib_deps}
+  ${heltec_v4_oled.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
 [env:heltec_v4_companion_radio_usb]
-extends = Heltec_lora32_v4
+extends = heltec_v4_oled
 build_flags =
-  ${Heltec_lora32_v4.build_flags}
+  ${heltec_v4_oled.build_flags}
   -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
   -D DISPLAY_CLASS=SSD1306Display
 ; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
 ; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
-build_src_filter = ${Heltec_lora32_v4.build_src_filter}
+build_src_filter = ${heltec_v4_oled.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<helpers/ui/MomentaryButton.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
-  ${Heltec_lora32_v4.lib_deps}
+  ${heltec_v4_oled.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
 [env:heltec_v4_companion_radio_ble]
-extends = Heltec_lora32_v4
+extends = heltec_v4_oled
 build_flags =
-  ${Heltec_lora32_v4.build_flags}
+  ${heltec_v4_oled.build_flags}
   -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
@@ -155,20 +187,20 @@ build_flags =
   -D OFFLINE_QUEUE_SIZE=256
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
-build_src_filter = ${Heltec_lora32_v4.build_src_filter}
+build_src_filter = ${heltec_v4_oled.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<helpers/ui/MomentaryButton.cpp>
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
-  ${Heltec_lora32_v4.lib_deps}
+  ${heltec_v4_oled.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
 [env:heltec_v4_companion_radio_wifi]
-extends = Heltec_lora32_v4
+extends = heltec_v4_oled
 build_flags =
-  ${Heltec_lora32_v4.build_flags}
+  ${heltec_v4_oled.build_flags}
   -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
@@ -176,24 +208,23 @@ build_flags =
   -D WIFI_DEBUG_LOGGING=1
   -D WIFI_SSID='"myssid"'
   -D WIFI_PWD='"mypwd"'
-  -D OFFLINE_QUEUE_SIZE=256
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
-build_src_filter = ${Heltec_lora32_v4.build_src_filter}
+build_src_filter = ${heltec_v4_oled.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<helpers/ui/MomentaryButton.cpp>
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-new/*.cpp>
 lib_deps =
-  ${Heltec_lora32_v4.lib_deps}
+  ${heltec_v4_oled.lib_deps}
   densaugeo/base64 @ ~1.4.0
 
 [env:heltec_v4_sensor]
-extends = Heltec_lora32_v4
+extends = heltec_v4_oled
 build_flags =
-  ${Heltec_lora32_v4.build_flags}
-  -D ADVERT_NAME='"Heltec v3 Sensor"'
+  ${heltec_v4_oled.build_flags}
+  -D ADVERT_NAME='"Heltec v4 Sensor"'
   -D ADVERT_LAT=0.0
   -D ADVERT_LON=0.0
   -D ADMIN_PASSWORD='"password"'
@@ -202,9 +233,172 @@ build_flags =
   -D DISPLAY_CLASS=SSD1306Display
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
-build_src_filter = ${Heltec_lora32_v4.build_src_filter}
+build_src_filter = ${heltec_v4_oled.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_sensor>
 lib_deps =
-  ${Heltec_lora32_v4.lib_deps}
+  ${heltec_v4_oled.lib_deps}
+  ${esp32_ota.lib_deps}
+
+
+[env:heltec_v4_tft_repeater]
+extends = heltec_v4_tft
+build_flags =
+  ${heltec_v4_tft.build_flags}
+  -D DISPLAY_CLASS=ST7789LCDDisplay
+  -D ADVERT_NAME='"Heltec Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${heltec_v4_tft.build_src_filter}
+  +<helpers/ui/ST7789LCDDisplay.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${heltec_v4_tft.lib_deps}
+  ${esp32_ota.lib_deps}
+  bakercp/CRC32 @ ^2.0.0
+
+
+[env:heltec_v4_tft_repeater_bridge_espnow]
+extends = heltec_v4_tft
+build_flags =
+  ${heltec_v4_tft.build_flags}
+  -D DISPLAY_CLASS=ST7789LCDDisplay
+  -D ADVERT_NAME='"ESPNow Bridge"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WITH_ESPNOW_BRIDGE=1
+;  -D BRIDGE_DEBUG=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${heltec_v4_tft.build_src_filter}
+  +<helpers/bridges/ESPNowBridge.cpp>
+  +<helpers/ui/ST7789LCDDisplay.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${heltec_v4_tft.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:heltec_v4_tft_room_server]
+extends = heltec_v4_tft
+build_flags =
+  ${heltec_v4_tft.build_flags}
+  -D DISPLAY_CLASS=ST7789LCDDisplay
+  -D ADVERT_NAME='"Heltec Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${heltec_v4_tft.build_src_filter}
+  +<helpers/ui/ST7789LCDDisplay.cpp>
+  +<../examples/simple_room_server>
+lib_deps =
+  ${heltec_v4_tft.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:heltec_v4_tft_terminal_chat]
+extends = heltec_v4_tft
+build_flags =
+  ${heltec_v4_tft.build_flags}
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${heltec_v4_tft.build_src_filter}
+  +<../examples/simple_secure_chat/main.cpp>
+lib_deps =
+  ${heltec_v4_tft.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:heltec_v4_tft_companion_radio_usb]
+extends = heltec_v4_tft
+build_flags =
+  ${heltec_v4_tft.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D DISPLAY_CLASS=ST7789LCDDisplay
+; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
+; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
+build_src_filter = ${heltec_v4_tft.build_src_filter}
+  +<helpers/ui/ST7789LCDDisplay.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${heltec_v4_tft.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:heltec_v4_tft_companion_radio_ble]
+extends = heltec_v4_tft
+build_flags =
+  ${heltec_v4_tft.build_flags}
+  -I examples/companion_radio/ui-new
+  -D DISPLAY_CLASS=ST7789LCDDisplay
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456   ; dynamic, random PIN
+  -D AUTO_SHUTDOWN_MILLIVOLTS=3400
+  -D BLE_DEBUG_LOGGING=1
+  -D OFFLINE_QUEUE_SIZE=256
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${heltec_v4_tft.build_src_filter}
+  +<helpers/ui/ST7789LCDDisplay.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${heltec_v4_tft.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:heltec_v4_tft_companion_radio_wifi]
+extends = heltec_v4_tft
+build_flags =
+  ${heltec_v4_tft.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D DISPLAY_CLASS=ST7789LCDDisplay
+  -D WIFI_DEBUG_LOGGING=1
+  -D WIFI_SSID='"myssid"'
+  -D WIFI_PWD='"mypwd"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${heltec_v4_tft.build_src_filter}
+  +<helpers/ui/ST7789LCDDisplay.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<helpers/esp32/*.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${heltec_v4_tft.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:heltec_v4_tft_sensor]
+extends = heltec_v4_tft
+build_flags =
+  ${heltec_v4_tft.build_flags}
+  -D ADVERT_NAME='"Heltec v4 Sensor"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ENV_PIN_SDA=3
+  -D ENV_PIN_SCL=4
+  -D DISPLAY_CLASS=ST7789LCDDisplay
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${heltec_v4_tft.build_src_filter}
+  +<helpers/ui/ST7789LCDDisplay.cpp>
+  +<../examples/simple_sensor>
+lib_deps =
+  ${heltec_v4_tft.lib_deps}
   ${esp32_ota.lib_deps}

--- a/variants/heltec_v4/target.cpp
+++ b/variants/heltec_v4/target.cpp
@@ -24,7 +24,7 @@ AutoDiscoverRTCClock rtc_clock(fallback_clock);
 #endif
 
 #ifdef DISPLAY_CLASS
-  DISPLAY_CLASS display;
+  DISPLAY_CLASS display(&(board.periph_power));
   MomentaryButton user_btn(PIN_USER_BTN, 1000, true);
 #endif
 

--- a/variants/heltec_v4/target.h
+++ b/variants/heltec_v4/target.h
@@ -9,7 +9,11 @@
 #include <helpers/SensorManager.h>
 #include <helpers/sensors/EnvironmentSensorManager.h>
 #ifdef DISPLAY_CLASS
-  #include <helpers/ui/SSD1306Display.h>
+#ifdef HELTEC_LORA_V4_OLED
+    #include <helpers/ui/SSD1306Display.h>
+#elif defined(HELTEC_LORA_V4_TFT)
+    #include <helpers/ui/ST7789LCDDisplay.h>
+#endif
   #include <helpers/ui/MomentaryButton.h>
 #endif
 


### PR DESCRIPTION
The previous commit #1118 for V4-tft enabled macros related to the env sensor, causing the OLED version to freeze at startup. Testing revealed this was due to issues with I2C usage, which has been fixed in #1456. Therefore, the v4-tft code has been resubmitted.