### PR TITLE
Support for Meshtiny

### DIFF
--- a/boards/meshtiny.json
+++ b/boards/meshtiny.json
@@ -1,0 +1,74 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "nrf52840_s140_v6.ld"
+    },
+    "core": "nRF5",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DARDUINO_NRF52840_FEATHER -DNRF52840_XXAA",
+    "f_cpu": "64000000L",
+    "hwids": [
+      [
+        "0x239A",
+        "0x8029"
+      ],
+      [
+        "0x239A",
+        "0x0029"
+      ],
+      [
+        "0x239A",
+        "0x002A"
+      ],
+      [
+        "0x239A",
+        "0x802A"
+      ]
+    ],
+    "usb_product": "Meshtiny",
+    "mcu": "nrf52840",
+    "variant": "meshtiny",
+    "bsp": {
+      "name": "adafruit"
+    },
+    "softdevice": {
+      "sd_flags": "-DS140",
+      "sd_name": "s140",
+      "sd_version": "6.1.1",
+      "sd_fwid": "0x00B6"
+    },
+    "bootloader": {
+      "settings_addr": "0xFF000"
+    }
+  },
+  "connectivity": [
+    "bluetooth"
+  ],
+  "debug": {
+    "jlink_device": "nRF52840_xxAA",
+    "svd_path": "nrf52840.svd",
+    "openocd_target": "nrf52840-mdk-rs"
+  },
+  "frameworks": [
+    "arduino",
+    "freertos"
+  ],
+  "name": "Meshtiny",
+  "upload": {
+    "maximum_ram_size": 248832,
+    "maximum_size": 815104,
+    "speed": 115200,
+    "protocol": "nrfutil",
+    "protocols": [
+      "jlink",
+      "nrfjprog",
+      "nrfutil",
+      "stlink"
+    ],
+    "use_1200bps_touch": true,
+    "require_upload_port": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://shop.mtoolstec.com/product/meshtiny",
+  "vendor": "MTools Tec"
+}

--- a/variants/meshtiny/MeshtinyBoard.cpp
+++ b/variants/meshtiny/MeshtinyBoard.cpp
@@ -1,0 +1,44 @@
+#include "MeshtinyBoard.h"
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <bluefruit.h>
+
+static BLEDfu bledfu;
+
+static void connect_callback(uint16_t conn_handle) {
+  (void)conn_handle;
+  MESH_DEBUG_PRINTLN("BLE client connected");
+}
+
+static void disconnect_callback(uint16_t conn_handle, uint8_t reason) {
+  (void)conn_handle;
+  (void)reason;
+
+  MESH_DEBUG_PRINTLN("BLE client disconnected");
+}
+
+void MeshtinyBoard::begin() {
+  NRF52BoardDCDC::begin();
+  btn_prev_state = HIGH;
+
+  pinMode(PIN_VBAT_READ, INPUT); // VBAT ADC input
+
+  // Set all button pins to INPUT_PULLUP
+  pinMode(PIN_BUTTON1, INPUT_PULLUP);
+  pinMode(PIN_BUTTON2, INPUT_PULLUP);
+  pinMode(PIN_BUTTON3, INPUT_PULLUP);
+  pinMode(PIN_BUTTON4, INPUT_PULLUP);
+
+#if defined(PIN_WIRE_SDA) && defined(PIN_WIRE_SCL)
+  Wire.setPins(PIN_WIRE_SDA, PIN_WIRE_SCL);
+#endif
+
+  Wire.begin();
+
+  pinMode(SX126X_POWER_EN, OUTPUT);
+  digitalWrite(SX126X_POWER_EN, HIGH);
+  delay(10);   // give sx1262 some time to power up
+}
+
+

