### PR TITLE
Add recv_errors to CMD_GET_STATS STATS_TYPE_PACKETS response

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1688,12 +1688,14 @@ void MyMesh::handleCmdFrame(size_t len) {
       uint32_t n_sent_direct = getNumSentDirect();
       uint32_t n_recv_flood = getNumRecvFlood();
       uint32_t n_recv_direct = getNumRecvDirect();
+      uint32_t n_recv_errors = radio_driver.getPacketsRecvErrors();
       memcpy(&out_frame[i], &recv, 4); i += 4;
       memcpy(&out_frame[i], &sent, 4); i += 4;
       memcpy(&out_frame[i], &n_sent_flood, 4); i += 4;
       memcpy(&out_frame[i], &n_sent_direct, 4); i += 4;
       memcpy(&out_frame[i], &n_recv_flood, 4); i += 4;
       memcpy(&out_frame[i], &n_recv_direct, 4); i += 4;
+      memcpy(&out_frame[i], &n_recv_errors, 4); i += 4;
       _serial->writeFrame(out_frame, i);
     } else {
       writeErrFrame(ERR_CODE_ILLEGAL_ARG); // invalid stats sub-type


### PR DESCRIPTION
**Add `recv_errors` to CMD_GET_STATS STATS_TYPE_PACKETS (56, 2) response**

Adds the RadioLib receive/CRC error count to the companion binary stats response so it matches the repeater GET_STATUS payload (which already includes `n_recv_errors`).

- **Firmware:** Companion radio appends a 4-byte `uint32_t` `recv_errors` to the STATS_TYPE_PACKETS frame. Frame size goes from 26 to 30 bytes; existing fields and offsets are unchanged.
- **Docs:** `docs/stats_binary_frames.md` updated with the new field, 26/30-byte behaviour, and Python/TypeScript examples that accept length ≥ 26 and parse `recv_errors` when length ≥ 30.
- **Compatibility:** Append-only, so **non-breaking for meshcore_py**: it already validates minimum length (not exact length). Old firmware keeps sending 26 bytes; new firmware sends 30. Clients that support both lengths can parse `recv_errors` when present.