### PR TITLE
sensecap_solar: Fixing LED definitions

### DIFF
--- a/variants/sensecap_solar/variant.cpp
+++ b/variants/sensecap_solar/variant.cpp
@@ -18,8 +18,8 @@ const uint32_t g_ADigitalPinMap[] = {
     47, // D10 P1.15 (SPI_MOSI) LORA_MOSI
 
     // D11-D12 - LED outputs
-    15, // D11 P0.15 User LED
-    19, // D12 P0.19 Breathing LED
+    15, // D11 P0.15 User LED (White LED)
+    19, // D12 P0.19 Breathing LED (Blue LED - LoRa TX)
 
     // D13 - User input
     33, // D13 P1.01 User Button
@@ -58,8 +58,8 @@ void initVariant() {
     pinMode(PIN_QSPI_CS, OUTPUT);
     digitalWrite(PIN_QSPI_CS, HIGH);
 
-    pinMode(LED_GREEN, OUTPUT);
-    digitalWrite(LED_GREEN, LOW);
+    pinMode(LED_WHITE, OUTPUT);
+    digitalWrite(LED_WHITE, LOW);
 
     pinMode(LED_BLUE, OUTPUT);
     digitalWrite(LED_BLUE, LOW);

--- a/variants/sensecap_solar/variant.h
+++ b/variants/sensecap_solar/variant.h
@@ -24,8 +24,8 @@
 #define LED_BUILTIN             (PIN_LED)
 
 #define LED_RED                 (PINS_COUNT)
-#define LED_GREEN               (12)
-#define LED_BLUE                (11)
+#define LED_WHITE               (11)
+#define LED_BLUE                (12)    // LoRa TX indicator
 
 #define LED_STATE_ON            (1)     // State when LED is litted
 


### PR DESCRIPTION
### Summary

Corrects the LED pin definitions for the SenseCap Solar P1 to match the actual hardware. The blue LoRa TX LED was incorrectly named green in the code, and the user LED is white (not blue).

### Problem

- **User LED (D11)** – White LED on pin 11 was defined as `LED_GREEN` on pin 12
- **LoRa TX LED (D12)** – Blue LED on pin 12 was defined as `LED_BLUE` on pin 11

### Changes

- `LED_GREEN` (12) → `LED_WHITE` (11) – User LED on D11
- `LED_BLUE` (11) → `LED_BLUE` (12) – LoRa TX indicator on D12

### Hardware mapping

| Pin | Function | Define |
|-----|----------|--------|
| D11 (P0.15) | User LED (white) | `LED_WHITE` |
| D12 (P0.19) | LoRa TX / breathing LED (blue) | `LED_BLUE` |