### PR TITLE
Ikoka Handheld compile fix, fix inverted LED, add status LED

### DIFF
--- a/variants/ikoka_handheld_nrf/IkokaNrf52Board.cpp
+++ b/variants/ikoka_handheld_nrf/IkokaNrf52Board.cpp
@@ -34,6 +34,11 @@ void IkokaNrf52Board::begin() {
   digitalWrite(P_LORA_TX_LED, HIGH);
 #endif
 
+#ifdef PIN_STATUS_LED
+  pinMode(PIN_STATUS_LED, OUTPUT);
+  digitalWrite(PIN_STATUS_LED, HIGH);
+#endif
+
   delay(10); // give sx1262 some time to power up
 }
 

--- a/variants/ikoka_handheld_nrf/platformio.ini
+++ b/variants/ikoka_handheld_nrf/platformio.ini
@@ -1,5 +1,7 @@
 [ikoka_handheld_nrf]
 extends = nrf52_base
+board = seeed-xiao-afruitnrf52-nrf52840
+board_build.ldscript = boards/nrf52840_s140_v7.ld
 build_flags = ${nrf52_base.build_flags}
   ${sensor_base.build_flags}
   -I lib/nrf52/s140_nrf52_7.3.0_API/include
@@ -48,7 +50,7 @@ build_src_filter = ${ikoka_handheld_nrf.build_src_filter}
   +<../examples/companion_radio/*.cpp>
 
 [env:ikoka_handheld_nrf_e22_30dbm_096_companion_radio_ble]
-extends = ikoka_nrf52
+extends = ikoka_handheld_nrf
 build_flags = ${ikoka_handheld_nrf_ssd1306_companion.build_flags}
   -D BLE_PIN_CODE=123456
   -D LORA_TX_POWER=20
@@ -56,7 +58,7 @@ build_src_filter = ${ikoka_handheld_nrf_ssd1306_companion.build_src_filter}
   +<helpers/nrf52/SerialBLEInterface.cpp>
 
 [env:ikoka_handheld_nrf_e22_30dbm_096_rotated_companion_radio_ble]
-extends = ikoka_nrf52
+extends = ikoka_handheld_nrf
 build_flags = ${ikoka_handheld_nrf_ssd1306_companion.build_flags}
   -D BLE_PIN_CODE=123456
   -D LORA_TX_POWER=20
@@ -65,20 +67,20 @@ build_src_filter = ${ikoka_handheld_nrf_ssd1306_companion.build_src_filter}
   +<helpers/nrf52/SerialBLEInterface.cpp>
 
 [env:ikoka_handheld_nrf_e22_30dbm_096_companion_radio_usb]
-extends = ikoka_nrf52
+extends = ikoka_handheld_nrf
 build_flags = ${ikoka_handheld_nrf_ssd1306_companion.build_flags}
   -D LORA_TX_POWER=20
 build_src_filter = ${ikoka_handheld_nrf_ssd1306_companion.build_src_filter}
 
 [env:ikoka_handheld_nrf_e22_30dbm_096_rotated_companion_radio_usb]
-extends = ikoka_nrf52
+extends = ikoka_handheld_nrf
 build_flags = ${ikoka_handheld_nrf_ssd1306_companion.build_flags}
   -D LORA_TX_POWER=20
   -D DISPLAY_ROTATION=2
 build_src_filter = ${ikoka_handheld_nrf_ssd1306_companion.build_src_filter}
 
 [env:ikoka_handheld_nrf_e22_30dbm_repeater]
-extends = ikoka_nrf52
+extends = ikoka_handheld_nrf
 build_flags =
   ${ikoka_handheld_nrf.build_flags}
   -D ADVERT_NAME='"ikoka_handheld Repeater"'
@@ -91,7 +93,7 @@ build_src_filter = ${ikoka_handheld_nrf.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
 
 [env:ikoka_handheld_nrf_e22_30dbm_room_server]
-extends = ikoka_nrf52
+extends = ikoka_handheld_nrf
 build_flags =
   ${ikoka_handheld_nrf.build_flags}
   -D ADVERT_NAME='"ikoka_handheld Room"'

--- a/variants/ikoka_handheld_nrf/variant.h
+++ b/variants/ikoka_handheld_nrf/variant.h
@@ -35,7 +35,7 @@ extern "C"
 #define LED_GREEN               (13)
 #define LED_BLUE                (12)
 
-#define LED_STATE_ON            (1)     // State when LED is litted
+#define LED_STATE_ON            (0)     // State when LED is litted
 
 // Buttons
 #define PIN_BUTTON1             (PINS_COUNT)

--- a/variants/ikoka_handheld_nrf/variant.h
+++ b/variants/ikoka_handheld_nrf/variant.h
@@ -37,6 +37,8 @@ extern "C"
 
 #define LED_STATE_ON            (0)     // State when LED is litted
 
+#define PIN_STATUS_LED          LED_GREEN
+
 // Buttons
 #define PIN_BUTTON1             (PINS_COUNT)
 


### PR DESCRIPTION
This supersedes #1695. Fixes compiling on Ikoka Handheld but also fixes the inverted LED state (BLE status LED now works) and adds the green LED as a user status LED.