### PR TITLE
Fix Unbounded sprintf with sender_name in BaseChatMesh.cpp

### DIFF
--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -438,9 +438,11 @@ bool BaseChatMesh::sendGroupMessage(uint32_t timestamp, mesh::GroupChannel& chan
   memcpy(temp, &timestamp, 4);   // mostly an extra blob to help make packet_hash unique
   temp[4] = 0;  // TXT_TYPE_PLAIN
 
-  sprintf((char *) &temp[5], "%s: ", sender_name);  // <sender>: <msg>
+  size_t prefix_buf_sz = (size_t)(MAX_TEXT_LEN + 32);
+  snprintf((char *) &temp[5], prefix_buf_sz, "%s: ", sender_name ? sender_name : "");  // <sender>: <msg>, bounded
+  ((char *)&temp[5])[prefix_buf_sz - 1] = '\0';
   char *ep = strchr((char *) &temp[5], 0);
-  int prefix_len = ep - (char *) &temp[5];
+  int prefix_len = (int)(ep - (char *) &temp[5]);
 
   if (text_len + prefix_len > MAX_TEXT_LEN) text_len = MAX_TEXT_LEN - prefix_len;
   memcpy(ep, text, text_len);


### PR DESCRIPTION
`sprintf((char *)&temp[5], "%s: ", sender_name)` has no length limit. If `sender_name` is longer than the space left in `temp` (about `MAX_TEXT_LEN + 32` bytes from `temp[5]` onward), the write goes past the end of `temp`.

A remote host (e.g. over BLE or other future code) could send a long string as `sender_name` and trigger the overflow when the device sends a group message.

This fix updates src/helpers/BaseChatMesh.cpp (sendGroupMessage):

1. Bounded length – The prefix ("sender: ") is written with snprintf using prefix_buf_sz = MAX_TEXT_LEN + 32, so output is limited to the space in temp after the 5-byte header and no overflow is possible.
2. Null sender – If sender_name is null, sender_name ? sender_name : "" is used so the format string always gets a valid string and you avoid undefined behavior.
3. Guaranteed termination – ((char *)&temp[5])[prefix_buf_sz - 1] = '\0' forces a null terminator at the end of the prefix buffer so strchr and later uses always see a valid C string.
4. Type of prefix_len – The result of ep - (char *)&temp[5] is cast to (int) so it matches the existing prefix_len type.

Currently, the companion radio example in `examples/companion_radio/MyMesh.cpp` already bounds name:

```cpp
int nlen = len - 1;
if (nlen > sizeof(_prefs.node_name) - 1) nlen = sizeof(_prefs.node_name) - 1;
memcpy(_prefs.node_name, &cmd_frame[1], nlen);
_prefs.node_name[nlen] = 0;
```
so most users shouldn't currently experience this, but who knows what future people may do with their own clients.