--- a/variants/meshtiny/MeshtinyBoard.h
+++ b/variants/meshtiny/MeshtinyBoard.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <Arduino.h>
+#include <MeshCore.h>
+#include <helpers/NRF52Board.h>
+
+class MeshtinyBoard : public NRF52BoardDCDC, public NRF52BoardOTA {
+protected:
+  uint8_t btn_prev_state;
+
+public:
+  MeshtinyBoard() : NRF52BoardOTA("Meshtiny OTA") {}
+  void begin();
+
+#if defined(P_LORA_TX_LED)
+  void onBeforeTransmit() override {
+    digitalWrite(P_LORA_TX_LED, HIGH);   // turn TX LED on
+  }
+  void onAfterTransmit() override {
+    digitalWrite(P_LORA_TX_LED, LOW);   // turn TX LED off
+  }
+#endif
+
+  uint16_t getBattMilliVolts() override {
+    int adcvalue = 0;
+    analogReadResolution(12);
+    analogReference(AR_INTERNAL_3_0);
+    delay(10);
+    adcvalue = analogRead(PIN_VBAT_READ);
+    return (adcvalue * ADC_MULTIPLIER * AREF_VOLTAGE) / 4.096;
+  }
+
+  const char *getManufacturerName() const override { return "Meshtiny"; }
+
+  void reboot() override { NVIC_SystemReset(); }
+
+  void powerOff() override {
+
+#ifdef PIN_USER_BTN
+    while (digitalRead(PIN_USER_BTN) == LOW) {
+      delay(10);
+    }
+#endif
+
+#ifdef PIN_3V3_EN
+    pinMode(PIN_3V3_EN, OUTPUT);
+    digitalWrite(PIN_3V3_EN, LOW);
+#endif
+
+
+#ifdef PIN_LED1
+    digitalWrite(PIN_LED1, LOW);
+#endif
+
+#ifdef PIN_LED2
+    digitalWrite(PIN_LED2, LOW);
+#endif
+
+#ifdef PIN_USER_BTN
+    nrf_gpio_cfg_sense_input(g_ADigitalPinMap[PIN_USER_BTN], NRF_GPIO_PIN_PULLUP, NRF_GPIO_PIN_SENSE_LOW);
+#endif
+
+    sd_power_system_off();
+  }
+
+};

--- a/variants/meshtiny/platformio.ini
+++ b/variants/meshtiny/platformio.ini
@@ -1,0 +1,68 @@
+[Meshtiny]
+extends = nrf52_base
+board = meshtiny
+board_build.ldscript = boards/nrf52840_s140_v6.ld
+build_flags = ${nrf52_base.build_flags}
+  -I lib/nrf52/s140_nrf52_6.1.1_API/include
+  -I lib/nrf52/s140_nrf52_6.1.1_API/include/nrf52
+  -I variants/meshtiny
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D LORA_TX_POWER=22
+  -D SX126X_CURRENT_LIMIT=140
+  -D SX126X_RX_BOOSTED_GAIN=1
+  -D PIN_3V3_EN=34
+  -D MESHTINY
+  -D UI_HAS_JOYSTICK
+build_src_filter = ${nrf52_base.build_src_filter}
+  +<../variants/meshtiny>
+  +<helpers/ui/SSD1306Display.cpp>
+  +<helpers/ui/buzzer.cpp>
+  +<helpers/sensors>
+lib_deps =
+  ${nrf52_base.lib_deps}
+  adafruit/Adafruit SSD1306 @ ^2.5.13
+  end2endzone/NonBlockingRTTTL@^1.3.0
+
+[env:Meshtiny_companion_radio_usb]
+extends = Meshtiny
+build_flags =
+  ${Meshtiny.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MESHTINY
+  -D PIN_BUZZER=30
+  -D DISPLAY_CLASS=SSD1306Display
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Meshtiny.build_src_filter}
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${Meshtiny.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:Meshtiny_companion_radio_ble]
+extends = Meshtiny
+build_flags =
+  ${Meshtiny.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MESHTINY
+  -D PIN_BUZZER=30
+  -D DISPLAY_CLASS=SSD1306Display
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+;  -D BLE_DEBUG_LOGGING=1
+build_src_filter = ${Meshtiny.build_src_filter}
+  +<helpers/nrf52/SerialBLEInterface.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${Meshtiny.lib_deps}
+  densaugeo/base64 @ ~1.4.0

--- a/variants/meshtiny/target.cpp
+++ b/variants/meshtiny/target.cpp
@@ -1,0 +1,47 @@
+#include "target.h"
+
+#include <Arduino.h>
+#include <helpers/ArduinoHelpers.h>
+
+MeshtinyBoard board;
+
+RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, SPI);
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+VolatileRTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+EnvironmentSensorManager sensors = EnvironmentSensorManager();
+
+#ifdef DISPLAY_CLASS
+DISPLAY_CLASS display;
+  MomentaryButton user_btn(ENCODER_PRESS, 1000, true, true);
+  MomentaryButton joystick_left(ENCODER_LEFT, 1000, true, true);
+  MomentaryButton joystick_right(ENCODER_RIGHT, 1000, true, true);
+  MomentaryButton back_btn(PIN_SIDE_BUTTON, 1000, true, true);
+#endif
+
+bool radio_init() {
+  rtc_clock.begin(Wire);
+  return radio.std_init(&SPI);
+}
+
+uint32_t radio_get_rng_seed() {
+  return radio.random(0x7FFFFFFF);
+}
+
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr) {
+  radio.setFrequency(freq);
+  radio.setSpreadingFactor(sf);
+  radio.setBandwidth(bw);
+  radio.setCodingRate(cr);
+}
+
+void radio_set_tx_power(uint8_t dbm) {
+  radio.setOutputPower(dbm);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng); // create new random identity
+}

