### PR TITLE
fix: usb and ui for rak 3112

### DIFF
--- a/variants/rak3112/platformio.ini
+++ b/variants/rak3112/platformio.ini
@@ -7,6 +7,7 @@ build_flags =
   -I variants/rak3112
   -D RAK_3112=1
   -D ESP32_CPU_FREQ=80
+  -D ARDUINO_USB_CDC_ON_BOOT=1
   -D P_LORA_DIO_1=47
   -D P_LORA_NSS=7
   -D P_LORA_RESET=8
@@ -131,14 +132,14 @@ lib_deps =
 extends = rak3112
 build_flags =
   ${rak3112.build_flags}
-  -I examples/companion_radio/ui-new
+  -I examples/companion_radio/ui-orig
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
 ; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
 ; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
 build_src_filter = ${rak3112.build_src_filter}
   +<../examples/companion_radio/*.cpp>
-  +<../examples/companion_radio/ui-new/*.cpp>
+  +<../examples/companion_radio/ui-orig/*.cpp>
 lib_deps =
   ${rak3112.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -147,7 +148,7 @@ lib_deps =
 extends = rak3112
 build_flags =
   ${rak3112.build_flags}
-  -I examples/companion_radio/ui-new
+  -I examples/companion_radio/ui-orig
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
   -D BLE_PIN_CODE=123456   ; dynamic, random PIN
@@ -159,7 +160,7 @@ build_flags =
 build_src_filter = ${rak3112.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
-  +<../examples/companion_radio/ui-new/*.cpp>
+  +<../examples/companion_radio/ui-orig/*.cpp>
 lib_deps =
   ${rak3112.lib_deps}
   densaugeo/base64 @ ~1.4.0
@@ -168,7 +169,7 @@ lib_deps =
 extends = rak3112
 build_flags =
   ${rak3112.build_flags}
-  -I examples/companion_radio/ui-new
+  -I examples/companion_radio/ui-orig
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
   -D WIFI_DEBUG_LOGGING=1
@@ -180,7 +181,7 @@ build_flags =
 build_src_filter = ${rak3112.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<../examples/companion_radio/*.cpp>
-  +<../examples/companion_radio/ui-new/*.cpp>
+  +<../examples/companion_radio/ui-orig/*.cpp>
 lib_deps =
   ${rak3112.lib_deps}
   densaugeo/base64 @ ~1.4.0


### PR DESCRIPTION
* ARDUINO_USB_CDC_ON_BOOT is required for correct usb serial communication (usb serial console)
* ui-new requires display, which is not enabled for this variant, so defaulting to ui-orig