### PR TITLE
Harden framing and exact I/O paths for partial read/write safety (plus related parser and stats improvements)

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -113,7 +113,7 @@
 
 ---
 
-### Radio Stats - Noise floor, Last RSSI/SNR, Airtime, Receive errors
+### Radio Stats - Noise floor, Last RSSI/SNR, Airtime, WiFi drop count (0 when not using WiFi serial)
 **Usage:** `stats-radio`
 
 **Serial Only:** Yes

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -1022,7 +1022,7 @@ void MyMesh::formatStatsReply(char *reply) {
 }
 
 void MyMesh::formatRadioStatsReply(char *reply) {
-  StatsFormatHelper::formatRadioStats(reply, _radio, radio_driver, getTotalAirTime(), getReceiveAirTime());
+  StatsFormatHelper::formatRadioStats(reply, _radio, radio_driver, getTotalAirTime(), getReceiveAirTime(), getSerialDropCount());
 }
 
 void MyMesh::formatPacketStatsReply(char *reply) {

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -749,7 +749,7 @@ void MyMesh::formatStatsReply(char *reply) {
 }
 
 void MyMesh::formatRadioStatsReply(char *reply) {
-  StatsFormatHelper::formatRadioStats(reply, _radio, radio_driver, getTotalAirTime(), getReceiveAirTime());
+  StatsFormatHelper::formatRadioStats(reply, _radio, radio_driver, getTotalAirTime(), getReceiveAirTime(), getSerialDropCount());
 }
 
 void MyMesh::formatPacketStatsReply(char *reply) {

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -825,7 +825,7 @@ void SensorMesh::formatStatsReply(char *reply) {
 }
 
 void SensorMesh::formatRadioStatsReply(char *reply) {
-  StatsFormatHelper::formatRadioStats(reply, _radio, radio_driver, getTotalAirTime(), getReceiveAirTime());
+  StatsFormatHelper::formatRadioStats(reply, _radio, radio_driver, getTotalAirTime(), getReceiveAirTime(), getSerialDropCount());
 }
 
 void SensorMesh::formatPacketStatsReply(char *reply) {

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -109,45 +109,11 @@ void Dispatcher::loop() {
 }
 
 bool Dispatcher::tryParsePacket(Packet* pkt, const uint8_t* raw, int len) {
-  int i = 0;
+  if (len <= 0 || len > MAX_TRANS_UNIT) return false;
+  if (pkt->readFrom(raw, (size_t) len)) return true;
 
-  pkt->header = raw[i++];
-  if (pkt->getPayloadVer() > PAYLOAD_VER_1) {
-    MESH_DEBUG_PRINTLN("%s Dispatcher::checkRecv(): unsupported packet version", getLogDateTime());
-    return false;
-  }
-
-  if (pkt->hasTransportCodes()) {
-    memcpy(&pkt->transport_codes[0], &raw[i], 2); i += 2;
-    memcpy(&pkt->transport_codes[1], &raw[i], 2); i += 2;
-  } else {
-    pkt->transport_codes[0] = pkt->transport_codes[1] = 0;
-  }
-
-  pkt->path_len = raw[i++];
-  uint8_t path_mode = pkt->path_len >> 6;  // upper 2 bits (legacy firmware: 00)
-  if (path_mode == 3) {   // Reserved for future
-    MESH_DEBUG_PRINTLN("%s Dispatcher::checkRecv(): unsupported path mode: 3", getLogDateTime());
-    return false;
-  }
-
-  uint8_t path_byte_len = (pkt->path_len & 63) * pkt->getPathHashSize();
-  if (path_byte_len > MAX_PATH_SIZE || i + path_byte_len > len) {
-    MESH_DEBUG_PRINTLN("%s Dispatcher::checkRecv(): partial or corrupt packet received, len=%d", getLogDateTime(), len);
-    return false;
-  }
-
-  memcpy(pkt->path, &raw[i], path_byte_len); i += path_byte_len;
-
-  pkt->payload_len = len - i;  // payload is remainder
-  if (pkt->payload_len > sizeof(pkt->payload)) {
-    MESH_DEBUG_PRINTLN("%s Dispatcher::checkRecv(): packet payload too big, payload_len=%d", getLogDateTime(), (uint32_t)pkt->payload_len);
-    return false;
-  }
-
-  memcpy(pkt->payload, &raw[i], pkt->payload_len);
-
-  return true;  // success
+  MESH_DEBUG_PRINTLN("%s Dispatcher::checkRecv(): partial or corrupt packet received, len=%d", getLogDateTime(), len);
+  return false;
 }
 
 void Dispatcher::checkRecv() {

--- a/src/Packet.cpp
+++ b/src/Packet.cpp
@@ -62,26 +62,45 @@ uint8_t Packet::writeTo(uint8_t dest[]) const {
   return i;
 }
 
-bool Packet::readFrom(const uint8_t src[], uint8_t len) {
-  uint8_t i = 0;
-  header = src[i++];
-  if (hasTransportCodes()) {
-    memcpy(&transport_codes[0], &src[i], 2); i += 2;
-    memcpy(&transport_codes[1], &src[i], 2); i += 2;
-  } else {
-    transport_codes[0] = transport_codes[1] = 0;
+bool Packet::readFrom(const uint8_t src[], size_t len) {
+  if (src == NULL || len < 2) return false;  // needs at least header + path_len
+
+  size_t i = 0;
+  uint8_t new_header = src[i++];
+  uint16_t new_transport_codes[2] = {0, 0};
+
+  uint8_t route_type = new_header & PH_ROUTE_MASK;
+  bool has_transport = route_type == ROUTE_TYPE_TRANSPORT_FLOOD || route_type == ROUTE_TYPE_TRANSPORT_DIRECT;
+  if (has_transport) {
+    if (len - i < 4) return false;   // truncated transport header
+    memcpy(&new_transport_codes[0], &src[i], 2); i += 2;
+    memcpy(&new_transport_codes[1], &src[i], 2); i += 2;
   }
-  path_len = src[i++];
-  if (!isValidPathLen(path_len)) return false;   // bad encoding
 
-  uint8_t bl = getPathByteLen();
-  memcpy(path, &src[i], bl); i += bl;
+  if (len - i < 1) return false;   // missing path_len
+  uint8_t new_path_len = src[i++];
+  uint8_t payload_ver = (new_header >> PH_VER_SHIFT) & PH_VER_MASK;
+  if (payload_ver > PAYLOAD_VER_1 || !isValidPathLen(new_path_len)) return false;
 
-  if (i >= len) return false;   // bad encoding
-  payload_len = len - i;
-  if (payload_len > sizeof(payload)) return false;  // bad encoding
-  memcpy(payload, &src[i], payload_len); //i += payload_len;
-  return true;   // success
+  size_t path_byte_len = (new_path_len & 63) * ((new_path_len >> 6) + 1);
+  if (len - i < path_byte_len) return false;   // truncated path
+
+  uint8_t new_path[MAX_PATH_SIZE];
+  memcpy(new_path, &src[i], path_byte_len); i += path_byte_len;
+
+  if (i >= len) return false;   // empty payload is invalid encoding
+  size_t new_payload_len = len - i;
+  if (new_payload_len > sizeof(payload)) return false;
+
+  // Only commit state after all bounds checks succeed.
+  header = new_header;
+  transport_codes[0] = new_transport_codes[0];
+  transport_codes[1] = new_transport_codes[1];
+  path_len = new_path_len;
+  payload_len = new_payload_len;
+  memcpy(path, new_path, path_byte_len);
+  memcpy(payload, &src[i], new_payload_len);
+  return true;
 }
 
 }

--- a/src/Packet.h
+++ b/src/Packet.h
@@ -108,7 +108,7 @@ public:
    * \param  src  (IN) buffer containing blob
    * \param  len  the packet length (as returned by writeTo())
    */
-  bool readFrom(const uint8_t src[], uint8_t len);
+  bool readFrom(const uint8_t src[], size_t len);
 };
 
 }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -73,6 +73,7 @@ int Utils::encryptThenMAC(const uint8_t* shared_secret, uint8_t* dest, const uin
 
 int Utils::MACThenDecrypt(const uint8_t* shared_secret, uint8_t* dest, const uint8_t* src, int src_len) {
   if (src_len <= CIPHER_MAC_SIZE) return 0;  // invalid src bytes
+  if ((src_len - CIPHER_MAC_SIZE) % CIPHER_BLOCK_SIZE != 0) return 0;  // invalid ciphertext length
 
   uint8_t hmac[CIPHER_MAC_SIZE];
   {

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -452,7 +452,10 @@ bool BaseChatMesh::shareContactZeroHop(const ContactInfo& contact) {
   auto packet = obtainNewPacket();
   if (packet == NULL) return false;  // no Packets available
 
-  packet->readFrom(temp_buf, plen);  // restore Packet from 'blob'
+  if (!packet->readFrom(temp_buf, plen)) {  // restore Packet from 'blob'
+    releasePacket(packet);
+    return false;
+  }
   uint16_t codes[2];
   codes[0] = codes[1] = 0;   // { 0, 0 } means 'send this nowhere'
   sendZeroHop(packet, codes);

--- a/src/helpers/BaseSerialInterface.h
+++ b/src/helpers/BaseSerialInterface.h
@@ -18,4 +18,5 @@ public:
   virtual bool isWriteBusy() const = 0;
   virtual size_t writeFrame(const uint8_t src[], size_t len) = 0;
   virtual size_t checkRecvFrame(uint8_t dest[]) = 0;
+  virtual uint32_t getDropCount() const { return 0; }
 };

--- a/src/helpers/CheckedIO.h
+++ b/src/helpers/CheckedIO.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#if defined(ESP32) || defined(RP2040_PLATFORM)
+  #include <FS.h>
+#elif defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
+  #include <Adafruit_LittleFS.h>
+  using namespace Adafruit_LittleFS_Namespace;
+#endif
+
+namespace checked_io {
+
+inline bool readExact(File& file, uint8_t* dest, size_t len) {
+  size_t done = 0;
+  while (done < len) {
+    int n = file.read(dest + done, len - done);
+    if (n <= 0) return false;
+    done += (size_t) n;
+  }
+  return true;
+}
+
+inline bool writeExact(File& file, const uint8_t* src, size_t len) {
+  size_t done = 0;
+  while (done < len) {
+    size_t n = file.write(src + done, len - done);
+    if (n == 0) return false;
+    done += n;
+  }
+  return true;
+}
+
+template <typename T>
+inline bool readValue(File& file, T& value) {
+  return readExact(file, (uint8_t*) &value, sizeof(T));
+}
+
+template <typename T>
+inline bool writeValue(File& file, const T& value) {
+  return writeExact(file, (const uint8_t*) &value, sizeof(T));
+}
+
+}

--- a/src/helpers/ClientACL.cpp
+++ b/src/helpers/ClientACL.cpp
@@ -1,4 +1,5 @@
 #include "ClientACL.h"
+#include "CheckedIO.h"
 
 static File openWrite(FILESYSTEM* _fs, const char* filename) {
   #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
@@ -29,13 +30,13 @@ void ClientACL::load(FILESYSTEM* fs, const mesh::LocalIdentity& self_id) {
 
         memset(&c, 0, sizeof(c));
 
-        bool success = (file.read(pub_key, 32) == 32);
-        success = success && (file.read((uint8_t *) &c.permissions, 1) == 1);
-        success = success && (file.read((uint8_t *) &c.extra.room.sync_since, 4) == 4);
-        success = success && (file.read(unused, 2) == 2);
-        success = success && (file.read((uint8_t *)&c.out_path_len, 1) == 1);
-        success = success && (file.read(c.out_path, 64) == 64);
-        success = success && (file.read(c.shared_secret, PUB_KEY_SIZE) == PUB_KEY_SIZE); // will be recalculated below
+        bool success = checked_io::readExact(file, pub_key, 32);
+        success = success && checked_io::readValue(file, c.permissions);
+        success = success && checked_io::readValue(file, c.extra.room.sync_since);
+        success = success && checked_io::readExact(file, unused, 2);
+        success = success && checked_io::readValue(file, c.out_path_len);
+        success = success && checked_io::readExact(file, c.out_path, 64);
+        success = success && checked_io::readExact(file, c.shared_secret, PUB_KEY_SIZE); // recalculated below
 
         if (!success) break; // EOF
 
@@ -63,13 +64,13 @@ void ClientACL::save(FILESYSTEM* fs, bool (*filter)(ClientInfo*)) {
       auto c = &clients[i];
       if (c->permissions == 0 || (filter && !filter(c))) continue;    // skip deleted entries, or by filter function
 
-      bool success = (file.write(c->id.pub_key, 32) == 32);
-      success = success && (file.write((uint8_t *) &c->permissions, 1) == 1);
-      success = success && (file.write((uint8_t *) &c->extra.room.sync_since, 4) == 4);
-      success = success && (file.write(unused, 2) == 2);
-      success = success && (file.write((uint8_t *)&c->out_path_len, 1) == 1);
-      success = success && (file.write(c->out_path, 64) == 64);
-      success = success && (file.write(c->shared_secret, PUB_KEY_SIZE) == PUB_KEY_SIZE);
+      bool success = checked_io::writeExact(file, c->id.pub_key, 32);
+      success = success && checked_io::writeValue(file, c->permissions);
+      success = success && checked_io::writeValue(file, c->extra.room.sync_since);
+      success = success && checked_io::writeExact(file, unused, 2);
+      success = success && checked_io::writeValue(file, c->out_path_len);
+      success = success && checked_io::writeExact(file, c->out_path, 64);
+      success = success && checked_io::writeExact(file, c->shared_secret, PUB_KEY_SIZE);
 
       if (!success) break; // write failed
     }

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -2,6 +2,7 @@
 #include "CommonCLI.h"
 #include "TxtDataHelpers.h"
 #include "AdvertDataHelpers.h"
+#include "CheckedIO.h"
 #include <RTClib.h>
 
 // Believe it or not, this std C function is busted on some platforms!
@@ -22,6 +23,37 @@ static bool isValidName(const char *n) {
   return true;
 }
 
+static void readCompatPad(File& file, bool& truncated, size_t n) {
+  if (truncated) return;
+  uint8_t pad[8];
+  if (n > sizeof(pad) || !checked_io::readExact(file, pad, n)) {
+    truncated = true;
+  }
+}
+
+template <typename T>
+static void readCompatValue(File& file, bool& truncated, T& field) {
+  if (truncated) return;
+  T tmp = field;
+  if (checked_io::readValue(file, tmp)) {
+    field = tmp;
+  } else {
+    truncated = true;
+  }
+}
+
+template <size_t N>
+static void readCompatCharArray(File& file, bool& truncated, char (&arr)[N]) {
+  if (truncated) return;
+  char tmp[N];
+  memcpy(tmp, arr, sizeof(tmp));
+  if (checked_io::readExact(file, (uint8_t*) tmp, sizeof(tmp))) {
+    memcpy(arr, tmp, sizeof(tmp));
+  } else {
+    truncated = true;
+  }
+}
+
 void CommonCLI::loadPrefs(FILESYSTEM* fs) {
   if (fs->exists("/com_prefs")) {
     loadPrefsInt(fs, "/com_prefs");   // new filename
@@ -39,50 +71,53 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
   File file = fs->open(filename);
 #endif
   if (file) {
-    uint8_t pad[8];
+    NodePrefs loaded = *_prefs;
+    bool truncated = false;
 
-    file.read((uint8_t *)&_prefs->airtime_factor, sizeof(_prefs->airtime_factor));    // 0
-    file.read((uint8_t *)&_prefs->node_name, sizeof(_prefs->node_name));              // 4
-    file.read(pad, 4);                                                                // 36
-    file.read((uint8_t *)&_prefs->node_lat, sizeof(_prefs->node_lat));                // 40
-    file.read((uint8_t *)&_prefs->node_lon, sizeof(_prefs->node_lon));                // 48
-    file.read((uint8_t *)&_prefs->password[0], sizeof(_prefs->password));             // 56
-    file.read((uint8_t *)&_prefs->freq, sizeof(_prefs->freq));                        // 72
-    file.read((uint8_t *)&_prefs->tx_power_dbm, sizeof(_prefs->tx_power_dbm));        // 76
-    file.read((uint8_t *)&_prefs->disable_fwd, sizeof(_prefs->disable_fwd));          // 77
-    file.read((uint8_t *)&_prefs->advert_interval, sizeof(_prefs->advert_interval));  // 78
-    file.read((uint8_t *)pad, 1);                                                     // 79  was 'unused'
-    file.read((uint8_t *)&_prefs->rx_delay_base, sizeof(_prefs->rx_delay_base));      // 80
-    file.read((uint8_t *)&_prefs->tx_delay_factor, sizeof(_prefs->tx_delay_factor));  // 84
-    file.read((uint8_t *)&_prefs->guest_password[0], sizeof(_prefs->guest_password)); // 88
-    file.read((uint8_t *)&_prefs->direct_tx_delay_factor, sizeof(_prefs->direct_tx_delay_factor)); // 104
-    file.read(pad, 4);                                                                             // 108
-    file.read((uint8_t *)&_prefs->sf, sizeof(_prefs->sf));                                         // 112
-    file.read((uint8_t *)&_prefs->cr, sizeof(_prefs->cr));                                         // 113
-    file.read((uint8_t *)&_prefs->allow_read_only, sizeof(_prefs->allow_read_only));               // 114
-    file.read((uint8_t *)&_prefs->multi_acks, sizeof(_prefs->multi_acks));                         // 115
-    file.read((uint8_t *)&_prefs->bw, sizeof(_prefs->bw));                                         // 116
-    file.read((uint8_t *)&_prefs->agc_reset_interval, sizeof(_prefs->agc_reset_interval));         // 120
-    file.read((uint8_t *)&_prefs->path_hash_mode, sizeof(_prefs->path_hash_mode));                 // 121
-    file.read(pad, 2);                                                                             // 122
-    file.read((uint8_t *)&_prefs->flood_max, sizeof(_prefs->flood_max));                           // 124
-    file.read((uint8_t *)&_prefs->flood_advert_interval, sizeof(_prefs->flood_advert_interval));   // 125
-    file.read((uint8_t *)&_prefs->interference_threshold, sizeof(_prefs->interference_threshold)); // 126
-    file.read((uint8_t *)&_prefs->bridge_enabled, sizeof(_prefs->bridge_enabled));                 // 127
-    file.read((uint8_t *)&_prefs->bridge_delay, sizeof(_prefs->bridge_delay));                     // 128
-    file.read((uint8_t *)&_prefs->bridge_pkt_src, sizeof(_prefs->bridge_pkt_src));                 // 130
-    file.read((uint8_t *)&_prefs->bridge_baud, sizeof(_prefs->bridge_baud));                       // 131
-    file.read((uint8_t *)&_prefs->bridge_channel, sizeof(_prefs->bridge_channel));                 // 135
-    file.read((uint8_t *)&_prefs->bridge_secret, sizeof(_prefs->bridge_secret));                   // 136
-    file.read((uint8_t *)&_prefs->powersaving_enabled, sizeof(_prefs->powersaving_enabled));       // 152
-    file.read(pad, 3);                                                                             // 153
-    file.read((uint8_t *)&_prefs->gps_enabled, sizeof(_prefs->gps_enabled));                       // 156
-    file.read((uint8_t *)&_prefs->gps_interval, sizeof(_prefs->gps_interval));                     // 157
-    file.read((uint8_t *)&_prefs->advert_loc_policy, sizeof (_prefs->advert_loc_policy));          // 161
-    file.read((uint8_t *)&_prefs->discovery_mod_timestamp, sizeof(_prefs->discovery_mod_timestamp)); // 162
-    file.read((uint8_t *)&_prefs->adc_multiplier, sizeof(_prefs->adc_multiplier)); // 166
-    file.read((uint8_t *)_prefs->owner_info, sizeof(_prefs->owner_info));  // 170
-    // 290
+    readCompatValue(file, truncated, loaded.airtime_factor);         // 0
+    readCompatCharArray(file, truncated, loaded.node_name);          // 4
+    readCompatPad(file, truncated, 4);                               // 36
+    readCompatValue(file, truncated, loaded.node_lat);               // 40
+    readCompatValue(file, truncated, loaded.node_lon);               // 48
+    readCompatCharArray(file, truncated, loaded.password);           // 56
+    readCompatValue(file, truncated, loaded.freq);                   // 72
+    readCompatValue(file, truncated, loaded.tx_power_dbm);           // 76
+    readCompatValue(file, truncated, loaded.disable_fwd);            // 77
+    readCompatValue(file, truncated, loaded.advert_interval);        // 78
+    readCompatPad(file, truncated, 1);                               // 79  was 'unused'
+    readCompatValue(file, truncated, loaded.rx_delay_base);          // 80
+    readCompatValue(file, truncated, loaded.tx_delay_factor);        // 84
+    readCompatCharArray(file, truncated, loaded.guest_password);     // 88
+    readCompatValue(file, truncated, loaded.direct_tx_delay_factor); // 104
+    readCompatPad(file, truncated, 4);                               // 108
+    readCompatValue(file, truncated, loaded.sf);                     // 112
+    readCompatValue(file, truncated, loaded.cr);                     // 113
+    readCompatValue(file, truncated, loaded.allow_read_only);        // 114
+    readCompatValue(file, truncated, loaded.multi_acks);             // 115
+    readCompatValue(file, truncated, loaded.bw);                     // 116
+    readCompatValue(file, truncated, loaded.agc_reset_interval);     // 120
+    readCompatValue(file, truncated, loaded.path_hash_mode);         // 121
+    readCompatPad(file, truncated, 2);                               // 122
+    readCompatValue(file, truncated, loaded.flood_max);              // 124
+    readCompatValue(file, truncated, loaded.flood_advert_interval);  // 125
+    readCompatValue(file, truncated, loaded.interference_threshold); // 126
+    readCompatValue(file, truncated, loaded.bridge_enabled);         // 127
+    readCompatValue(file, truncated, loaded.bridge_delay);           // 128
+    readCompatValue(file, truncated, loaded.bridge_pkt_src);         // 130
+    readCompatValue(file, truncated, loaded.bridge_baud);            // 131
+    readCompatValue(file, truncated, loaded.bridge_channel);         // 135
+    readCompatCharArray(file, truncated, loaded.bridge_secret);      // 136
+    readCompatValue(file, truncated, loaded.powersaving_enabled);    // 152
+    readCompatPad(file, truncated, 3);                               // 153
+    readCompatValue(file, truncated, loaded.gps_enabled);            // 156
+    readCompatValue(file, truncated, loaded.gps_interval);           // 157
+    readCompatValue(file, truncated, loaded.advert_loc_policy);      // 161
+    readCompatValue(file, truncated, loaded.discovery_mod_timestamp);// 162
+    readCompatValue(file, truncated, loaded.adc_multiplier);         // 166
+    readCompatCharArray(file, truncated, loaded.owner_info);         // 170
+    // 290 bytes total
+
+    *_prefs = loaded;
 
     // sanitise bad pref values
     _prefs->rx_delay_base = constrain(_prefs->rx_delay_base, 0, 20.0f);
@@ -110,6 +145,10 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     _prefs->gps_enabled = constrain(_prefs->gps_enabled, 0, 1);
     _prefs->advert_loc_policy = constrain(_prefs->advert_loc_policy, 0, 2);
 
+    if (truncated) {
+      MESH_DEBUG_PRINTLN("CommonCLI::loadPrefsInt() truncated prefs, keeping defaults for missing fields");
+    }
+
     file.close();
   }
 }
@@ -126,49 +165,52 @@ void CommonCLI::savePrefs(FILESYSTEM* fs) {
   if (file) {
     uint8_t pad[8];
     memset(pad, 0, sizeof(pad));
+    bool success = checked_io::writeValue(file, _prefs->airtime_factor);         // 0
+    success = success && checked_io::writeExact(file, (uint8_t *) _prefs->node_name, sizeof(_prefs->node_name)); // 4
+    success = success && checked_io::writeExact(file, pad, 4);                   // 36
+    success = success && checked_io::writeValue(file, _prefs->node_lat);         // 40
+    success = success && checked_io::writeValue(file, _prefs->node_lon);         // 48
+    success = success && checked_io::writeExact(file, (uint8_t *) &_prefs->password[0], sizeof(_prefs->password)); // 56
+    success = success && checked_io::writeValue(file, _prefs->freq);             // 72
+    success = success && checked_io::writeValue(file, _prefs->tx_power_dbm);     // 76
+    success = success && checked_io::writeValue(file, _prefs->disable_fwd);      // 77
+    success = success && checked_io::writeValue(file, _prefs->advert_interval);  // 78
+    success = success && checked_io::writeExact(file, pad, 1);                   // 79  was 'unused'
+    success = success && checked_io::writeValue(file, _prefs->rx_delay_base);    // 80
+    success = success && checked_io::writeValue(file, _prefs->tx_delay_factor);  // 84
+    success = success && checked_io::writeExact(file, (uint8_t *) &_prefs->guest_password[0], sizeof(_prefs->guest_password)); // 88
+    success = success && checked_io::writeValue(file, _prefs->direct_tx_delay_factor); // 104
+    success = success && checked_io::writeExact(file, pad, 4);                   // 108
+    success = success && checked_io::writeValue(file, _prefs->sf);               // 112
+    success = success && checked_io::writeValue(file, _prefs->cr);               // 113
+    success = success && checked_io::writeValue(file, _prefs->allow_read_only);  // 114
+    success = success && checked_io::writeValue(file, _prefs->multi_acks);       // 115
+    success = success && checked_io::writeValue(file, _prefs->bw);               // 116
+    success = success && checked_io::writeValue(file, _prefs->agc_reset_interval); // 120
+    success = success && checked_io::writeValue(file, _prefs->path_hash_mode);   // 121
+    success = success && checked_io::writeExact(file, pad, 2);                   // 122
+    success = success && checked_io::writeValue(file, _prefs->flood_max);        // 124
+    success = success && checked_io::writeValue(file, _prefs->flood_advert_interval); // 125
+    success = success && checked_io::writeValue(file, _prefs->interference_threshold); // 126
+    success = success && checked_io::writeValue(file, _prefs->bridge_enabled);   // 127
+    success = success && checked_io::writeValue(file, _prefs->bridge_delay);     // 128
+    success = success && checked_io::writeValue(file, _prefs->bridge_pkt_src);   // 130
+    success = success && checked_io::writeValue(file, _prefs->bridge_baud);      // 131
+    success = success && checked_io::writeValue(file, _prefs->bridge_channel);   // 135
+    success = success && checked_io::writeExact(file, (uint8_t *) _prefs->bridge_secret, sizeof(_prefs->bridge_secret)); // 136
+    success = success && checked_io::writeValue(file, _prefs->powersaving_enabled); // 152
+    success = success && checked_io::writeExact(file, pad, 3);                   // 153
+    success = success && checked_io::writeValue(file, _prefs->gps_enabled);      // 156
+    success = success && checked_io::writeValue(file, _prefs->gps_interval);     // 157
+    success = success && checked_io::writeValue(file, _prefs->advert_loc_policy);// 161
+    success = success && checked_io::writeValue(file, _prefs->discovery_mod_timestamp); // 162
+    success = success && checked_io::writeValue(file, _prefs->adc_multiplier);   // 166
+    success = success && checked_io::writeExact(file, (uint8_t *) _prefs->owner_info, sizeof(_prefs->owner_info)); // 170
+    // 290 bytes total
 
-    file.write((uint8_t *)&_prefs->airtime_factor, sizeof(_prefs->airtime_factor));    // 0
-    file.write((uint8_t *)&_prefs->node_name, sizeof(_prefs->node_name));              // 4
-    file.write(pad, 4);                                                                // 36
-    file.write((uint8_t *)&_prefs->node_lat, sizeof(_prefs->node_lat));                // 40
-    file.write((uint8_t *)&_prefs->node_lon, sizeof(_prefs->node_lon));                // 48
-    file.write((uint8_t *)&_prefs->password[0], sizeof(_prefs->password));             // 56
-    file.write((uint8_t *)&_prefs->freq, sizeof(_prefs->freq));                        // 72
-    file.write((uint8_t *)&_prefs->tx_power_dbm, sizeof(_prefs->tx_power_dbm));        // 76
-    file.write((uint8_t *)&_prefs->disable_fwd, sizeof(_prefs->disable_fwd));          // 77
-    file.write((uint8_t *)&_prefs->advert_interval, sizeof(_prefs->advert_interval));  // 78
-    file.write((uint8_t *)pad, 1);                                                     // 79  was 'unused'
-    file.write((uint8_t *)&_prefs->rx_delay_base, sizeof(_prefs->rx_delay_base));      // 80
-    file.write((uint8_t *)&_prefs->tx_delay_factor, sizeof(_prefs->tx_delay_factor));  // 84
-    file.write((uint8_t *)&_prefs->guest_password[0], sizeof(_prefs->guest_password)); // 88
-    file.write((uint8_t *)&_prefs->direct_tx_delay_factor, sizeof(_prefs->direct_tx_delay_factor)); // 104
-    file.write(pad, 4);                                                                             // 108
-    file.write((uint8_t *)&_prefs->sf, sizeof(_prefs->sf));                                         // 112
-    file.write((uint8_t *)&_prefs->cr, sizeof(_prefs->cr));                                         // 113
-    file.write((uint8_t *)&_prefs->allow_read_only, sizeof(_prefs->allow_read_only));               // 114
-    file.write((uint8_t *)&_prefs->multi_acks, sizeof(_prefs->multi_acks));                         // 115
-    file.write((uint8_t *)&_prefs->bw, sizeof(_prefs->bw));                                         // 116
-    file.write((uint8_t *)&_prefs->agc_reset_interval, sizeof(_prefs->agc_reset_interval));         // 120
-    file.write((uint8_t *)&_prefs->path_hash_mode, sizeof(_prefs->path_hash_mode));                 // 121
-    file.write(pad, 2);                                                                             // 122
-    file.write((uint8_t *)&_prefs->flood_max, sizeof(_prefs->flood_max));                           // 124
-    file.write((uint8_t *)&_prefs->flood_advert_interval, sizeof(_prefs->flood_advert_interval));   // 125
-    file.write((uint8_t *)&_prefs->interference_threshold, sizeof(_prefs->interference_threshold)); // 126
-    file.write((uint8_t *)&_prefs->bridge_enabled, sizeof(_prefs->bridge_enabled));                 // 127
-    file.write((uint8_t *)&_prefs->bridge_delay, sizeof(_prefs->bridge_delay));                     // 128
-    file.write((uint8_t *)&_prefs->bridge_pkt_src, sizeof(_prefs->bridge_pkt_src));                 // 130
-    file.write((uint8_t *)&_prefs->bridge_baud, sizeof(_prefs->bridge_baud));                       // 131
-    file.write((uint8_t *)&_prefs->bridge_channel, sizeof(_prefs->bridge_channel));                 // 135
-    file.write((uint8_t *)&_prefs->bridge_secret, sizeof(_prefs->bridge_secret));                   // 136
-    file.write((uint8_t *)&_prefs->powersaving_enabled, sizeof(_prefs->powersaving_enabled));       // 152
-    file.write(pad, 3);                                                                             // 153
-    file.write((uint8_t *)&_prefs->gps_enabled, sizeof(_prefs->gps_enabled));                       // 156
-    file.write((uint8_t *)&_prefs->gps_interval, sizeof(_prefs->gps_interval));                     // 157
-    file.write((uint8_t *)&_prefs->advert_loc_policy, sizeof(_prefs->advert_loc_policy));           // 161
-    file.write((uint8_t *)&_prefs->discovery_mod_timestamp, sizeof(_prefs->discovery_mod_timestamp)); // 162
-    file.write((uint8_t *)&_prefs->adc_multiplier, sizeof(_prefs->adc_multiplier));                 // 166
-    file.write((uint8_t *)_prefs->owner_info, sizeof(_prefs->owner_info));  // 170
-    // 290
+    if (!success) {
+      MESH_DEBUG_PRINTLN("CommonCLI::savePrefs() failed: partial/short write");
+    }
 
     file.close();
   }

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -76,6 +76,7 @@ public:
   virtual void formatStatsReply(char *reply) = 0;
   virtual void formatRadioStatsReply(char *reply) = 0;
   virtual void formatPacketStatsReply(char *reply) = 0;
+  virtual uint32_t getSerialDropCount() const { return 0; }
   virtual mesh::LocalIdentity& getSelfId() = 0;
   virtual void saveIdentity(const mesh::LocalIdentity& new_id) = 0;
   virtual void clearStats() = 0;

--- a/src/helpers/IdentityStore.cpp
+++ b/src/helpers/IdentityStore.cpp
@@ -1,4 +1,5 @@
 #include "IdentityStore.h"
+#include "CheckedIO.h"
 
 bool IdentityStore::load(const char *name, mesh::LocalIdentity& id) {
   bool loaded = false;
@@ -19,6 +20,8 @@ bool IdentityStore::load(const char *name, mesh::LocalIdentity& id) {
 }
 
 bool IdentityStore::load(const char *name, mesh::LocalIdentity& id, char display_name[], int max_name_sz) {
+  if (display_name == NULL || max_name_sz <= 0) return false;
+
   bool loaded = false;
   char filename[40];
   sprintf(filename, "%s/%s.id", _dir, name);
@@ -33,7 +36,7 @@ bool IdentityStore::load(const char *name, mesh::LocalIdentity& id, char display
 
       int n = max_name_sz;   // up to 32 bytes
       if (n > 32) n = 32;
-      file.read((uint8_t *) display_name, n);
+      loaded = loaded && checked_io::readExact(file, (uint8_t *) display_name, n);
       display_name[n - 1] = 0;  // ensure null terminator
 
       file.close();
@@ -58,7 +61,7 @@ bool IdentityStore::save(const char *name, const mesh::LocalIdentity& id) {
     bool success = id.writeTo(file);
     file.close();
     MESH_DEBUG_PRINTLN("IdentityStore::save() write - %s", success ? "OK" : "Err");
-    return true;
+    return success;
   }
   MESH_DEBUG_PRINTLN("IdentityStore::save() failed");
   return false;
@@ -77,17 +80,17 @@ bool IdentityStore::save(const char *name, const mesh::LocalIdentity& id, const 
   File file = _fs->open(filename, "w", true);
 #endif
   if (file) {
-    id.writeTo(file);
+    bool success = id.writeTo(file);
 
     uint8_t tmp[32];
     memset(tmp, 0, sizeof(tmp));
     int n = strlen(display_name);
     if (n > sizeof(tmp)-1) n = sizeof(tmp)-1;
     memcpy(tmp, display_name, n);
-    file.write(tmp, sizeof(tmp));
+    success = success && checked_io::writeExact(file, tmp, sizeof(tmp));
 
     file.close();
-    return true;
+    return success;
   }
   return false;
 }

--- a/src/helpers/StatsFormatHelper.h
+++ b/src/helpers/StatsFormatHelper.h
@@ -23,14 +23,16 @@ public:
                               mesh::Radio* radio,
                               RadioDriverType& driver,
                               uint32_t total_air_time_ms,
-                              uint32_t total_rx_air_time_ms) {
+                              uint32_t total_rx_air_time_ms,
+                              uint32_t wifi_drop_count = 0) {
     sprintf(reply, 
-      "{\"noise_floor\":%d,\"last_rssi\":%d,\"last_snr\":%.2f,\"tx_air_secs\":%u,\"rx_air_secs\":%u}",
+      "{\"noise_floor\":%d,\"last_rssi\":%d,\"last_snr\":%.2f,\"tx_air_secs\":%u,\"rx_air_secs\":%u,\"wifi_drops\":%u}",
       (int16_t)radio->getNoiseFloor(),
       (int16_t)driver.getLastRSSI(),
       driver.getLastSNR(),
       total_air_time_ms / 1000,
-      total_rx_air_time_ms / 1000
+      total_rx_air_time_ms / 1000,
+      wifi_drop_count
     );
   }
 

--- a/src/helpers/bridges/RS232Bridge.cpp
+++ b/src/helpers/bridges/RS232Bridge.cpp
@@ -71,7 +71,7 @@ void RS232Bridge::loop() {
         uint16_t len = (_rx_buffer[2] << 8) | _rx_buffer[3];
 
         // Validate length field
-        if (len > (MAX_TRANS_UNIT + 1)) {
+        if (len > MAX_TRANS_UNIT) {
           BRIDGE_DEBUG_PRINTLN("RX invalid length %d, resetting\n", len);
           _rx_buffer_pos = 0; // Invalid length, reset
           continue;
@@ -84,7 +84,7 @@ void RS232Bridge::loop() {
             BRIDGE_DEBUG_PRINTLN("RX, len=%d crc=0x%04x\n", len, received_checksum);
             mesh::Packet *pkt = _mgr->allocNew();
             if (pkt) {
-              if (pkt->readFrom(_rx_buffer + 4, len)) {
+              if (pkt->readFrom(_rx_buffer + 4, (size_t) len)) {
                 onPacketReceived(pkt);
               } else {
                 BRIDGE_DEBUG_PRINTLN("RX failed to parse packet\n");
@@ -121,8 +121,8 @@ void RS232Bridge::sendPacket(mesh::Packet *packet) {
     uint16_t len = packet->writeTo(buffer + 4);
 
     // Check if packet fits within our maximum payload size
-    if (len > (MAX_TRANS_UNIT + 1)) {
-      BRIDGE_DEBUG_PRINTLN("TX packet too large (payload=%d, max=%d)\n", len, MAX_TRANS_UNIT + 1);
+    if (len > MAX_TRANS_UNIT) {
+      BRIDGE_DEBUG_PRINTLN("TX packet too large (payload=%d, max=%d)\n", len, MAX_TRANS_UNIT);
       return;
     }
 

--- a/src/helpers/esp32/ESPNOWRadio.cpp
+++ b/src/helpers/esp32/ESPNOWRadio.cpp
@@ -18,6 +18,8 @@ static void OnDataSent(const uint8_t *mac_addr, esp_now_send_status_t status) {
 
 static void OnDataRecv(const uint8_t *mac, const uint8_t *data, int len) {
   ESPNOW_DEBUG_PRINTLN("Recv: len = %d", len);
+  if (len <= 0) return;
+  if (len > (int) sizeof(rx_buf)) len = sizeof(rx_buf);
   memcpy(rx_buf, data, len);
   last_rx_len = len;
 }
@@ -101,7 +103,8 @@ float ESPNOWRadio::getLastSNR() const { return 0; }
 int ESPNOWRadio::recvRaw(uint8_t* bytes, int sz) {
   int len = last_rx_len;
   if (last_rx_len > 0) {
-    memcpy(bytes, rx_buf, last_rx_len);
+    if (len > sz) len = sz;
+    memcpy(bytes, rx_buf, len);
     last_rx_len = 0;
     n_recv++;
   }

--- a/src/helpers/esp32/SerialWifiInterface.cpp
+++ b/src/helpers/esp32/SerialWifiInterface.cpp
@@ -1,6 +1,22 @@
 #include "SerialWifiInterface.h"
 #include <WiFi.h>
 
+static bool readClientExact(WiFiClient& client, uint8_t* dest, size_t len) {
+  if (len == 0) return true;
+  return client.readBytes(dest, len) == len;
+}
+
+static bool discardClientExact(WiFiClient& client, size_t len) {
+  uint8_t skip[16];
+  while (len > 0) {
+    size_t chunk = len > sizeof(skip) ? sizeof(skip) : len;
+    int n = client.read(skip, chunk);
+    if (n <= 0) return false;
+    len -= n;
+  }
+  return true;
+}
+
 void SerialWifiInterface::begin(int port) {
   // wifi setup is handled outside of this class, only starts the server
   server.begin(port);
@@ -21,12 +37,14 @@ void SerialWifiInterface::disable() {
 size_t SerialWifiInterface::writeFrame(const uint8_t src[], size_t len) {
   if (len > MAX_FRAME_SIZE) {
     WIFI_DEBUG_PRINTLN("writeFrame(), frame too big, len=%d\n", len);
+    _drop_count++;
     return 0;
   }
 
   if (deviceConnected && len > 0) {
     if (send_queue_len >= FRAME_QUEUE_SIZE) {
       WIFI_DEBUG_PRINTLN("writeFrame(), send_queue is full!");
+      _drop_count++;
       return 0;
     }
 
@@ -92,10 +110,21 @@ size_t SerialWifiInterface::checkRecvFrame(uint8_t dest[]) {
       pkt[1] = (len & 0xFF);  // LSB
       pkt[2] = (len >> 8);    // MSB
       memcpy(&pkt[3], send_queue[0].buf, send_queue[0].len);
-      client.write(pkt, 3 + len);
-      send_queue_len--;
-      for (int i = 0; i < send_queue_len; i++) {   // delete top item from queue
-        send_queue[i] = send_queue[i + 1];
+      size_t written = client.write(pkt, 3 + len);
+      if (written == (size_t)(3 + len)) {
+        send_queue_len--;
+        for (int i = 0; i < send_queue_len; i++) {   // delete top item from queue
+          send_queue[i] = send_queue[i + 1];
+        }
+      } else if (written > 0) {
+        WIFI_DEBUG_PRINTLN("Partial write: wrote %d of %d bytes, disconnecting to resync framing", (int)written, 3 + len);
+        _drop_count += send_queue_len;
+        client.stop();
+        deviceConnected = false;
+        clearBuffers();
+        resetReceivedFrameHeader();
+      } else {
+        WIFI_DEBUG_PRINTLN("Write returned 0 bytes, keeping frame for retry");
       }
     } else {
 
@@ -108,8 +137,17 @@ size_t SerialWifiInterface::checkRecvFrame(uint8_t dest[]) {
         if(client.available() >= frame_header_length){
 
           // read frame header
-          client.readBytes(&received_frame_header.type, 1);
-          client.readBytes((uint8_t*)&received_frame_header.length, 2);
+          bool ok = readClientExact(client, &received_frame_header.type, 1);
+          ok = ok && readClientExact(client, (uint8_t*)&received_frame_header.length, 2);
+          if (!ok) {
+            WIFI_DEBUG_PRINTLN("Failed to read frame header exactly");
+            _drop_count++;
+            client.stop();
+            deviceConnected = false;
+            clearBuffers();
+            resetReceivedFrameHeader();
+            return 0;
+          }
 
         }
 
@@ -130,11 +168,16 @@ size_t SerialWifiInterface::checkRecvFrame(uint8_t dest[]) {
         // skip frames that are larger than MAX_FRAME_SIZE
         if(frame_length > MAX_FRAME_SIZE){
           WIFI_DEBUG_PRINTLN("Skipping frame: length=%d is larger than MAX_FRAME_SIZE=%d", frame_length, MAX_FRAME_SIZE);
-          while(frame_length > 0){
-            uint8_t skip[1];
-            int skipped = client.read(skip, 1);
-            frame_length -= skipped;
+          if (!discardClientExact(client, frame_length)) {
+            WIFI_DEBUG_PRINTLN("Failed to discard oversized frame");
+            _drop_count++;
+            client.stop();
+            deviceConnected = false;
+            clearBuffers();
+            resetReceivedFrameHeader();
+            return 0;
           }
+          _drop_count++;
           resetReceivedFrameHeader();
           return 0;
         }
@@ -143,17 +186,30 @@ size_t SerialWifiInterface::checkRecvFrame(uint8_t dest[]) {
         // '<' is 0x3c which indicates a frame sent from app to radio
         if(frame_type != '<'){
           WIFI_DEBUG_PRINTLN("Skipping frame: type=0x%x is unexpected", frame_type);
-          while(frame_length > 0){
-            uint8_t skip[1];
-            int skipped = client.read(skip, 1);
-            frame_length -= skipped;
+          if (!discardClientExact(client, frame_length)) {
+            WIFI_DEBUG_PRINTLN("Failed to discard unexpected frame");
+            _drop_count++;
+            client.stop();
+            deviceConnected = false;
+            clearBuffers();
+            resetReceivedFrameHeader();
+            return 0;
           }
+          _drop_count++;
           resetReceivedFrameHeader();
           return 0;
         }
 
         // read frame data to provided buffer
-        client.readBytes(dest, frame_length);
+        if (!readClientExact(client, dest, frame_length)) {
+          WIFI_DEBUG_PRINTLN("Failed to read frame payload exactly");
+          _drop_count++;
+          client.stop();
+          deviceConnected = false;
+          clearBuffers();
+          resetReceivedFrameHeader();
+          return 0;
+        }
 
         // ready for next frame
         resetReceivedFrameHeader();

--- a/src/helpers/esp32/SerialWifiInterface.h
+++ b/src/helpers/esp32/SerialWifiInterface.h
@@ -29,6 +29,7 @@ class SerialWifiInterface : public BaseSerialInterface {
   Frame recv_queue[FRAME_QUEUE_SIZE];
   int send_queue_len;
   Frame send_queue[FRAME_QUEUE_SIZE];
+  uint32_t _drop_count;
 
   void clearBuffers() { recv_queue_len = 0; send_queue_len = 0; }
 
@@ -42,6 +43,7 @@ public:
     send_queue_len = recv_queue_len = 0;
     received_frame_header.type = 0;
     received_frame_header.length = 0;
+    _drop_count = 0;
   }
 
   void begin(int port);
@@ -56,6 +58,7 @@ public:
 
   size_t writeFrame(const uint8_t src[], size_t len) override;
   size_t checkRecvFrame(uint8_t dest[]) override;
+  uint32_t getDropCount() const override { return _drop_count; }
 
   bool hasReceivedFrameHeader();
   void resetReceivedFrameHeader();


### PR DESCRIPTION
## Summary
This PR focuses on the primary reliability issue for embedded environments: **partial reads/writes and unchecked I/O** causing stream/file corruption, parse desync, or silent persistence failures.

The core change introduces and applies stricter exact-I/O behavior, then extends related hardening in packet framing/parsing and serial bridge ingress/egress paths.

## Problem
On constrained devices and links, reads/writes can be partial. Existing code paths had several risks:
- file reads/writes assuming one call transfers all bytes
- socket frame handling that could desynchronize after partial writes/reads
- packet parsing paths with weaker bounds/consistency checks
- some persistence paths ignoring write return values

These issues can lead to:
- corrupted on-disk state
- broken framed stream alignment
- dropped/invalid packets being mishandled
- hard-to-debug reliability failures under load/noisy links

## Primary Changes (Partial Read/Write Handling)

### 1) Added strict exact file I/O helper
- **Added:** `src/helpers/CheckedIO.h`
- Provides:
  - `checked_io::readExact(...)` with loop-until-complete or fail
  - `checked_io::writeExact(...)` with loop-until-complete or fail
  - typed wrappers `readValue/writeValue`

### 2) Applied checked exact I/O to persistence paths
- **Updated:** `src/helpers/ClientACL.cpp`
  - replaced raw read/write checks with checked exact/value helpers
- **Updated:** `src/helpers/IdentityStore.cpp`
  - checked reads for optional display name
  - save now returns real success/failure (no unconditional true)
  - checked exact write for display name block
- **Updated:** `src/helpers/CommonCLI.cpp`
  - prefs load switched to compatibility-safe incremental checked reads
  - prefs save now checks all writes via checked exact/value helpers
  - logs when save path encounters partial/short write failure

### 3) Hardened WiFi framed I/O for partial read/write failures
- **Updated:** `src/helpers/esp32/SerialWifiInterface.cpp`
  - exact header/payload socket reads
  - exact discard helper for oversized/unexpected frames
  - on partial TX write: treat as framing corruption, disconnect/reset queues/header
  - on header/payload read failure: disconnect/reset
  - on discard failure: disconnect/reset
  - drop counter incremented for dropped/error conditions
- **Updated:** `src/helpers/esp32/SerialWifiInterface.h`
  - added WiFi drop counter storage + getter override
- **Updated:** `src/helpers/BaseSerialInterface.h`
  - added default `getDropCount()` API (returns 0 by default)

## Related / Derived Hardening Changes

### Packet framing/parsing correctness
- **Updated:** `src/Packet.h`, `src/Packet.cpp`
  - `Packet::readFrom` now takes `size_t`
  - strict bounds checks before transport/path/payload reads
  - validates payload version/path encoding early
  - commits packet state only after full validation succeeds
- **Updated:** `src/Dispatcher.cpp`
  - parser path delegates to hardened `Packet::readFrom`
  - simplified and tightened invalid packet handling/logging
- **Updated:** `src/helpers/BaseChatMesh.cpp`
  - now checks `readFrom` return and releases packet on failure

### Bridge/radio ingress bounds
- **Updated:** `src/helpers/bridges/RS232Bridge.cpp`
  - max packet length checks aligned to `MAX_TRANS_UNIT`
  - uses updated `readFrom(..., size_t)`
- **Updated:** `src/helpers/esp32/ESPNOWRadio.cpp`
  - clamp received length to local buffer size
  - clamp copy length to destination size in `recvRaw`

### Crypto input guard
- **Updated:** `src/Utils.cpp`
  - rejects MAC+ciphertext lengths not aligned to cipher block size before decrypt

### Stats surface for WiFi drops (no protocol framing changes)
- **Updated:** `src/helpers/StatsFormatHelper.h`
  - `stats-radio` JSON now includes `wifi_drops`
- **Updated:** `src/helpers/CommonCLI.h`
  - added `getSerialDropCount()` callback hook (default 0)
- **Updated call sites:**
  - `examples/simple_sensor/SensorMesh.cpp`
  - `examples/simple_room_server/MyMesh.cpp`
  - `examples/simple_repeater/MyMesh.cpp`
- **Updated docs:** `docs/cli_commands.md`
  - clarified WiFi drop count field context

