### PR TITLE
docs/faq.md: Table of Contents: Remove bogous `[| | High Output | 22 dBm | 28 dBm | |](#--high-output--22-dbm--28-dbm--)`

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -84,7 +84,6 @@ A list of frequently-asked questions and answers for MeshCore
   - [7.5. Q: What is the format of a contact or channel QR code?](#75-q-what-is-the-format-of-a-contact-or-channel-qr-code)
   - [7.6. Q: How do I connect to the companion via WIFI, e.g. using a heltec v3?](#76-q-how-do-i-connect-to-the-companion-via-wifi-eg-using-a-heltec-v3)
   - [7.7. Q: I have a Station G2, or a Heltec V4, or an Ikoka Stick, or a radio with a EByte E22-900M30S or a E22-900M33S module, what should their transmit power be set to?](#77-q-i-have-a-station-g2-or-a-heltec-v4-or-an-ikoka-stick-or-a-radio-with-a-ebyte-e22-900m30s-or-a-e22-900m33s-module-what-should-their-transmit-power-be-set-to)
-- [| | High Output | 22 dBm | 28 dBm | |](#--high-output--22-dbm--28-dbm--)
 
 ## 1. Introduction
 


### PR DESCRIPTION
The table of contents of [`docs/faq.md`](https://github.com/meshcore-dev/MeshCore/blob/main/docs/faq.md) had at the end a bogous entry  
```markdown
- [| | High Output | 22 dBm | 28 dBm | |](#--high-output--22-dbm--28-dbm--)
```

This patch removes that bogous entry.