### PR TITLE
Removed section for isolated `get bridge.source`

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -816,12 +816,6 @@ region save
 
 ---
 
-#### View the bridge source
-**Usage:**
-- `get bridge.source`
-
----
-
 #### Add a delay to packets routed through this bridge
 **Usage:**
 - `get bridge.delay`


### PR DESCRIPTION
Fix for issue #1963 