### PR TITLE
Added build flags for M5Stack Unit C6L

### DIFF
--- a/variants/m5stack_unit_c6l/platformio.ini
+++ b/variants/m5stack_unit_c6l/platformio.ini
@@ -94,6 +94,8 @@ build_flags = ${M5Stack_Unit_C6L.build_flags}
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
   -D OFFLINE_QUEUE_SIZE=256
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D ARDUINO_USB_MODE=1
 build_src_filter = ${M5Stack_Unit_C6L.build_src_filter}
   +<helpers/esp32/*.cpp>
   -<helpers/esp32/ESPNOWRadio.cpp>


### PR DESCRIPTION
Enabled USB-CDC on boot for M5Stack_Unit_C6L_companion_radio_usb to fix serial connection issues