### PR TITLE
fix(mesh): use memmove for overlapping path shift

### DIFF
--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -321,7 +321,7 @@ void Mesh::removeSelfFromPath(Packet* pkt) {
 
   uint8_t sz = pkt->getPathHashSize();
   for (int k = 0; k < pkt->getPathHashCount()*sz; k += sz) {  // shuffle path by 1 'entry'
-    memcpy(&pkt->path[k], &pkt->path[k + sz], sz);
+    memmove(&pkt->path[k], &pkt->path[k + sz], sz);
   }
 }
 


### PR DESCRIPTION
This PR fixes undefined behavior in direct-route path rewriting by replacing an overlapping `memcpy` with `memmove`.

## Problem / Impact

`removeSelfFromPath()` shifts path entries left in-place after decrementing the hop count.  
Source and destination ranges overlap by design (`dest = path + k`, `src = path + k + sz`).

Using `memcpy` on overlapping ranges is undefined behavior in C/C++.

On embedded builds, UB here can lead to:
- corrupted route paths,
- intermittent forwarding failures,
- architecture/libc/optimization-dependent behavior that is difficult to reproduce and debug.

Because this function is in the packet forwarding path, even rare corruption can have high network reliability impact.

## Why This Fix Is Correct

`memmove` is defined for overlapping memory regions and preserves the intended in-place shift semantics.

