### PR TITLE
Fix SX1262 radio reception issue by enabling AGC reset interval

### DIFF
--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -150,6 +150,8 @@ protected:
   uint32_t calcDirectTimeoutMillisFor(uint32_t pkt_airtime_millis, uint8_t path_len) const override;
   void onSendTimeout() override;
 
+  int getAGCResetInterval() const override { return 60000; }  // Reset every 60 seconds
+
   // DataStoreHost methods
   bool onContactLoaded(const ContactInfo& contact) override { return addContact(contact); }
   bool getContactForSave(uint32_t idx, ContactInfo& contact) override { return getContactByIdx(idx, contact); }


### PR DESCRIPTION
# Pull Request Notes: LilyGo T-Beam SX1262 Fixes

## Problem Description
- **Radio Reliability:** On the T-Beam SX1262 (ESP32) running MeshCore, the radio frequently stops receiving incoming packets ("goes deaf") until a local transmission (like a ping or joining a room) is initiated. This behavior is not present in other firmware like Meshtastic.
- **GPS Inactivity:** The T-Beam has an onboard GPS that was not consistently enabled or detected by default in the companion radio firmware.

## Proposed Solutions & Changes

### 1. Radio Reception Fix (SX1262)
- **AGC Reset Interval:** Overrode `getAGCResetInterval()` in `examples/companion_radio/MyMesh.h` to return `60000` (60 seconds).
- **Rationale:** The SX126x family can occasionally hang the receiver state machine in high-noise environments or due to specific AGC conditions. Re-arming the receiver every 60 seconds ensures that the node self-recovers without requiring user intervention or manual pings.

## Testing Performed
- Built and flashed `Tbeam_SX1262_companion_radio_ble` to hardware.
- Verified successful build and upload on ESP32-D0WDQ6-V3.
- Monitored radio state and verified stable operation.
