### PR TITLE
Simply send SSD1306 off/on commands to keep I2C bus on Wire functioning correctly

### DIFF
--- a/src/helpers/ui/SSD1306Display.cpp
+++ b/src/helpers/ui/SSD1306Display.cpp
@@ -19,30 +19,14 @@ bool SSD1306Display::begin() {
 
 void SSD1306Display::turnOn() {
   if (!_isOn) {
-    if (_peripher_power) {
-      _peripher_power->claim();
-#if defined(PIN_BOARD_SDA) && defined(PIN_BOARD_SCL)
-      Wire.begin(PIN_BOARD_SDA, PIN_BOARD_SCL);  // re-init after Wire.end() in turnOff()
-#else
-      Wire.begin();
-#endif
-    }
-    _isOn = true;  // set before begin() to prevent double claim
-    if (_peripher_power) begin();  // re-init display after power was cut
+    _isOn = true;
+    display.ssd1306_command(SSD1306_DISPLAYON);
   }
-  display.ssd1306_command(SSD1306_DISPLAYON);
 }
 
 void SSD1306Display::turnOff() {
-  display.ssd1306_command(SSD1306_DISPLAYOFF);
   if (_isOn) {
-    if (_peripher_power) {
-      Wire.end();  // release GPIO17/18 before VEXT cut to prevent parasitic current through de-powered SSD1306
-#if PIN_OLED_RESET >= 0
-      digitalWrite(PIN_OLED_RESET, LOW);
-#endif
-      _peripher_power->release();
-    }
+    display.ssd1306_command(SSD1306_DISPLAYOFF);
     _isOn = false;
   }
 }


### PR DESCRIPTION
Following comment by @IoTThinks  that the code killed the I2C bus. Even though pins 17/18 are mentioned to be dedicated to the OLED, you could still use the I2C bus on there for other things. I started out by stopping/restarting the Wire, but maybe it's easier to just put SSD11306 to sleep and avoid VEXT claim/release altogether? Power consumption should be very very minimal (< 10µA).

Confirmed that my BME280 works again when I comment out dedicated env pins:

<img width="257" height="104" alt="image" src="https://github.com/user-attachments/assets/10156e22-a560-494c-913e-2429edc5f7cf" />

Before this change with these lines commented out the BME280 would not be read because the bus would be broken.

I don't have a Heltec v4 with the TFT display, would be great if someone could test. I'd suspect the behavior is unchanged.

@Quency-D thoughts?

Tested this on a USB companion and v4 repeater, both working fine. No increased power consumption. Theoretically a 3500 mAh 18650 could power the SSD11306 display for 40 years if it's in the off state.

The only concern might be keeping VEXT on, but currently only the heltec boards have VEXT defined for the display and there's nothing else on there.

For anyone that can't build themselves easily but wants to try this: https://mcimages.weebl.me?commitId=fix-ssd1306display