### PR TITLE
Add Low-Power Sleep for nRF52 Boards

### DIFF
--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -127,14 +127,17 @@ void loop() {
 #endif
   rtc_clock.tick();
 
-  if (the_mesh.getNodePrefs()->powersaving_enabled &&                     // To check if power saving is enabled
-      the_mesh.millisHasNowPassed(lastActive + nextSleepinSecs * 1000)) { // To check if it is time to sleep
-    if (!the_mesh.hasPendingWork()) { // No pending work. Safe to sleep
+  if (the_mesh.getNodePrefs()->powersaving_enabled && !the_mesh.hasPendingWork()) {
+    #if defined(NRF52_PLATFORM)
+    board.sleep(1800); // nrf ignores seconds param, sleeps whenever possible
+    #else
+    if (the_mesh.millisHasNowPassed(lastActive + nextSleepinSecs * 1000)) { // To check if it is time to sleep
       board.sleep(1800);             // To sleep. Wake up after 30 minutes or when receiving a LoRa packet
       lastActive = millis();
       nextSleepinSecs = 5;  // Default: To work for 5s and sleep again
     } else {
       nextSleepinSecs += 5; // When there is pending work, to work another 5s
     }
+    #endif
   }
 }

--- a/src/helpers/NRF52Board.h
+++ b/src/helpers/NRF52Board.h
@@ -51,6 +51,7 @@ public:
   virtual float getMCUTemperature() override;
   virtual void reboot() override { NVIC_SystemReset(); }
   virtual bool startOTAUpdate(const char *id, char reply[]) override;
+  virtual void sleep(uint32_t secs) override;
 
 #ifdef NRF52_POWER_MANAGEMENT
   bool isExternalPowered() override;


### PR DESCRIPTION
~~**Note: Draft PR, Testing required**  - Please test this PR on your NRF52 repeaters, it seems to work well from my initial testing and in theory shouldn't cause packets to be dropped but **thorough testing is still required**.~~
I'm no longer considering this a draft PR as it's working fine for me. It would still be nice if some others could test it out though.

This PR implements proper low-power sleep for repeater firmware on NRF52 boards, reducing idle power consumption:
Repeater firmware: 6-7mA down to 5mA at 3.6v (after first advert is sent).
Companion firmware: Not yet integrated (see below)

Added NRF52Board::sleep() which uses __WFE() (Wait For Event) to put the CPU into idle whenever possible. CPU will automatically wake on any interrupt so there should be no effect on serial/lora/clock etc. This drops the number of main loops during idle from ~25000+/sec to ~1000/loops per second, because it wakes for every rtc.tick().

Includes the [workaround for errata 87](https://docs.nordicsemi.com/bundle/errata_nRF52840_Rev3/page/ERR/nRF52840/Rev3/latest/anomaly_840_87.html) which probably isn't necessary for repeaters but seems to be required for companions to go into idle.

Note on companions: I haven't added ``board.sleep()`` to the main loop for companions, although I did test it briefly and found it to drop idle current draw from ~8-9ma to ~6ma at 3.6v. More testing would be welcomed for this as well.


