### PR TITLE
Refactor display scaling definitions for HELTEC_VISION_MASTER_T190

### DIFF
--- a/src/helpers/ui/ST7789Display.cpp
+++ b/src/helpers/ui/ST7789Display.cpp
@@ -10,8 +10,13 @@
 #define Y_OFFSET 1  // Vertical offset to prevent top row cutoff
 #endif
 
-#define SCALE_X  1.875f     // 240 / 128
-#define SCALE_Y  2.109375f   // 135 / 64
+#ifdef HELTEC_VISION_MASTER_T190
+  #define SCALE_X  2.5f        // 320 / 128
+  #define SCALE_Y  2.65625f    // 170 / 64
+#else
+  #define SCALE_X  1.875f      // 240 / 128
+  #define SCALE_Y  2.109375f   // 135 / 64
+#endif
 
 bool ST7789Display::begin() {
   if(!_isOn) {


### PR DESCRIPTION
Previously the display was rendering in the top-left at native size.
This change updates the layout/scaling so it correctly fills the screen.

_(Pics are not of the same view, but still shows the behavior change.)_

Before
<img width="450" alt="image" src="https://github.com/user-attachments/assets/3aeb5c5f-37c3-4b1b-a869-938b7f889c28" />

After
<img width="450" alt="image" src="https://github.com/user-attachments/assets/eaa0426c-821e-418e-ab8d-9a2ede4fd392" />