### PR TITLE
Add termperature reading from MCU to room server firmware

### DIFF
--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -172,6 +172,12 @@ int MyMesh::handleRequest(ClientInfo *sender, uint32_t sender_timestamp, uint8_t
     }
     sensors.querySensors(perm_mask, telemetry);
 
+    // This default temperature will be overridden by external sensors (if any)
+    float temperature = board.getMCUTemperature();
+    if(!isnan(temperature)) { // Supported boards with built-in temperature sensor. ESP32-C3 may return NAN
+      telemetry.addTemperature(TELEM_CHANNEL_SELF, temperature); // Built-in MCU Temperature
+    }
+
     uint8_t tlen = telemetry.getSize();
     memcpy(&reply_data[4], telemetry.getBuffer(), tlen);
     return 4 + tlen; // reply_len


### PR DESCRIPTION
This was allegedly added back in [v1.12.0](https://github.com/meshcore-dev/MeshCore/releases/tag/room-server-v1.12.0) according to its release notes, but it wasn't actually there.  This fixes that and puts the MCU temp in telemetry responses from room servers.