### PR TITLE
Add counter-based relay suppression for flood packets

### DIFF
--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -162,6 +162,7 @@ protected:
 #endif
 
   bool filterRecvFloodPacket(mesh::Packet* pkt) override;
+  void onDuplicateFloodRecv(mesh::Packet* pkt) override;
 
   void onAnonDataRecv(mesh::Packet* packet, const uint8_t* secret, const mesh::Identity& sender, uint8_t* data, size_t len) override;
   int searchPeersByHash(const uint8_t* hash) override;

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -303,6 +303,7 @@ Packet* Dispatcher::obtainNewPacket() {
   } else {
     pkt->payload_len = pkt->path_len = 0;
     pkt->_snr = 0;
+    pkt->_relay_count = 0;
   }
   return pkt;
 }

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -123,6 +123,8 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
       } else if (!_tables->hasSeen(pkt)) {
         onAckRecv(pkt, ack_crc);
         action = routeRecvPacket(pkt);
+      } else if (pkt->isRouteFlood()) {
+        onDuplicateFloodRecv(pkt);
       }
       break;
     }
@@ -183,6 +185,8 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
           }
         }
         action = routeRecvPacket(pkt);
+      } else if (pkt->isRouteFlood()) {
+        onDuplicateFloodRecv(pkt);
       }
       break;
     }
@@ -210,6 +214,8 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
           }
         }
         action = routeRecvPacket(pkt);
+      } else if (pkt->isRouteFlood()) {
+        onDuplicateFloodRecv(pkt);
       }
       break;
     }
@@ -236,6 +242,8 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
           }
         }
         action = routeRecvPacket(pkt);
+      } else if (pkt->isRouteFlood()) {
+        onDuplicateFloodRecv(pkt);
       }
       break;
     }
@@ -275,6 +283,8 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
         } else {
           MESH_DEBUG_PRINTLN("%s Mesh::onRecvPacket(): received advertisement with forged signature! (app_data_len=%d)", getLogDateTime(), app_data_len);
         }
+      } else if (pkt->isRouteFlood()) {
+        onDuplicateFloodRecv(pkt);
       }
       break;
     }

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -165,6 +165,12 @@ protected:
   */
   virtual void onAckRecv(Packet* packet, uint32_t ack_crc) { }
 
+  /**
+   * \brief  A duplicate flood packet was received (hasSeen returned true).
+   *         Sub-classes can use this to implement counter-based relay suppression.
+  */
+  virtual void onDuplicateFloodRecv(Packet* pkt) { }
+
   Mesh(Radio& radio, MillisecondClock& ms, RNG& rng, RTCClock& rtc, PacketManager& mgr, MeshTables& tables)
     : Dispatcher(radio, ms, mgr), _rng(&rng), _rtc(&rtc), _tables(&tables)
   {

--- a/src/Packet.cpp
+++ b/src/Packet.cpp
@@ -8,6 +8,7 @@ Packet::Packet() {
   header = 0;
   path_len = 0;
   payload_len = 0;
+  _relay_count = 0;
 }
 
 int Packet::getRawLength() const {

--- a/src/Packet.h
+++ b/src/Packet.h
@@ -49,6 +49,7 @@ public:
   uint8_t path[MAX_PATH_SIZE];
   uint8_t payload[MAX_PACKET_PAYLOAD];
   int8_t _snr;
+  uint8_t _relay_count;
 
   /**
    * \brief calculate the hash of payload + type

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -81,7 +81,8 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     file.read((uint8_t *)&_prefs->discovery_mod_timestamp, sizeof(_prefs->discovery_mod_timestamp)); // 162
     file.read((uint8_t *)&_prefs->adc_multiplier, sizeof(_prefs->adc_multiplier)); // 166
     file.read((uint8_t *)_prefs->owner_info, sizeof(_prefs->owner_info));  // 170
-    // 290
+    file.read((uint8_t *)&_prefs->relay_redundancy, sizeof(_prefs->relay_redundancy)); // 290
+    // 291
 
     // sanitise bad pref values
     _prefs->rx_delay_base = constrain(_prefs->rx_delay_base, 0, 20.0f);
@@ -107,6 +108,7 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
 
     _prefs->gps_enabled = constrain(_prefs->gps_enabled, 0, 1);
     _prefs->advert_loc_policy = constrain(_prefs->advert_loc_policy, 0, 2);
+    _prefs->relay_redundancy = constrain(_prefs->relay_redundancy, 0, 10);
 
     file.close();
   }
@@ -165,7 +167,8 @@ void CommonCLI::savePrefs(FILESYSTEM* fs) {
     file.write((uint8_t *)&_prefs->discovery_mod_timestamp, sizeof(_prefs->discovery_mod_timestamp)); // 162
     file.write((uint8_t *)&_prefs->adc_multiplier, sizeof(_prefs->adc_multiplier));                 // 166
     file.write((uint8_t *)_prefs->owner_info, sizeof(_prefs->owner_info));  // 170
-    // 290
+    file.write((uint8_t *)&_prefs->relay_redundancy, sizeof(_prefs->relay_redundancy)); // 290
+    // 291
 
     file.close();
   }
@@ -314,6 +317,8 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
         sprintf(reply, "> %s", StrHelper::ftoa(_prefs->tx_delay_factor));
       } else if (memcmp(config, "flood.max", 9) == 0) {
         sprintf(reply, "> %d", (uint32_t)_prefs->flood_max);
+      } else if (memcmp(config, "relay.redundancy", 16) == 0) {
+        sprintf(reply, "> %d", (uint32_t)_prefs->relay_redundancy);
       } else if (memcmp(config, "direct.txdelay", 14) == 0) {
         sprintf(reply, "> %s", StrHelper::ftoa(_prefs->direct_tx_delay_factor));
       } else if (memcmp(config, "owner.info", 10) == 0) {
@@ -525,6 +530,15 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
           strcpy(reply, "OK");
         } else {
           strcpy(reply, "Error, max 64");
+        }
+      } else if (memcmp(config, "relay.redundancy ", 17) == 0) {
+        uint8_t v = atoi(&config[17]);
+        if (v <= 10) {
+          _prefs->relay_redundancy = v;
+          savePrefs();
+          strcpy(reply, "OK");
+        } else {
+          strcpy(reply, "Error, range 0-10");
         }
       } else if (memcmp(config, "direct.txdelay ", 15) == 0) {
         float f = atof(&config[15]);

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -52,6 +52,7 @@ struct NodePrefs { // persisted to file
   uint32_t discovery_mod_timestamp;
   float adc_multiplier;
   char owner_info[120];
+  uint8_t relay_redundancy;
 };
 
 class CommonCLICallbacks {


### PR DESCRIPTION
Implements a MANET-style counter-based relay suppression mechanism for repeaters. During the random backoff before relaying a flood packet, if the node hears the same packet relayed by enough neighbors, it cancels its own relay since the area is already covered.

- Adds onDuplicateFloodRecv hook in Mesh, called when a duplicate flood packet arrives
- Repeater override scans the outbound queue for a matching pending relay and increments a per-packet counter
- When the counter reaches the configurable threshold, the queued relay is removed immediately
- New relay.redundancy preference (default 3, 0 to disable), remotely configurable via get/set relay.redundancy
- Persisted to prefs file, backward-compatible with existing saved configs