### PR TITLE
Set OFFLINE_QUEUE_SIZE=256 for missing WiFi companion environments

### DIFF
--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -206,6 +206,7 @@ build_flags =
   -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
   -D DISPLAY_CLASS=SSD1306Display
   -D WIFI_DEBUG_LOGGING=1
   -D WIFI_SSID='"myssid"'
@@ -369,6 +370,7 @@ build_flags =
   -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
   -D DISPLAY_CLASS=ST7789LCDDisplay
   -D WIFI_DEBUG_LOGGING=1
   -D WIFI_SSID='"myssid"'

--- a/variants/lilygo_tbeam_1w/platformio.ini
+++ b/variants/lilygo_tbeam_1w/platformio.ini
@@ -154,6 +154,7 @@ build_flags =
   -I examples/companion_radio/ui-new
   -D MAX_CONTACTS=350
   -D MAX_GROUP_CHANNELS=40
+  -D OFFLINE_QUEUE_SIZE=256
   -D WIFI_DEBUG_LOGGING=1
   -D WIFI_SSID='"myssid"'
   -D WIFI_PWD='"mypwd"'


### PR DESCRIPTION
This PR adds -D OFFLINE_QUEUE_SIZE=256 to WiFi companion environments that were missing this parameter:

- heltec_v4_companion_radio_wifi
- heltec_v4_tft_companion_radio_wifi
- LilyGo_TBeam_1W_companion_radio_wifi

I did successful builds for all three targets.