### PR TITLE
fix: RegionMap::save() always returned true on write failure

### DIFF
--- a/src/helpers/RegionMap.cpp
+++ b/src/helpers/RegionMap.cpp
@@ -135,7 +135,7 @@ bool RegionMap::save(FILESYSTEM* _fs, const char* path) {
       }
     }
     file.close();
-    return true;
+    return success;
   }
   return false;  // failed
 }


### PR DESCRIPTION
Return 'success' instead of hardcoded 'true' so that failed flash writes are correctly reported to the caller.

I hope this will be helpful for the issue "region name memory space max out #1880".

