### PR TITLE
fix: enable GPIO on NFC pins for RAK4631 and WisMesh Tag variants

### DIFF
--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -19,6 +19,7 @@ build_flags = ${nrf52_base.build_flags}
   -D LORA_TX_POWER=22
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
+  -D CONFIG_NFCT_PINS_AS_GPIOS=1
 build_src_filter = ${nrf52_base.build_src_filter}
   +<../variants/rak4631>
   +<helpers/sensors>

--- a/variants/rak_wismesh_tag/platformio.ini
+++ b/variants/rak_wismesh_tag/platformio.ini
@@ -25,6 +25,7 @@ build_flags = ${nrf52_base.build_flags}
   -D PIN_BUZZER=21
   -D PIN_BOARD_SDA=PIN_WIRE_SDA
   -D PIN_BOARD_SCL=PIN_WIRE_SCL
+  -D CONFIG_NFCT_PINS_AS_GPIOS=1
 build_src_filter = ${nrf52_base.build_src_filter}
   +<../variants/rak_wismesh_tag>
   +<helpers/ui/MomentaryButton.cpp>


### PR DESCRIPTION
## Summary

Adds `-D CONFIG_NFCT_PINS_AS_GPIOS=1` build flag to the RAK4631 and WisMesh Tag base
variant configs, fixing a bug where the user button (P0.09) becomes permanently
unresponsive after a full flash erase.

## Problem

On the nRF52840, pins P0.09 and P0.10 are dual-function: they serve as NFC antenna
pins by default, and can only be used as GPIO if the UICR `NFCPINS` register is
reprogrammed to release them. Both the RAK4631 and WisMesh Tag use P0.09 as the user
button (`PIN_BUTTON1`).

Under normal circumstances, the UICR is already correctly configured by a prior
bootloader or firmware, so the button works. However, performing a full flash erase
(e.g. via the MeshCore web flasher's "Erase Flash" step) resets the UICR to factory
defaults, re-enabling NFC on P0.09. After this, `digitalRead()` on the button pin
returns a fixed value and the button is completely unresponsive — no press gesture
(single, double, triple, long) produces any effect.

The Nordic SDK provides a mechanism to fix this automatically: when
`CONFIG_NFCT_PINS_AS_GPIOS` is defined, `SystemInit()` checks the UICR on every boot
and reprograms it if NFC is still enabled, followed by a one-time automatic reset.
This flag was not set for either variant.

## Scoping Decision

We considered three scopes for this fix:

| Scope | Affected builds |
|---|---|
| `rak_wismesh_tag` only | 5 WisMesh Tag environments |
| `rak_wismesh_tag` + `rak4631` | 5 + 8 = 13 environments |
| `nrf52_base` (all nRF52) | All nRF52 variants globally |

We chose `rak_wismesh_tag` + `rak4631` because:
- Both variants define `PIN_BUTTON1 = 9` (P0.09 / NFC1) and are directly affected
- No device in the MeshCore codebase uses NFC functionality, so the flag is safe
- The flag is a no-op on devices where the UICR is already correctly configured
- Broader `nrf52_base` scope could be done separately if desired, but these are the
  two variants we could directly validate

## Changes

Two files, one line each:

- `variants/rak_wismesh_tag/platformio.ini` — added `-D CONFIG_NFCT_PINS_AS_GPIOS=1`
  to `[rak_wismesh_tag]` base build flags
- `variants/rak4631/platformio.ini` — added `-D CONFIG_NFCT_PINS_AS_GPIOS=1` to
  `[rak4631]` base build flags

## Testing

Tested on a RAK WisMesh Tag (companion radio BLE build) that had previously undergone
a full flash erase via the web flasher, rendering the button unresponsive.

After flashing with this fix:
- **Triple press** — buzzer toggle: **PASS** (audible beep on enable, silence on disable)
- **Double press** — flood advert: **PASS** (advert received by other radios on the mesh)
- **Long press (3s)** — shutdown: **PASS** (device powers off, LEDs dark, button press to wake)

First boot after flash showed the expected one-time automatic reset as `SystemInit()`
reprogrammed the UICR. Subsequent boots were normal with no extra reset.
