### PR TITLE
Fix LilyGo_TLora_V2_1_1_6_terminal_chat build

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -292,6 +292,7 @@ int MyMesh::handleRequest(ClientInfo *sender, uint32_t sender_timestamp, uint8_t
 
       // create copy of neighbours list, skipping empty entries so we can sort it separately from main list
       int16_t neighbours_count = 0;
+#if MAX_NEIGHBOURS
       NeighbourInfo* sorted_neighbours[MAX_NEIGHBOURS];
       for (int i = 0; i < MAX_NEIGHBOURS; i++) {
         auto neighbour = &neighbours[i];
@@ -327,6 +328,7 @@ int MyMesh::handleRequest(ClientInfo *sender, uint32_t sender_timestamp, uint8_t
           return a->snr < b->snr; // asc
         });
       }
+#endif
 
       // build results buffer
       int results_count = 0;
@@ -341,6 +343,7 @@ int MyMesh::handleRequest(ClientInfo *sender, uint32_t sender_timestamp, uint8_t
           break;
         }
 
+#if MAX_NEIGHBOURS
         // add next neighbour to results
         auto neighbour = sorted_neighbours[index + offset];
         uint32_t heard_seconds_ago = getRTCClock()->getCurrentTime() - neighbour->heard_timestamp;
@@ -348,6 +351,7 @@ int MyMesh::handleRequest(ClientInfo *sender, uint32_t sender_timestamp, uint8_t
         memcpy(&results_buffer[results_offset], &heard_seconds_ago, 4); results_offset += 4;
         memcpy(&results_buffer[results_offset], &neighbour->snr, 1); results_offset += 1;
         results_count++;
+#endif
 
       }
 

--- a/variants/lilygo_tlora_v2_1/platformio.ini
+++ b/variants/lilygo_tlora_v2_1/platformio.ini
@@ -65,7 +65,7 @@ build_flags =
 ;  -D MESH_PACKET_LOGGING=1
 ;  -D MESH_DEBUG=1
 build_src_filter = ${LilyGo_TLora_V2_1_1_6.build_src_filter}
-  +<../examples/simple_repeater>
+  +<../examples/simple_secure_chat/main.cpp>
 lib_deps =
   ${LilyGo_TLora_V2_1_1_6.lib_deps}
   densaugeo/base64 @ ~1.4.0


### PR DESCRIPTION
This change addresses two issues. The first is that the LilyGo_TLora_V2_1_1_6_terminal_chat build would try to compile `simple_repeater/MyMesh.cpp`. All other examples of terminal chat targets are instead building `simple_secure_chat/main.cpp` . This change would align this build to the rest of the builds.

The second issue, found during the course of investigating the first, stems from `simple_repeater/MyMesh.cpp` using the `MAX_NEIGHBOURS` #define to control whether the neighbor list is kept. Repeaters that keep this list must define this value, and if the value is not defined, then all neighbor-related functionality is compiled out. However, the code that replies to
`REQ_TYPE_GET_NEIGHBOURS` did not properly check for this #define, and thus any target that compiles `simple_repeater/MyMesh.cpp` without defining `MAX_NEIGHBOURS` would get an undefined variable compilation error.

As a practical matter though, there are no targets that compile `simple_repeater/MyMesh.cpp` AND do not define `MAX_NEIGHBOURS`, except this build due to the first issue. As a result, the second issue is addressed only as a matter of completeness. The expected behavior with this change is that such a repeater would send a valid reply indicating zero known neighbors.