--- a/variants/meshtiny/target.h
+++ b/variants/meshtiny/target.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <MeshtinyBoard.h>
+#include <RadioLib.h>
+#include <helpers/ArduinoHelpers.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/radiolib/CustomSX1262Wrapper.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#ifdef DISPLAY_CLASS
+#include <helpers/ui/MomentaryButton.h>
+#include <helpers/ui/SSD1306Display.h>
+#endif
+#include <helpers/sensors/EnvironmentSensorManager.h>
+
+extern MeshtinyBoard board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern EnvironmentSensorManager sensors;
+
+#ifdef DISPLAY_CLASS
+extern DISPLAY_CLASS display;
+extern MomentaryButton user_btn;
+extern MomentaryButton joystick_left;
+extern MomentaryButton joystick_right;
+extern MomentaryButton back_btn;
+#endif
+
+bool radio_init();
+uint32_t radio_get_rng_seed();
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr);
+void radio_set_tx_power(uint8_t dbm);
+mesh::LocalIdentity radio_new_identity();

--- a/variants/meshtiny/variant.cpp
+++ b/variants/meshtiny/variant.cpp
@@ -1,0 +1,51 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2018, Adafruit Industries (adafruit.com)
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "variant.h"
+
+#include "nrf.h"
+#include "wiring_constants.h"
+#include "wiring_digital.h"
+
+const uint32_t g_ADigitalPinMap[] = {
+  // P0
+  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+  29, 30, 31,
+
+  // P1
+  32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47
+};
+
+void initVariant() {
+  // LED1 & LED2
+#ifdef PIN_LED1
+  pinMode(PIN_LED1, OUTPUT);
+  ledOff(PIN_LED1);
+#endif
+
+#ifdef PIN_LED2
+  pinMode(PIN_LED2, OUTPUT);
+  ledOff(PIN_LED2);
+#endif
+
+  // 3V3 Power Rail - nothing connected on meshtiny
+  pinMode(PIN_3V3_EN, OUTPUT);
+  digitalWrite(PIN_3V3_EN, LOW);
+}

