### PR TITLE
Fix GPS UART consuming +8mA when disabled (nRF52)

### DIFF
--- a/src/helpers/sensors/EnvironmentSensorManager.cpp
+++ b/src/helpers/sensors/EnvironmentSensorManager.cpp
@@ -707,7 +707,9 @@ void EnvironmentSensorManager::loop() {
   static long next_gps_update = 0;
 
   #if ENV_INCLUDE_GPS
-  _location->loop();
+  if (gps_active) {
+    _location->loop();
+  }
   if (millis() > next_gps_update) {
 
     if(gps_active){

--- a/src/helpers/sensors/MicroNMEALocationProvider.h
+++ b/src/helpers/sensors/MicroNMEALocationProvider.h
@@ -79,7 +79,10 @@ public :
         if (_pin_en != -1) {
             digitalWrite(_pin_en, !PIN_GPS_EN_ACTIVE);
         }
-        if (_peripher_power) _peripher_power->release();  
+        if (_pin_reset != -1) {
+            digitalWrite(_pin_reset, GPS_RESET_FORCE);
+        }
+        if (_peripher_power) _peripher_power->release();
     }
 
     bool isEnabled() override {


### PR DESCRIPTION
## Summary

Fixes #1628 — GPS causes +8mA power consumption even when disabled on Heltec T114 (nRF52840).

### Root cause

On the T114, `GPS_RESET` (pin 38) is the same pin as `PIN_3V3_EN` — it controls a 3.3V power rail for the GPS module:

```cpp
// variants/heltec_t114/variant.h
#define PIN_3V3_EN              (38)
#define GPS_RESET               (38)  // same pin!
```

`MicroNMEALocationProvider::begin()` sets pin 38 HIGH (powering the 3V3 rail / releasing GPS reset), but `stop()` never touched it — it only set `GPS_EN` (pin 21) LOW. The 3V3 rail stayed on, the GPS module stayed powered, drawing +8mA.

Confirmed by comparing with the Meshtastic T114 variant, which has `GPS_RESET` commented out and uses `PIN_GPS_STANDBY` (pin 34) for GPS power control.

### Changes

- **Assert reset pin in `stop()`** — `MicroNMEALocationProvider::stop()` now calls `digitalWrite(_pin_reset, GPS_RESET_FORCE)`, mirroring what `begin()` does in reverse. On the T114 this pulls pin 38 LOW, cutting the 3V3 rail.
- **Guard `_location->loop()`** behind `gps_active` check to skip NMEA processing when GPS is disabled.

### Safety for other boards

- Boards without `GPS_RESET` defined: `_pin_reset` is -1, the new code is skipped entirely.
- Boards with `GPS_RESET`: The constructor already asserts reset at boot. `stop()` now returns to that same state. `begin()` de-asserts it as before. This is the symmetric counterpart that was missing.

### Verified power readings (Heltec T114, reported by @mileshkin)

| State | Current |
|---|---|
| Screen on, GPS on | ~53mA |
| Screen off, GPS on | ~44mA |
| Screen on, GPS off | ~28mA |
| Screen off, GPS off | ~16mA |

## Test plan

- [x] Verify idle current returns to ~16mA with GPS disabled (Heltec T114)
- [x] Verify GPS can be toggled on/off via settings and continues to acquire fix
- [x] Verify no regression on ESP32 GPS targets (Heltec Tracker v2, etc.)

---
**Build firmware:** [Build from this branch](https://mcimages.weebl.me/?commitId=fix/gps-uart-power-leak)