### PR TITLE
Modify build flags in platformio.ini for RAK3401

### DIFF
--- a/variants/rak3401/platformio.ini
+++ b/variants/rak3401/platformio.ini
@@ -7,7 +7,7 @@ build_flags = ${nrf52_base.build_flags}
   -I variants/rak3401
   -D RAK_3401
   -D RAK_BOARD
-  - PIN_GPS_EN=-1
+  -D PIN_GPS_EN=-1
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper
   -D LORA_TX_POWER=22


### PR DESCRIPTION
Added GPS Functionality for the 12500 and commented out the RX_BOOSTED_GAIN. GPS module should be installed on Slot A.