### PR TITLE
Enable I2C sensors and EnvironmentSensorManager for Heltec T114

### DIFF
--- a/variants/heltec_t114/platformio.ini
+++ b/variants/heltec_t114/platformio.ini
@@ -6,6 +6,7 @@ extends = nrf52_base
 board = heltec_t114
 board_build.ldscript = boards/nrf52840_s140_v6.ld
 build_flags = ${nrf52_base.build_flags}
+  ${sensor_base.build_flags}
   -I lib/nrf52/s140_nrf52_6.1.1_API/include
   -I lib/nrf52/s140_nrf52_6.1.1_API/include/nrf52
   -I variants/heltec_t114
@@ -35,11 +36,15 @@ build_flags = ${nrf52_base.build_flags}
   -D PIN_GPS_EN=21
   -D PIN_GPS_RESET=38
   -D PIN_GPS_RESET_ACTIVE=LOW
+  -D PIN_BOARD_SDA=16
+  -D PIN_BOARD_SCL=13
 build_src_filter = ${nrf52_base.build_src_filter}
   +<helpers/*.cpp>
+  +<helpers/sensors>
   +<../variants/heltec_t114>
 lib_deps =
   ${nrf52_base.lib_deps}
+  ${sensor_base.lib_deps}
   stevemarple/MicroNMEA @ ^2.0.6
   adafruit/Adafruit GFX Library @ ^1.12.1
 debug_tool = jlink

--- a/variants/heltec_t114/target.cpp
+++ b/variants/heltec_t114/target.cpp
@@ -45,26 +45,12 @@ mesh::LocalIdentity radio_new_identity() {
   return mesh::LocalIdentity(&rng);  // create new random identity
 }
 
-void T114SensorManager::start_gps() {
-  if (!gps_active) {
-    gps_active = true;
-    _location->begin();
-  }
-}
-
-void T114SensorManager::stop_gps() {
-  if (gps_active) {
-    gps_active = false;
-    _location->stop();
-  }
-}
-
 bool T114SensorManager::begin() {
   Serial1.begin(9600);
 
   // Try to detect if GPS is physically connected to determine if we should expose the setting
-  pinMode(GPS_EN, OUTPUT);
-  digitalWrite(GPS_EN, HIGH);  // Power on GPS
+  pinMode(PIN_GPS_EN, OUTPUT);
+  digitalWrite(PIN_GPS_EN, HIGH);  // Power on GPS
 
   // Give GPS a moment to power up and send data
   delay(1500);
@@ -77,57 +63,16 @@ bool T114SensorManager::begin() {
   } else {
     MESH_DEBUG_PRINTLN("No GPS detected");
   }
-  digitalWrite(GPS_EN, LOW);  // Power off GPS until the setting is changed
+  digitalWrite(PIN_GPS_EN, LOW);  // Power off GPS until the setting is changed
 
-  return true;
+  return EnvironmentSensorManager::begin();
 }
 
 bool T114SensorManager::querySensors(uint8_t requester_permissions, CayenneLPP& telemetry) {
+  EnvironmentSensorManager::querySensors(requester_permissions, telemetry);
+
   if (requester_permissions & TELEM_PERM_LOCATION) {   // does requester have permission?
     telemetry.addGPS(TELEM_CHANNEL_SELF, node_lat, node_lon, node_altitude);
   }
   return true;
-}
-
-void T114SensorManager::loop() {
-  static long next_gps_update = 0;
-
-  _location->loop();
-
-  if (millis() > next_gps_update) {
-    if (_location->isValid()) {
-      node_lat = ((double)_location->getLatitude())/1000000.;
-      node_lon = ((double)_location->getLongitude())/1000000.;
-      node_altitude = ((double)_location->getAltitude()) / 1000.0;
-      MESH_DEBUG_PRINTLN("lat %f lon %f", node_lat, node_lon);
-    }
-    next_gps_update = millis() + 1000;
-  }
-}
-
-int T114SensorManager::getNumSettings() const {
-  return gps_detected ? 1 : 0;  // only show GPS setting if GPS is detected
-}
-
-const char* T114SensorManager::getSettingName(int i) const {
-  return (gps_detected && i == 0) ? "gps" : NULL;
-}
-
-const char* T114SensorManager::getSettingValue(int i) const {
-  if (gps_detected && i == 0) {
-    return gps_active ? "1" : "0";
-  }
-  return NULL;
-}
-
-bool T114SensorManager::setSettingValue(const char* name, const char* value) {
-  if (gps_detected && strcmp(name, "gps") == 0) {
-    if (strcmp(value, "0") == 0) {
-      stop_gps();
-    } else {
-      start_gps();
-    }
-    return true;
-  }
-  return false;  // not supported
 }

--- a/variants/heltec_t114/target.h
+++ b/variants/heltec_t114/target.h
@@ -6,7 +6,7 @@
 #include <T114Board.h>
 #include <helpers/radiolib/CustomSX1262Wrapper.h>
 #include <helpers/AutoDiscoverRTCClock.h>
-#include <helpers/SensorManager.h>
+#include <helpers/sensors/EnvironmentSensorManager.h>
 #include <helpers/sensors/LocationProvider.h>
 
 #ifdef DISPLAY_CLASS
@@ -18,23 +18,11 @@
 #endif
 #endif
 
-class T114SensorManager : public SensorManager {
-  bool gps_active = false;
-  bool gps_detected = false;
-  LocationProvider* _location;
-
-  void start_gps();
-  void stop_gps();
+class T114SensorManager : public EnvironmentSensorManager {
 public:
-  T114SensorManager(LocationProvider &location): _location(&location) { }
+  T114SensorManager(LocationProvider &location): EnvironmentSensorManager(location) { }
   bool begin() override;
   bool querySensors(uint8_t requester_permissions, CayenneLPP& telemetry) override;
-  void loop() override;
-  LocationProvider* getLocationProvider() override { return gps_detected ? _location : NULL; }
-  int getNumSettings() const override;
-  const char* getSettingName(int i) const override;
-  const char* getSettingValue(int i) const override;
-  bool setSettingValue(const char* name, const char* value) override;
 };
 
 extern T114Board board;


### PR DESCRIPTION
This is simple patch for enabling sensors on Heltec T114 (defacto copy of behavior from Heltec v3, T114 have support only for GPS and nothing more).

While standard I2C is occupied, i'm using PINs used by MT (i know, i know).
-D PIN_BOARD_SDA=16
-D PIN_BOARD_SCL=13