### PR TITLE
Default button polarity to active-LOW across all firmware types

### DIFF
--- a/examples/simple_repeater/UITask.cpp
+++ b/examples/simple_repeater/UITask.cpp
@@ -2,6 +2,10 @@
 #include <Arduino.h>
 #include <helpers/CommonCLI.h>
 
+#ifndef USER_BTN_PRESSED
+#define USER_BTN_PRESSED LOW
+#endif
+
 #define AUTO_OFF_MILLIS      20000  // 20 seconds
 #define BOOT_SCREEN_MILLIS   4000   // 4 seconds
 
@@ -85,7 +89,7 @@ void UITask::loop() {
   if (millis() >= _next_read) {
     int btnState = digitalRead(PIN_USER_BTN);
     if (btnState != _prevBtnState) {
-      if (btnState == LOW) {  // pressed?
+      if (btnState == USER_BTN_PRESSED) {  // pressed?
         if (_display->isOn()) {
           // TODO: any action ?
         } else {

--- a/examples/simple_room_server/UITask.cpp
+++ b/examples/simple_room_server/UITask.cpp
@@ -2,6 +2,10 @@
 #include <Arduino.h>
 #include <helpers/CommonCLI.h>
 
+#ifndef USER_BTN_PRESSED
+#define USER_BTN_PRESSED LOW
+#endif
+
 #define AUTO_OFF_MILLIS      20000  // 20 seconds
 #define BOOT_SCREEN_MILLIS   4000   // 4 seconds
 
@@ -85,7 +89,7 @@ void UITask::loop() {
   if (millis() >= _next_read) {
     int btnState = digitalRead(PIN_USER_BTN);
     if (btnState != _prevBtnState) {
-      if (btnState == LOW) {  // pressed?
+      if (btnState == USER_BTN_PRESSED) {  // pressed?
         if (_display->isOn()) {
           // TODO: any action ?
         } else {

--- a/examples/simple_sensor/UITask.cpp
+++ b/examples/simple_sensor/UITask.cpp
@@ -2,6 +2,10 @@
 #include <Arduino.h>
 #include <helpers/CommonCLI.h>
 
+#ifndef USER_BTN_PRESSED
+#define USER_BTN_PRESSED LOW
+#endif
+
 #define AUTO_OFF_MILLIS      20000  // 20 seconds
 #define BOOT_SCREEN_MILLIS   4000   // 4 seconds
 
@@ -85,7 +89,7 @@ void UITask::loop() {
   if (millis() >= _next_read) {
     int btnState = digitalRead(PIN_USER_BTN);
     if (btnState != _prevBtnState) {
-      if (btnState == LOW) {  // pressed?
+      if (btnState == USER_BTN_PRESSED) {  // pressed?
         if (_display->isOn()) {
           // TODO: any action ?
         } else {

--- a/src/helpers/ESP32Board.h
+++ b/src/helpers/ESP32Board.h
@@ -3,6 +3,10 @@
 #include <MeshCore.h>
 #include <Arduino.h>
 
+#ifndef USER_BTN_PRESSED
+#define USER_BTN_PRESSED LOW
+#endif
+
 #if defined(ESP_PLATFORM)
 
 #include <rom/rtc.h>

--- a/variants/minewsemi_me25ls01/MinewsemiME25LS01Board.h
+++ b/variants/minewsemi_me25ls01/MinewsemiME25LS01Board.h
@@ -63,7 +63,7 @@ public:
     digitalWrite(LED_PIN, LOW);
     #endif
     #ifdef BUTTON_PIN
-    nrf_gpio_cfg_sense_input(digitalPinToInterrupt(BUTTON_PIN), NRF_GPIO_PIN_PULLUP, NRF_GPIO_PIN_SENSE_HIGH);
+    nrf_gpio_cfg_sense_input(digitalPinToInterrupt(BUTTON_PIN), NRF_GPIO_PIN_PULLUP, NRF_GPIO_PIN_SENSE_LOW);
     #endif
     sd_power_system_off();
   }

--- a/variants/minewsemi_me25ls01/platformio.ini
+++ b/variants/minewsemi_me25ls01/platformio.ini
@@ -21,7 +21,6 @@ build_flags = ${nrf52840_me25ls01.build_flags}
   -I variants/minewsemi_me25ls01
   -D me25ls01
   -D PIN_USER_BTN=27
-  -D USER_BTN_PRESSED=HIGH
   -D PIN_STATUS_LED=39
   -D P_LORA_TX_LED=22
   -D RADIO_CLASS=CustomLR1110

--- a/variants/t1000-e/T1000eBoard.h
+++ b/variants/t1000-e/T1000eBoard.h
@@ -78,14 +78,14 @@ public:
     digitalWrite(LED_PIN, HIGH);
     #endif
     #ifdef BUTTON_PIN
-    while(digitalRead(BUTTON_PIN));
+    while(digitalRead(BUTTON_PIN) == LOW);
     #endif
     #ifdef LED_PIN
     digitalWrite(LED_PIN, LOW);
     #endif
 
     #ifdef BUTTON_PIN
-    nrf_gpio_cfg_sense_input(BUTTON_PIN, NRF_GPIO_PIN_NOPULL, NRF_GPIO_PIN_SENSE_HIGH);
+    nrf_gpio_cfg_sense_input(BUTTON_PIN, NRF_GPIO_PIN_NOPULL, NRF_GPIO_PIN_SENSE_LOW);
     #endif
 
     sd_power_system_off();

--- a/variants/t1000-e/T1000eBoard.h
+++ b/variants/t1000-e/T1000eBoard.h
@@ -43,7 +43,7 @@ public:
     uint8_t v = digitalRead(BUTTON_PIN);
     if (v != btn_prev_state) {
       btn_prev_state = v;
-      return (v == LOW) ? 1 : -1;
+      return (v == USER_BTN_PRESSED) ? 1 : -1;
     }
   #endif
     return 0;
@@ -78,14 +78,14 @@ public:
     digitalWrite(LED_PIN, HIGH);
     #endif
     #ifdef BUTTON_PIN
-    while(digitalRead(BUTTON_PIN) == LOW);
+    while(digitalRead(BUTTON_PIN));
     #endif
     #ifdef LED_PIN
     digitalWrite(LED_PIN, LOW);
     #endif
 
     #ifdef BUTTON_PIN
-    nrf_gpio_cfg_sense_input(BUTTON_PIN, NRF_GPIO_PIN_NOPULL, NRF_GPIO_PIN_SENSE_LOW);
+    nrf_gpio_cfg_sense_input(BUTTON_PIN, NRF_GPIO_PIN_NOPULL, NRF_GPIO_PIN_SENSE_HIGH);
     #endif
 
     sd_power_system_off();

--- a/variants/t1000-e/platformio.ini
+++ b/variants/t1000-e/platformio.ini
@@ -10,7 +10,6 @@ build_flags = ${nrf52_base.build_flags}
   -I src/helpers/ui
   -D T1000_E
   -D PIN_USER_BTN=6
-  -D USER_BTN_PRESSED=HIGH
   -D PIN_STATUS_LED=24
   -D RADIO_CLASS=CustomLR1110
   -D WRAPPER_CLASS=CustomLR1110Wrapper

--- a/variants/t1000-e/platformio.ini
+++ b/variants/t1000-e/platformio.ini
@@ -10,6 +10,7 @@ build_flags = ${nrf52_base.build_flags}
   -I src/helpers/ui
   -D T1000_E
   -D PIN_USER_BTN=6
+  -D USER_BTN_PRESSED=HIGH
   -D PIN_STATUS_LED=24
   -D RADIO_CLASS=CustomLR1110
   -D WRAPPER_CLASS=CustomLR1110Wrapper

--- a/variants/thinknode_m3/platformio.ini
+++ b/variants/thinknode_m3/platformio.ini
@@ -10,7 +10,6 @@ build_flags = ${nrf52_base.build_flags}
   -I src/helpers/ui
   -D THINKNODE_M3
   -D PIN_USER_BTN=12
-  -D USER_BTN_PRESSED=LOW
   -D PIN_STATUS_LED=35
   -D RADIO_CLASS=CustomLR1110
   -D WRAPPER_CLASS=CustomLR1110Wrapper

--- a/variants/wio-e5-mini/platformio.ini
+++ b/variants/wio-e5-mini/platformio.ini
@@ -9,7 +9,6 @@ build_flags = ${stm32_base.build_flags}
   -D RX_BOOSTED_GAIN=true
   -D P_LORA_TX_LED=LED_RED
   -D PIN_USER_BTN=USER_BTN
-  -D USER_BTN_PRESSED=LOW
   -I variants/wio-e5-mini
 build_src_filter = ${stm32_base.build_src_filter}
   +<../variants/wio-e5-mini>

--- a/variants/xiao_nrf52/XiaoNrf52Board.h
+++ b/variants/xiao_nrf52/XiaoNrf52Board.h
@@ -4,6 +4,10 @@
 #include <Arduino.h>
 #include <helpers/NRF52Board.h>
 
+#ifndef USER_BTN_PRESSED
+#define USER_BTN_PRESSED LOW
+#endif
+
 #ifdef XIAO_NRF52
 
 class XiaoNrf52Board : public NRF52BoardDCDC {
@@ -35,7 +39,7 @@ public:
     // set led on and wait for button release before poweroff
     digitalWrite(PIN_LED, LOW);
 #ifdef PIN_USER_BTN
-    while(digitalRead(PIN_USER_BTN) == LOW);
+    while(digitalRead(PIN_USER_BTN) == USER_BTN_PRESSED);
 #endif
     digitalWrite(LED_GREEN, HIGH);
     digitalWrite(LED_BLUE, HIGH);


### PR DESCRIPTION
Nearly all LoRa boards use a boot button that pulls to ground when pressed. The T1000-E is the one exception — it uses a capacitive touch button that is active-HIGH (confirmed by Meshtastic's `BUTTON_ACTIVE_LOW false`).

Changes:
- Default `USER_BTN_PRESSED` to `LOW` where not already defined (ESP32Board.h, UITask.cpp, XiaoNrf52Board.h)
- Replace hardcoded `LOW` button checks with `USER_BTN_PRESSED` in UITask and board files
- Fix MinewSemi ME25LS01: was incorrectly set to `USER_BTN_PRESSED=HIGH` with `NRF_GPIO_PIN_SENSE_HIGH` — changed to active-LOW with `SENSE_LOW`
- Fix ThinkNode M3 / Wio-E5-Mini: remove redundant explicit `USER_BTN_PRESSED=LOW` (now the default)
- Fix T1000-E: keep `USER_BTN_PRESSED=HIGH` and `SENSE_HIGH` (correct for this hardware), but fix `buttonStateChanged()` to use `USER_BTN_PRESSED` instead of hardcoded `LOW`

I found out when I was working on #1347 — it was actually releasing the boot button that would trigger the wakeup, not the pressing.

---
**Build firmware:** [Build from this branch](https://mcimages.weebl.me/?commitId=default-button-low)