### PR TITLE
Add option to change between SPI0 and SPI1 on RP2040

### DIFF
--- a/variants/rpi_picow/platformio.ini
+++ b/variants/rpi_picow/platformio.ini
@@ -8,6 +8,14 @@ build_flags = ${rp2040_base.build_flags}
   -I variants/rpi_picow
 ;  -D PICOW
 ;  -D HW_SPI1_DEVICE
+
+; Change between SPI and SPI1
+; Default SPI1
+  -D PICOW_SPI=SPI1
+; Alternative SPI aka SPI0 hardware on RP2040
+;  -D PICOW_SPI=SPI
+; Set SPI and other pins correctly when changing SPI hardware
+
   -D P_LORA_DIO_1=20
   -D P_LORA_NSS=3
   -D P_LORA_RESET=15

--- a/variants/rpi_picow/target.cpp
+++ b/variants/rpi_picow/target.cpp
@@ -4,8 +4,11 @@
 
 PicoWBoard board;
 
-RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, SPI1);
-
+#ifdef PICOW_SPI  // if defined in config, use config value
+  RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, PICOW_SPI);
+#else  // If not defines use default
+  RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, SPI1);
+#endif
 WRAPPER_CLASS radio_driver(radio, board);
 
 VolatileRTCClock fallback_clock;
@@ -15,7 +18,11 @@ SensorManager sensors;
 bool radio_init() {
   rtc_clock.begin(Wire);
   
-  return radio.std_init(&SPI1);
+  #ifdef PICOW_SPI  // If defined in config, use defined
+    return radio.std_init(&PICOW_SPI);
+  #else  // If not defines, use default
+    return radio.std_init(&SPI1);
+  #endif
 }
 
 uint32_t radio_get_rng_seed() {


### PR DESCRIPTION
This is useful when somebody want to make/solder own custom Meshcore hardware

Open variants/rpi_picow/platformio.ini file
Comment out unneeded SPI line
Uncomment needed SPI line

Changes to be committed:
	modified:   variants/rpi_picow/platformio.ini
	modified:   variants/rpi_picow/target.cpp