### PR TITLE
On-Demand GPS Activation for Remote Telemetry Requests

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -708,6 +708,12 @@ void EnvironmentSensorManager::loop() {
 
   #if ENV_INCLUDE_GPS
   _location->loop();
+
+  if (gps_tmp_flag && !gps_active) {
+    MESH_DEBUG_PRINTLN("[GPS] GPS request flag set. Starting GPS for location fix.");  // Debug message
+    start_gps();
+  }
+
   if (millis() > next_gps_update) {
 
     if(gps_active){
@@ -718,6 +724,12 @@ void EnvironmentSensorManager::loop() {
       MESH_DEBUG_PRINTLN("lat %f lon %f", node_lat, node_lon);
       node_altitude = ((double)_location->getAltitude()) / 1000.0;
       MESH_DEBUG_PRINTLN("lat %f lon %f alt %f", node_lat, node_lon, node_altitude);
+
+      if (gps_tmp_flag) {
+          MESH_DEBUG_PRINTLN("[GPS] GPS location fix obtained. Disabling GPS.");
+          gps_tmp_flag = false;
+          stop_gps();
+      }
     }
     #else
     if (_location->isValid()) {
@@ -726,6 +738,12 @@ void EnvironmentSensorManager::loop() {
       MESH_DEBUG_PRINTLN("lat %f lon %f", node_lat, node_lon);
       node_altitude = ((double)_location->getAltitude()) / 1000.0;
       MESH_DEBUG_PRINTLN("lat %f lon %f alt %f", node_lat, node_lon, node_altitude);
+
+      if (gps_tmp_flag) {
+          MESH_DEBUG_PRINTLN("[GPS] GPS location fix obtained. Disabling GPS.");
+          gps_tmp_flag = false;
+          stop_gps();
+      }
     }
     #endif
     }

--- a/src/helpers/sensors/EnvironmentSensorManager.h
+++ b/src/helpers/sensors/EnvironmentSensorManager.h
@@ -32,6 +32,7 @@ protected:
   void start_gps();
   void stop_gps();
   void initBasicGPS();
+  bool gps_tmp_flag = false;
   #ifdef RAK_BOARD
   void rakGPSInit();
   bool gpsIsAwake(uint8_t ioPin);


### PR DESCRIPTION
Allow a node to temporarily enable GPS in response to an authorized remote telemetry request when GPS is otherwise disabled, obtain a fix (or timeout), include coordinates in the telemetry response, and then disable GPS again.

This draft does not handle a timeout nor any additional setting in the companion and might only be used as a PoC or discussion.