--- a/variants/meshtiny/variant.h
+++ b/variants/meshtiny/variant.h
@@ -1,0 +1,98 @@
+#ifndef _MESHTINY_H_
+#define _MESHTINY_H_
+
+/** Master clock frequency */
+#define VARIANT_MCK                     (64000000ul)
+
+#define USE_LFXO                        // Board uses 32khz crystal for LF
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#define PINS_COUNT                      (48)
+#define NUM_DIGITAL_PINS                (48)
+#define NUM_ANALOG_INPUTS               (6)
+#define NUM_ANALOG_OUTPUTS              (0)
+
+// LEDs
+#define PIN_LED1                        (35) // Green LED
+#define PIN_LED2                        (36) // Blue LED
+
+#define LED_RED                         (-1)
+#define LED_GREEN                       PIN_LED1
+#define LED_BLUE                        (-1)  // Disable annoying flashing caused by Bluefruit
+
+#define P_LORA_TX_LED                   PIN_LED2 // Blue LED
+// #define PIN_STATUS_LED                  LED_GREEN  // disable status led.
+#define LED_BUILTIN                     LED_GREEN
+#define PIN_LED                         LED_BUILTIN
+#define LED_PIN                         LED_BUILTIN
+#define LED_STATE_ON                    HIGH
+
+// Buttons
+#define PIN_BUTTON1                     (9)   // side button
+#define PIN_BUTTON2                     (4)   // encoder left
+#define PIN_BUTTON3                     (26)  // encoder right
+#define PIN_BUTTON4                     (28)  // encoder press
+#define PIN_SIDE_BUTTON                 PIN_BUTTON1
+#define ENCODER_LEFT                    PIN_BUTTON2
+#define ENCODER_RIGHT                   PIN_BUTTON3
+#define ENCODER_PRESS                   PIN_BUTTON4
+#define PIN_USER_BTN                    PIN_SIDE_BUTTON
+
+// VBAT sensing
+#define PIN_VBAT_READ                   (5)
+#define BATTERY_SENSE_RESOLUTION_BITS   12
+#define BATTERY_SENSE_RESOLUTION        4096.0
+#define AREF_VOLTAGE                    3.0
+#define VBAT_AR_INTERNAL                AR_INTERNAL_3_0
+#define ADC_MULTIPLIER                  1.73
+#define ADC_RESOLUTION                  14
+
+// Serial interfaces
+#define PIN_SERIAL1_RX                  (15)
+#define PIN_SERIAL1_TX                  (16)
+#define PIN_SERIAL2_RX                  (8)     // Connected to Jlink CDC
+#define PIN_SERIAL2_TX                  (6)
+
+// SPI Interfaces
+#define SPI_INTERFACES_COUNT            2
+
+#define PIN_SPI_MISO                    (45)
+#define PIN_SPI_MOSI                    (44)
+#define PIN_SPI_SCK                     (43)
+
+#define PIN_SPI1_MISO                   (29)
+#define PIN_SPI1_MOSI                   (30)
+#define PIN_SPI1_SCK                    (3)
+
+// LoRa SX1262 module pins
+#define P_LORA_SCLK                     PIN_SPI_SCK
+#define P_LORA_MISO                     PIN_SPI_MISO
+#define P_LORA_MOSI                     PIN_SPI_MOSI
+#define P_LORA_DIO_1                    (47)
+#define P_LORA_RESET                    (38)
+#define P_LORA_BUSY                     (46)
+#define P_LORA_NSS                      (42)
+#define SX126X_POWER_EN                 (37)
+
+#define SX126X_RXEN                     RADIOLIB_NC
+#define SX126X_TXEN                     RADIOLIB_NC
+
+#define SX126X_DIO2_AS_RF_SWITCH        true
+#define SX126X_DIO3_TCXO_VOLTAGE        (1.8f)
+
+// Wire Interfaces
+#define WIRE_INTERFACES_COUNT           1
+#define PIN_WIRE_SDA                    (13)
+#define PIN_WIRE_SCL                    (14)
+#define PIN_BOARD_SDA                   (13)
+#define PIN_BOARD_SCL                   (14)
+
+// Power control
+#define PIN_3V3_EN                      (34)    // nothing connected on meshtiny board
+
+#endif // _MESHTINY_H_


### PR DESCRIPTION
Support for meshtiny. All functions working. Used the 3-way "encoder" switch on top to act like the "joystick" on the WioTrackerL1. Hibernate works with wake from the side button.

I left the annoying Bluefruit flashy LED and the status LED disabled to try and save some juice, the tiny little thing only has 250mah :)

<img width="588" height="447" alt="image" src="https://github.com/user-attachments/assets/10756109-1093-4af6-842f-be809c013cb4" />
