### PR TITLE
Fix Heltec Wireless Paper voltage

### DIFF
--- a/variants/heltec_v3/HeltecV3Board.h
+++ b/variants/heltec_v3/HeltecV3Board.h
@@ -11,6 +11,9 @@
 #ifndef PIN_ADC_CTRL              // set in platformio.ini for Heltec Wireless Tracker (2)
   #define  PIN_ADC_CTRL    37
 #endif
+#ifndef ADC_MULTIPLIER  //default ADC multiplier
+  #define ADC_MULTIPLIER 1
+#endif
 #define  PIN_ADC_CTRL_ACTIVE    LOW
 #define  PIN_ADC_CTRL_INACTIVE  HIGH
 
@@ -88,7 +91,7 @@ public:
 
     digitalWrite(PIN_ADC_CTRL, !adc_active_state);
 
-    return (5.42 * (3.3 / 1024.0) * raw) * 1000;
+    return (5.42 * (3.3 / 1024.0) * raw) * 1000 * ADC_MULTIPLIER;
   }
 
   const char* getManufacturerName() const override {

--- a/variants/heltec_wireless_paper/platformio.ini
+++ b/variants/heltec_wireless_paper/platformio.ini
@@ -21,6 +21,7 @@ build_flags =
   ;-D PIN_BOARD_SCL=18               ; same GPIO as P_LORA_TX_LED
   -D PIN_USER_BTN=0
   -D PIN_VEXT_EN=45
+  -D ADC_MULTIPLIER=1.55
   -D PIN_VBAT_READ=20
   -D PIN_ADC_CTRL=19
   -D SX126X_DIO2_AS_RF_SWITCH=true


### PR DESCRIPTION
Added ADC_MULTIPLIER (default=1) to v3 board.
Added correct multiplier to ini of WP.

I think this is the easiest fix for the Heltec Wireless Paper not showing correct voltage.
