### PR TITLE
Update admin password command description

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -293,10 +293,9 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 
 ---
 
-#### View or change this node's admin password
+#### Change this node's admin password
 **Usage:**
-- `get password`
-- `set password <password>`
+- `password <password>`
 
 **Parameters:**
 - `password`: Admin password


### PR DESCRIPTION
Tested in v1.13.
These commands don't work anymore:
```
get password
  -> ??: password
set password secret
  -> unknown config: password secret
```
This does work:
```
password secret
  -> password now: secret
```