### PR TITLE
NRF52: Add get bootloader.ver command for NRF52

### DIFF
--- a/src/MeshCore.h
+++ b/src/MeshCore.h
@@ -55,6 +55,7 @@ public:
   virtual uint32_t getGpio() { return 0; }
   virtual void setGpio(uint32_t values) {}
   virtual uint8_t getStartupReason() const = 0;
+  virtual bool getBootloaderVersion(char* version, size_t max_len) { return false; }
   virtual bool startOTAUpdate(const char* id, char reply[]) { return false; }   // not supported
 
   // Power management interface (boards with power management override these)

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -362,6 +362,17 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
       } else if (memcmp(config, "bridge.secret", 13) == 0) {
         sprintf(reply, "> %s", _prefs->bridge_secret);
 #endif
+      } else if (memcmp(config, "bootloader.ver", 14) == 0) {
+      #ifdef NRF52_PLATFORM
+          char ver[32];
+          if (_board->getBootloaderVersion(ver, sizeof(ver))) {
+              sprintf(reply, "> %s", ver);
+          } else {
+              strcpy(reply, "> unknown");
+          }
+      #else
+          strcpy(reply, "ERROR: unsupported");
+      #endif
       } else if (memcmp(config, "adc.multiplier", 14) == 0) {
         float adc_mult = _board->getAdcMultiplier();
         if (adc_mult == 0.0f) {

--- a/src/helpers/NRF52Board.cpp
+++ b/src/helpers/NRF52Board.cpp
@@ -297,6 +297,25 @@ float NRF52Board::getMCUTemperature() {
   return temp * 0.25f; // Convert to *C
 }
 
+bool NRF52Board::getBootloaderVersion(char* out, size_t max_len) {
+    static const char BOOTLOADER_MARKER[] = "UF2 Bootloader ";
+    const uint8_t* flash = (const uint8_t*)0x000FB000; // earliest known info.txt location is 0xFB90B, latest is 0xFCC4B
+
+    for (uint32_t i = 0; i < 0x3000 - (sizeof(BOOTLOADER_MARKER) - 1); i++) {
+        if (memcmp(&flash[i], BOOTLOADER_MARKER, sizeof(BOOTLOADER_MARKER) - 1) == 0) {
+            const char* ver = (const char*)&flash[i + sizeof(BOOTLOADER_MARKER) - 1];
+            size_t len = 0;
+            while (len < max_len - 1 && ver[len] != '\0' && ver[len] != ' ' && ver[len] != '\n' && ver[len] != '\r') {
+                out[len] = ver[len];
+                len++;
+            }
+            out[len] = '\0';
+            return len > 0; // bootloader string is non-empty
+        }
+    }
+    return false;
+}
+
 bool NRF52Board::startOTAUpdate(const char *id, char reply[]) {
   // Config the peripheral connection with maximum bandwidth
   // more SRAM required by SoftDevice

--- a/src/helpers/NRF52Board.h
+++ b/src/helpers/NRF52Board.h
@@ -50,6 +50,7 @@ public:
   virtual uint8_t getStartupReason() const override { return startup_reason; }
   virtual float getMCUTemperature() override;
   virtual void reboot() override { NVIC_SystemReset(); }
+  virtual bool getBootloaderVersion(char* version, size_t max_len) override;
   virtual bool startOTAUpdate(const char *id, char reply[]) override;
   virtual void sleep(uint32_t secs) override;
 


### PR DESCRIPTION
This PR adds a function for finding out the NRF52 bootloader version. It relies on searching the flash memory from offset 0xF9000 to 0xFC000 for the "UF2 Bootloader " string which is found in the INFO.TXT file in bootloaders based on Adafruit nRF52 Bootloader.

Tested on RAK 4631 and Heltec V3.

RAK4631 stock bootloader:
```
get bootloader.ver
  -> > 0.4.2
```

RAK4631 latest OTAFIX bootloader:
```
get bootloader.ver
  -> > 0.9.2-OTAFIX1.2-BP1.1
```
Heltec V3:
```
get bootloader.ver
  -> ERROR: unsupported
```