### PR TITLE
Some small fixes and improvements extracted from PR1238

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -1340,5 +1340,5 @@ bool MyMesh::hasPendingWork() const {
 #if defined(WITH_BRIDGE)
   if (bridge.isRunning()) return true;  // bridge needs WiFi radio, can't sleep
 #endif
-  return _mgr->getOutboundTotal() > 0;
+  return (_mgr->getOutboundTotal() > 0) || !radio_driver.isInRecvMode();
 }

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -128,6 +128,8 @@ void loop() {
     Serial.print('\n');
     command[len - 1] = 0;  // replace newline with C string null terminator
     char reply[160];
+    lastActive = millis();
+    nextSleepinSecs = ACTIVE_TIME_SEC_INUSE;
     the_mesh.handleCommand(0, command, reply);  // NOTE: there is no sender_timestamp via serial!
     if (reply[0]) {
       Serial.print("  -> "); Serial.println(reply);

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -20,8 +20,12 @@ void halt() {
 static char command[160];
 
 // For power saving
+constexpr unsigned long ACTIVE_TIME_SEC_INUSE = 2 * 60; // 2 minutes
+constexpr unsigned long ACTIVE_TIME_SEC_IDLE = 5;       // 5 seconds
+constexpr unsigned long IDLE_PERIOD_SEC = 30 * 60;      // 30 minutes
+
 unsigned long lastActive = 0; // mark last active time
-unsigned long nextSleepinSecs = 120; // next sleep in seconds. The first sleep (if enabled) is after 2 minutes from boot
+unsigned long nextSleepinSecs = ACTIVE_TIME_SEC_INUSE; // next sleep in seconds
 
 #if defined(PIN_USER_BTN) && defined(_SEEED_SENSECAP_SOLAR_H_)
 static unsigned long userBtnDownAt = 0;
@@ -156,14 +160,14 @@ void loop() {
 
   if (the_mesh.getNodePrefs()->powersaving_enabled && !the_mesh.hasPendingWork()) {
     #if defined(NRF52_PLATFORM)
-    board.sleep(1800); // nrf ignores seconds param, sleeps whenever possible
+    board.sleep(IDLE_PERIOD_SEC); // nrf ignores seconds param, sleeps whenever possible
     #else
     if (the_mesh.millisHasNowPassed(lastActive + nextSleepinSecs * 1000)) { // To check if it is time to sleep
-      board.sleep(1800);             // To sleep. Wake up after 30 minutes or when receiving a LoRa packet
+      board.sleep(IDLE_PERIOD_SEC);             // To sleep. Wake up after 30 minutes or when receiving a LoRa packet
       lastActive = millis();
-      nextSleepinSecs = 5;  // Default: To work for 5s and sleep again
+      nextSleepinSecs = ACTIVE_TIME_SEC_IDLE; // Default: To work for 5s and sleep again
     } else {
-      nextSleepinSecs += 5; // When there is pending work, to work another 5s
+      nextSleepinSecs += ACTIVE_TIME_SEC_IDLE; // When there is pending work, to work another 5s
     }
     #endif
   }

--- a/src/helpers/radiolib/RadioLibWrappers.cpp
+++ b/src/helpers/radiolib/RadioLibWrappers.cpp
@@ -4,9 +4,10 @@
 
 #define STATE_IDLE       0
 #define STATE_RX         1
-#define STATE_TX_WAIT    3
-#define STATE_TX_DONE    4
-#define STATE_INT_READY 16
+#define STATE_TX_WAIT    2
+#define STATE_TX_DONE    3
+
+#define FLAG_INT_READY   (1 << 4)
 
 #define NUM_NOISE_FLOOR_SAMPLES  64
 #define SAMPLING_THRESHOLD  14
@@ -21,7 +22,7 @@ static
 #endif
 void setFlag(void) {
   // we sent a packet, set the flag
-  state |= STATE_INT_READY;
+  state |= FLAG_INT_READY;
 }
 
 void RadioLibWrapper::begin() {
@@ -59,7 +60,7 @@ void RadioLibWrapper::doResetAGC() {
 
 void RadioLibWrapper::resetAGC() {
   // make sure we're not mid-receive of packet!
-  if ((state & STATE_INT_READY) != 0 || isReceivingPacket()) return;
+  if ((state & FLAG_INT_READY) != 0 || isReceivingPacket()) return;
 
   doResetAGC();
   state = STATE_IDLE;   // trigger a startReceive()
@@ -103,12 +104,12 @@ void RadioLibWrapper::startRecv() {
 }
 
 bool RadioLibWrapper::isInRecvMode() const {
-  return (state & ~STATE_INT_READY) == STATE_RX;
+  return (state & ~FLAG_INT_READY) == STATE_RX;
 }
 
 int RadioLibWrapper::recvRaw(uint8_t* bytes, int sz) {
   int len = 0;
-  if (state & STATE_INT_READY) {
+  if (state & FLAG_INT_READY) {
     len = _radio->getPacketLength();
     if (len > 0) {
       if (len > sz) { len = sz; }
@@ -154,7 +155,7 @@ bool RadioLibWrapper::startSendRaw(const uint8_t* bytes, int len) {
 }
 
 bool RadioLibWrapper::isSendComplete() {
-  if (state & STATE_INT_READY) {
+  if (state & FLAG_INT_READY) {
     state = STATE_IDLE;
     n_sent++;
     return true;

--- a/variants/rak4631/variant.h
+++ b/variants/rak4631/variant.h
@@ -147,7 +147,7 @@ extern "C"
 // LoRa radio module pins for RAK4631
 #define  P_LORA_DIO_1 (47)
 #define  P_LORA_NSS (42)
-#define  P_LORA_RESET (-1)
+#define  P_LORA_RESET (38)
 #define  P_LORA_BUSY (46)
 #define  P_LORA_SCLK (43)
 #define  P_LORA_MISO (45)


### PR DESCRIPTION
While working on https://github.com/meshcore-dev/MeshCore/pull/1238 ~~I discovered a bug~~ I had a hard time understanding the logic of the state handling in `RadioLibWrappers.cpp`. Therefore this PR improves the readability of that part and a few other things which can be reviewed and merged separately.

* ~~Fix subtle bug in `RadioLibWrappers.cpp` state machine~~
* Improve readability of state machine macros in  in `RadioLibWrappers.cpp`
* Enable reset pin for RAK4631
* Repeater: improve `hasPendingWork()` which is used to decide when the system is idle and can enter powersaving mode
* Repeater: use `constexpr` values for powersaving timings instead of inline literals