### PR TITLE
fix(utils): reject invalid hex characters in fromHex

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -108,15 +108,15 @@ void Utils::printHex(Stream& s, const uint8_t* src, size_t len) {
   }
 }
 
-static uint8_t hexVal(char c) {
+static int8_t hexVal(char c) {
   if (c >= 'A' && c <= 'F') return c - 'A' + 10;
   if (c >= 'a' && c <= 'f') return c - 'a' + 10;
   if (c >= '0' && c <= '9') return c - '0';
-  return 0;
+  return -1;
 }
 
 bool Utils::isHexChar(char c) {
-  return c == '0' || hexVal(c) > 0;
+  return hexVal(c) >= 0;
 }
 
 bool Utils::fromHex(uint8_t* dest, int dest_size, const char *src_hex) {
@@ -127,7 +127,10 @@ bool Utils::fromHex(uint8_t* dest, int dest_size, const char *src_hex) {
   while (dp - dest < dest_size) {
     char ch = *src_hex++;
     char cl = *src_hex++;
-    *dp++ = (hexVal(ch) << 4) | hexVal(cl);
+    int8_t hi = hexVal(ch);
+    int8_t lo = hexVal(cl);
+    if (hi < 0 || lo < 0) return false;  // invalid chars
+    *dp++ = (hi << 4) | lo;
   }
   return true;
 }


### PR DESCRIPTION
## Summary
Hardens `Utils::fromHex` to reject non-hex characters instead of silently converting them.

## Bug
Hex conversion treated invalid characters as zero-equivalent values in decode flow, allowing malformed input to pass as valid bytes.

## Trigger
Provide non-hex input to flows that decode hex strings (example pattern: `"zz"` in a command expecting hex payload/ID).

## Impact
- Malformed identifiers/bytes accepted as valid
- Silent data corruption during parsing
- Commands can succeed with invalid user input, causing incorrect state changes

## Fix
Introduced strict nibble validation (`hexVal` returns invalid for non-hex chars) and made `fromHex` fail-fast on invalid characters.