### PR TITLE
Fix: Path Trace Timeout

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1568,7 +1568,7 @@ void MyMesh::handleCmdFrame(size_t len) {
         sendDirect(pkt, &cmd_frame[10], path_len);
 
         uint32_t t = _radio->getEstAirtimeFor(pkt->payload_len + pkt->path_len + 2);
-        uint32_t est_timeout = calcDirectTimeoutMillisFor(t, path_len);
+        uint32_t est_timeout = calcDirectTimeoutMillisFor(t, path_len >> path_sz);
 
         out_frame[0] = RESP_CODE_SENT;
         out_frame[1] = 0;


### PR DESCRIPTION
This PR fixes the estimated timeout calculation for multi-byte path traces.

Currently, if doing a trace through one repeater with a segment size of 4-bytes, the firmware calculation thinks we are hopping across 4 repeaters, when in reality we are only going through 1 repeater.

It now takes the path segment size into consideration when calculating the timeout.