### PR TITLE
fix(advert): validate parser input lengths before decoding fields

### DIFF
--- a/src/helpers/AdvertDataHelpers.cpp
+++ b/src/helpers/AdvertDataHelpers.cpp
@@ -29,19 +29,25 @@
   AdvertDataParser::AdvertDataParser(const uint8_t app_data[], uint8_t app_data_len) {
     _name[0] = 0;
     _lat = _lon = 0;
-    _flags = app_data[0];
+    _flags = 0;
     _valid = false;
     _extra1 = _extra2 = 0;
+    if (app_data == NULL || app_data_len == 0) return;
+
+    _flags = app_data[0];
   
     int i = 1;
     if (_flags & ADV_LATLON_MASK) {
+      if (i + 8 > app_data_len) return;
       memcpy(&_lat, &app_data[i], 4); i += 4;
       memcpy(&_lon, &app_data[i], 4); i += 4;
     }
     if (_flags & ADV_FEAT1_MASK) {
+      if (i + 2 > app_data_len) return;
       memcpy(&_extra1, &app_data[i], 2); i += 2;
     }
     if (_flags & ADV_FEAT2_MASK) {
+      if (i + 2 > app_data_len) return;
       memcpy(&_extra2, &app_data[i], 2); i += 2;
     }
 
@@ -51,6 +57,9 @@
         nlen = app_data_len - i;  // remainder of app_data
       }
       if (nlen > 0) {
+        if (nlen > MAX_ADVERT_DATA_SIZE - 1) {
+          nlen = MAX_ADVERT_DATA_SIZE - 1;
+        }
         memcpy(_name, &app_data[i], nlen);
         _name[nlen] = 0;  // set null terminator
       }


### PR DESCRIPTION
## Summary
Prevents buffer overreads in advertisement decoding by validating packet length before optional field reads.

## Bug
Advert parsing logic could read optional fields without confirming sufficient remaining bytes, especially for truncated payloads.

## Trigger
Feed truncated or malformed advertisement payloads where declared/expected fields are incomplete.

## Impact
- Stack/global buffer overread risk
- Parser instability on malformed radio input
- Potential crash/hard fault and invalid decoded metadata

## Fix
Added defensive input-length checks before each optional read and capped name-copy length to available buffer capacity.