### PR TITLE
Allow usage of "/" in radio names

### DIFF
--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -16,7 +16,7 @@ static uint32_t _atoi(const char* sp) {
 
 static bool isValidName(const char *n) {
   while (*n) {
-    if (*n == '[' || *n == ']' || *n == '/' || *n == '\\' || *n == ':' || *n == ',' || *n == '?' || *n == '*') return false;
+    if (*n == '[' || *n == ']' || *n == '\\' || *n == ':' || *n == ',' || *n == '?' || *n == '*') return false;
     n++;
   }
   return true;


### PR DESCRIPTION
In the amateur radio (ham radio) world, the forward slash "/" is used as a suffix to callsigns to indicate various operational conditions and locations thus I don't see a reason why "/" should be be considered a invalid char on the radio's name.

IMO it would be far more helpful to block emojis.. but that's outside the scope of this PR.