### PR TITLE
fix(txtdata): avoid UB in _ftoa bit shifts

### DIFF
--- a/src/helpers/TxtDataHelpers.cpp
+++ b/src/helpers/TxtDataHelpers.cpp
@@ -83,12 +83,12 @@ static void _ftoa(float f, char *p, int *status)
   } 
   else if (exp2 >= 23)
   { 
-    int_part = mantissa<<(exp2 - 23);
+    int_part = static_cast<int32_t>(static_cast<uint32_t>(mantissa) << (exp2 - 23));
   }
   else if (exp2 >= 0) 
   {
     int_part = mantissa>>(23 - exp2);
-    frac_part = (mantissa<<(exp2 + 1))&0xFFFFFF;
+    frac_part = static_cast<int32_t>((static_cast<uint32_t>(mantissa) << (exp2 + 1)) & 0xFFFFFFu);
   } 
   else 
   {


### PR DESCRIPTION
## Summary
Removes undefined behavior in float-to-text conversion bit operations in `TxtDataHelpers.cpp`.

## Bug
`_ftoa` used signed shift operations that can invoke undefined behavior for certain values/bit patterns.

## Trigger
Call float formatting on inputs that drive the problematic signed shift path in conversion internals.

## Impact
- Compiler/optimization-dependent output
- Incorrect numeric formatting in text payloads
- Potential runtime instability on some toolchains/targets

## Fix
Switched problematic shift intermediates to unsigned types so bit operations are well-defined across compilers and platforms.