### PR TITLE
Fix Wio Tracker L1 Enter Button Mapping

### DIFF
--- a/variants/wio-tracker-l1/variant.h
+++ b/variants/wio-tracker-l1/variant.h
@@ -37,7 +37,7 @@
 #define JOYSTICK_LEFT           PIN_BUTTON4
 #define JOYSTICK_RIGHT          PIN_BUTTON5
 #define JOYSTICK_PRESS          PIN_BUTTON6
-#define PIN_USER_BTN            PIN_BUTTON6
+#define PIN_USER_BTN            PIN_BUTTON1
 
 // Buzzer
 // #define PIN_BUZZER           (12) // Buzzer pin (defined per firmware type)


### PR DESCRIPTION
# Fix Wio Tracker L1 Enter Button Mapping
### Problem
The enter/select button on the Wio Tracker L1 was not responding to input. The joystick directions (up, down, left, right) worked correctly, but pressing the physical Menu/User button had no effect.

### Cause
`PIN_USER_BTN` was mapped to `PIN_BUTTON6` (Joystick Press), but the physical enter button on the Wio Tracker L1 is actually the Menu/User button `PIN_BUTTON1`.

### Fix
Changed `PIN_USER_BTN` from `PIN_BUTTON6` to `PIN_BUTTON1` in `variant.h`.

### Testing
Tested on physical Wio Tracker L1 hardware. The Menu button now correctly triggers enter/select actions in the UI.