### PR TITLE
Correct manufacturer name 'Elecrow ThinkNode M5'

### DIFF
--- a/variants/thinknode_m5/ThinknodeM5Board.cpp
+++ b/variants/thinknode_m5/ThinknodeM5Board.cpp
@@ -43,5 +43,5 @@ void ThinknodeM5Board::begin() {
 }
 
   const char* ThinknodeM5Board::getManufacturerName() const {
-    return "Elecrow ThinkNode M2";
+    return "Elecrow ThinkNode M5";
   }


### PR DESCRIPTION
Correct manufacturer name 'Elecrow ThinkNode M5'