### PR TITLE
Refactor ESP32Board.h to save ~500 bytes of DRAM

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -194,6 +194,7 @@ void setup() {
   );
 
 #ifdef WIFI_SSID
+  board.setInhibitSleep(true);   // prevent sleep when WiFi is active
   WiFi.begin(WIFI_SSID, WIFI_PWD);
   serial_interface.begin(TCP_PORT);
 #elif defined(BLE_PIN_CODE)

--- a/src/helpers/ESP32Board.cpp
+++ b/src/helpers/ESP32Board.cpp
@@ -11,6 +11,7 @@
 #include <SPIFFS.h>
 
 bool ESP32Board::startOTAUpdate(const char* id, char reply[]) {
+  inhibit_sleep = true;   // prevent sleep during OTA
   WiFi.softAP("MeshCore-OTA", NULL);
 
   sprintf(reply, "Started: http://%s/update", WiFi.softAPIP().toString().c_str());

--- a/src/helpers/ESP32Board.h
+++ b/src/helpers/ESP32Board.h
@@ -8,12 +8,12 @@
 #include <rom/rtc.h>
 #include <sys/time.h>
 #include <Wire.h>
-#include "esp_wifi.h"
 #include "driver/rtc_io.h"
 
 class ESP32Board : public mesh::MainBoard {
 protected:
   uint8_t startup_reason;
+  bool inhibit_sleep = false;
 
 public:
   void begin() {
@@ -72,11 +72,7 @@ public:
   }
 
   void sleep(uint32_t secs) override {
-    // To check for WiFi status to see if there is active OTA
-    wifi_mode_t mode;
-    esp_err_t err = esp_wifi_get_mode(&mode);
-    
-    if (err != ESP_OK) {          // WiFi is off ~ No active OTA, safe to go to sleep
+    if (!inhibit_sleep) {
       enterLightSleep(secs);      // To wake up after "secs" seconds or when receiving a LoRa packet
     }
   }
@@ -126,6 +122,10 @@ public:
   }
 
   bool startOTAUpdate(const char* id, char reply[]) override;
+
+  void setInhibitSleep(bool inhibit) {
+    inhibit_sleep = inhibit;
+  }
 };
 
 class ESP32RTCClock : public mesh::RTCClock {


### PR DESCRIPTION
Instead of calling esp_wifi_get_mode() we can set a flag to inhibit sleep when calling wifi.begin(), and check it before going to sleep.

This saves ~500 bytes of DRAM and allows Tbeam to compile again, fixes https://github.com/meshcore-dev/MeshCore/issues/1526

I'll mark this as draft until I can confirm it works as intended, but my reading of the docs for esp_wifi_get_mode() suggests it should be fine.