### PR TITLE
Update runArgs in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,11 +10,12 @@
 	},
 	"runArgs": [
 		"--privileged",
-		// arch tty* is owned by uucp (986)
-		// debian tty* is owned by uucp (20) - no change needed
-		"--group-add=986",
 		"--network=host",
-		"--volume=/dev/bus/usb:/dev/bus/usb:ro"
+		"--volume=/dev/bus/usb:/dev/bus/usb:ro",
+		// arch tty* is owned by uucp (986)
+		// debian tty* is owned by dialout (20)
+		"--group-add=20",
+		"--group-add=986"
 	],
 	"postCreateCommand": {
 		"platformio": "pipx install platformio"


### PR DESCRIPTION
Modify the `runArgs` to include additional group permissions for debian/arch host support.