### PR TITLE
Default to zerohop advert with 'advert' CLI-Command 

### DIFF
--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -200,10 +200,13 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
       // Reset clock
       getRTCClock()->setCurrentTime(1715770351);  // 15 May 2024, 8:50pm
       _board->reboot();  // doesn't return
-    } else if (memcmp(command, "advert", 6) == 0) {
+    } else if (memcmp(command, "advert.flood", 12) == 0 && (command[12] == 0 || command[12] == ' ')) {
       // send flood advert
       _callbacks->sendSelfAdvertisement(1500, true);  // longer delay, give CLI response time to be sent first
-      strcpy(reply, "OK - Advert sent");
+      strcpy(reply, "OK - Flood advert sent");
+    } else if (memcmp(command, "advert", 6) == 0 && (command[6] == 0 || command[6] == ' ')) {
+      _callbacks->sendSelfAdvertisement(1500, false);  // longer delay, give CLI response time to be sent first
+      strcpy(reply, "OK - zerohop advert sent");
     } else if (memcmp(command, "clock sync", 10) == 0) {
       uint32_t curr = getRTCClock()->getCurrentTime();
       if (sender_timestamp > curr) {


### PR DESCRIPTION
This is an alternative approach to #1490 

The goal is to reduce mesh-load cause by too many repeater adverts.

This PR modifies the logic of the `advert` command to send a zerohop advert by default and introduces a new `advert.flood` command for sending a flood advert.