### PR TITLE
Heltec T114: Remove extra DCDC enable call

### DIFF
--- a/variants/heltec_t114/T114Board.cpp
+++ b/variants/heltec_t114/T114Board.cpp
@@ -34,7 +34,6 @@ void T114Board::initiateShutdown(uint8_t reason) {
 
 void T114Board::begin() {
   NRF52Board::begin();
-  NRF_POWER->DCDCEN = 1;
 
   pinMode(PIN_VBAT_READ, INPUT);
 


### PR DESCRIPTION
This is call is unnecessary, it must have been forgotten when the call was refactored into NRF52BoardDCDC.begin()