### PR TITLE
Fix t-beam S3 supreme partitions

### DIFF
--- a/variants/lilygo_tbeam_supreme_SX1262/platformio.ini
+++ b/variants/lilygo_tbeam_supreme_SX1262/platformio.ini
@@ -26,7 +26,7 @@ build_src_filter = ${esp32_base.build_src_filter}
   +<helpers/ui/SH1106Display.cpp>
   +<helpers/esp32/TBeamBoard.cpp>
   +<helpers/sensors>
-board_build.partitions = min_spiffs.csv ; get around 4mb flash limit
+board_build.partitions = default_8MB.csv
 lib_deps =
   ${esp32_base.lib_deps}
   lewisxhe/XPowersLib @ ^0.2.7


### PR DESCRIPTION
fixes #1709

T-Beam supreme S3 has 8MB of flash memory.