### PR TITLE
fix(staticpool): guard outbound queue index access

### DIFF
--- a/src/helpers/StaticPoolPacketManager.h
+++ b/src/helpers/StaticPoolPacketManager.h
@@ -14,7 +14,7 @@ public:
   bool add(mesh::Packet* packet, uint8_t priority, uint32_t scheduled_for);
   int count() const { return _num; }
   int countBefore(uint32_t now) const;
-  mesh::Packet* itemAt(int i) const { return _table[i]; }
+  mesh::Packet* itemAt(int i) const { return (i >= 0 && i < _num) ? _table[i] : NULL; }
   mesh::Packet* removeByIdx(int i);
 };
 


### PR DESCRIPTION
## Summary
Adds bounds enforcement for outbound queue indexing in static pool packet management.

## Bug
`PacketQueue::itemAt` did not validate index bounds before dereferencing queue storage.

## Trigger
Request outbound queue items with an index outside current queue range (directly or through higher-level accessors like outbound-by-index paths).

## Impact
- Out-of-bounds memory access
- Possible crash or memory corruption
- Nondeterministic routing/queue behavior under invalid index usage

## Fix
Added explicit bounds checks in `itemAt`; invalid indices are rejected instead of dereferenced.