### PR TITLE
Bump RadioLib to 7.6.0

### DIFF
--- a/library.json
+++ b/library.json
@@ -4,7 +4,7 @@
     "dependencies": {
         "SPI": "*",
         "Wire": "*",
-        "jgromes/RadioLib": "^7.3.0",
+        "jgromes/RadioLib": "^7.6.0",
         "rweather/Crypto": "^0.4.0",
         "adafruit/RTClib": "^2.1.3",
         "melopero/Melopero RV3028": "^1.1.0",

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@ monitor_speed = 115200
 lib_deps =
   SPI
   Wire
-  jgromes/RadioLib @ ^7.3.0
+  jgromes/RadioLib @ ^7.6.0
   rweather/Crypto @ ^0.4.0
   adafruit/RTClib @ ^2.1.3
   melopero/Melopero RV3028 @ ^1.1.0


### PR DESCRIPTION
## RadioLib 7.3.0 → 7.6.0 Summary

**Bug fixes relevant to MeshCore:**
- SX1262/SX1268 PA optimization tables — more accurate TX power output against lower power consumption! [See here for more info](https://github.com/radiolib-org/power-tests)
- LR11x0 sleep busy-wait fix — affects T1000-E, WIO WM1110, SenseCAP
- HAL timer overflow fixes in `delay()`/`millis()`/etc. — long-running nodes
- STM32 HAL `dwt_init()` added — WIO-E5 boards
- SX128x null dereference fix
- SPI paranoid mode overflow fix

**API removals (MeshCore unaffected):**
- `getDataRate()` removed from all modules
- `setDIOMapping()` removed from PhysicalLayer

**New features (not currently used by MeshCore):**
- LR2021 radio module support + ADS-B
- SX1262/SX1268 experimental BPSK modem
- CMAC streaming crypto
- LoRaWAN: duty cycle fix, multicast, band/class/version getters

**Internal refactoring:**
- LR11x0 headers split into sub-files (transparent to consumers)
- SX126x PA config moved from derived classes to lookup tables

Build it [here](https://mcimages.weebl.me?commitId=radiolib7.6.0)

Running it on T1000E, Heltec V4 & Lilygo T-Beam S3 Supreme SX1262. So far no issues.

The SX1262 PA optimization is interesting, it boils down to, whenever you run SX1262 at lower than 22 dBm settings, you can configure the SX1262 to use lower power for the (internal) PA and get the same output. Particularly useful if you have a device with a FEM (PA/LNA) like Heltec v4 for example.