### PR TITLE
Check ACK payload_len before memcpy, not after

### DIFF
--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -79,13 +79,10 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
 
   if (pkt->isRouteDirect() && pkt->path_len >= PATH_HASH_SIZE) {
     // check for 'early received' ACK
-    if (pkt->getPayloadType() == PAYLOAD_TYPE_ACK) {
-      int i = 0;
+    if (pkt->getPayloadType() == PAYLOAD_TYPE_ACK && pkt->payload_len >= 4) {
       uint32_t ack_crc;
-      memcpy(&ack_crc, &pkt->payload[i], 4); i += 4;
-      if (i <= pkt->payload_len) {
-        onAckRecv(pkt, ack_crc);
-      }
+      memcpy(&ack_crc, pkt->payload, 4);
+      onAckRecv(pkt, ack_crc);
     }
 
     if (self_id.isHashMatch(pkt->path) && allowPacketForward(pkt)) {
@@ -115,12 +112,13 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
 
   switch (pkt->getPayloadType()) {
     case PAYLOAD_TYPE_ACK: {
-      int i = 0;
-      uint32_t ack_crc;
-      memcpy(&ack_crc, &pkt->payload[i], 4); i += 4;
-      if (i > pkt->payload_len) {
+      if (pkt->payload_len < 4) {
         MESH_DEBUG_PRINTLN("%s Mesh::onRecvPacket(): incomplete ACK packet", getLogDateTime());
-      } else if (!_tables->hasSeen(pkt)) {
+        break;
+      }
+      uint32_t ack_crc;
+      memcpy(&ack_crc, pkt->payload, 4);
+      if (!_tables->hasSeen(pkt)) {
         onAckRecv(pkt, ack_crc);
         action = routeRecvPacket(pkt);
       }


### PR DESCRIPTION
## Severity: Low

## Summary

Both ACK packet handlers in `Mesh::onRecvPacket` copy 4 bytes from the payload via `memcpy` before checking whether `payload_len >= 4`:

1. **Direct-route early ACK** (line 83–86): `memcpy` then `if (i <= pkt->payload_len)`
2. **Flood ACK** (line 118–121): `memcpy` then `if (i > pkt->payload_len)`

When `payload_len < 4`, the `memcpy` reads stale data from within the 184-byte payload buffer. The result (`ack_crc`) is discarded in both cases — the subsequent length check prevents it from being used — but the ordering is incorrect.

## Fix

Move the `payload_len >= 4` check before the `memcpy` in both locations. Short ACK packets are now rejected without touching the payload data.

## Test plan

- [x] Normal ACK processing still works (direct and flood)
- [x] Short/corrupt ACK packets are silently dropped
- [x] Build tested on `Heltec_v3_companion_radio_ble`

---
**Build firmware:** [Build from this branch](https://mcimages.weebl.me/?commitId=fix/ack-memcpy-bounds-order)