### PR TITLE
Add nrf52 power management for RAK3401

### DIFF
--- a/variants/rak3401/RAK3401Board.cpp
+++ b/variants/rak3401/RAK3401Board.cpp
@@ -3,6 +3,31 @@
 
 #include "RAK3401Board.h"
 
+#ifdef NRF52_POWER_MANAGEMENT
+// Static configuration for power management
+// Values set in variant.h defines
+const PowerMgtConfig power_config = {
+  .lpcomp_ain_channel = PWRMGT_LPCOMP_AIN,
+  .lpcomp_refsel = PWRMGT_LPCOMP_REFSEL,
+  .voltage_bootlock = PWRMGT_VOLTAGE_BOOTLOCK
+};
+
+void RAK3401Board::initiateShutdown(uint8_t reason) {
+  // Disable SKY66122 FEM (CSD+CPS LOW = shutdown, <1 uA)
+  digitalWrite(SX126X_POWER_EN, LOW);
+
+  // Disable 3V3 switched peripherals and 5V boost
+  digitalWrite(PIN_3V3_EN, LOW);
+
+  if (reason == SHUTDOWN_REASON_LOW_VOLTAGE ||
+      reason == SHUTDOWN_REASON_BOOT_PROTECT) {
+    configureVoltageWake(power_config.lpcomp_ain_channel, power_config.lpcomp_refsel);
+  }
+
+  enterSystemOff(reason);
+}
+#endif
+
 void RAK3401Board::begin() {
   NRF52BoardDCDC::begin();
   pinMode(PIN_VBAT_READ, INPUT);
@@ -31,18 +56,11 @@ void RAK3401Board::begin() {
   // HIGH = FEM active (LNA for RX, PA path available for TX).
   // TX/RX switching (CTX) is handled by SX1262 DIO2 via SetDIO2AsRfSwitchCtrl.
   pinMode(SX126X_POWER_EN, OUTPUT);
+#ifdef NRF52_POWER_MANAGEMENT
+  // Boot voltage protection check (may not return if voltage too low)
+  // We need to call this after we configure SX126X_POWER_EN as output but before we pull high
+  checkBootVoltage(&power_config);
+#endif
   digitalWrite(SX126X_POWER_EN, HIGH);
   delay(1);  // SKY66122 turn-on settling time (tON = 3us typ)
 }
-
-#ifdef NRF52_POWER_MANAGEMENT
-void RAK3401Board::initiateShutdown(uint8_t reason) {
-  // Disable SKY66122 FEM (CSD+CPS LOW = shutdown, <1 uA)
-  digitalWrite(SX126X_POWER_EN, LOW);
-
-  // Disable 3V3 switched peripherals and 5V boost
-  digitalWrite(PIN_3V3_EN, LOW);
-
-  enterSystemOff(reason);
-}
-#endif

--- a/variants/rak3401/platformio.ini
+++ b/variants/rak3401/platformio.ini
@@ -6,6 +6,7 @@ build_flags = ${nrf52_base.build_flags}
   ${sensor_base.build_flags}
   -I variants/rak3401
   -D RAK_3401
+  -D NRF52_POWER_MANAGEMENT
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper
   -D LORA_TX_POWER=22

--- a/variants/rak3401/variant.h
+++ b/variants/rak3401/variant.h
@@ -78,6 +78,14 @@ extern "C"
 	static const uint8_t A7 = PIN_A7;
 #define ADC_RESOLUTION 14
 
+// Power management boot protection threshold (millivolts)
+// Set to 0 to disable boot protection
+#define PWRMGT_VOLTAGE_BOOTLOCK 3300   // Won't boot below this voltage (mV)
+// LPCOMP wake configuration (voltage recovery from SYSTEMOFF)
+// AIN3 = P0.05 = PIN_A0 / PIN_VBAT_READ
+#define PWRMGT_LPCOMP_AIN 3
+#define PWRMGT_LPCOMP_REFSEL 4  // 5/8 VDD (~3.13-3.44V)
+
 // Other pins
 #define WB_I2C1_SDA (13) // SENSOR_SLOT IO_SLOT
 #define WB_I2C1_SCL (14) // SENSOR_SLOT IO_SLOT


### PR DESCRIPTION
## Summary
- Enable nrf52 power management for RAK3401, ported from the RAK4631 configuration

## Test plan
- [x] Verify boot protection triggers below 3300mV
- [x] Verify LPCOMP wake from SYSTEMOFF when voltage recovers
- [x] Verify normal boot path is unaffected above threshold