### PR TITLE
Add CMD_SEND_CHANNEL_DATA for binary mesh channel messages

### DIFF
--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -133,6 +133,8 @@ protected:
                            const uint8_t *sender_prefix, const char *text) override;
   void onChannelMessageRecv(const mesh::GroupChannel &channel, mesh::Packet *pkt, uint32_t timestamp,
                             const char *text) override;
+  void onChannelDataRecv(const mesh::GroupChannel &channel, mesh::Packet *pkt, uint32_t timestamp,
+                         const uint8_t *data, size_t len) override;
 
   uint8_t onContactRequest(const ContactInfo &contact, uint32_t sender_timestamp, const uint8_t *data,
                            uint8_t len, uint8_t *reply) override;

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -110,6 +110,7 @@ protected:
   virtual uint32_t calcDirectTimeoutMillisFor(uint32_t pkt_airtime_millis, uint8_t path_len) const = 0;
   virtual void onSendTimeout() = 0;
   virtual void onChannelMessageRecv(const mesh::GroupChannel& channel, mesh::Packet* pkt, uint32_t timestamp, const char *text) = 0;
+  virtual void onChannelDataRecv(const mesh::GroupChannel& channel, mesh::Packet* pkt, uint32_t timestamp, const uint8_t *data, size_t len) = 0;
   virtual uint8_t onContactRequest(const ContactInfo& contact, uint32_t sender_timestamp, const uint8_t* data, uint8_t len, uint8_t* reply) = 0;
   virtual void onContactResponse(const ContactInfo& contact, const uint8_t* data, uint8_t len) = 0;
   virtual void handleReturnPathRetry(const ContactInfo& contact, const uint8_t* path, uint8_t path_len);


### PR DESCRIPTION
Introduce CMD_SEND_CHANNEL_DATA (0x60) to send binary payloads over channels via flood routing

Define MAX_BINARY_LEN (164 bytes) from MAX_PACKET_PAYLOAD - CIPHER_BLOCK_SIZE - 4

Add onChannelDataRecv() to receive and queue binary channel data

Route PAYLOAD_TYPE_GRP_DATA in onGroupDataRecv() to onChannelDataRecv

Add RESP_CODE_CHANNEL_DATA_RECV (0x1A) for binary responses

Update protocol documentation with command and response frame formats

Binary format: [timestamp(4B LE)][data]
Response format: [0x1A][SNR*4][reserved][channel_idx][path_len][timestamp][data]


This will allow apps to send binary data for non-text messages. For Example Meshcore opens reactions or gifs. 