### PR TITLE
Prevent auto-restarting BLE when disabling it on nRF52

### DIFF
--- a/src/helpers/nrf52/SerialBLEInterface.cpp
+++ b/src/helpers/nrf52/SerialBLEInterface.cpp
@@ -246,6 +246,7 @@ void SerialBLEInterface::enable() {
   clearBuffers();
   _last_health_check = millis();
 
+  Bluefruit.Advertising.restartOnDisconnect(true);
   Bluefruit.Advertising.start(0);
 }
 
@@ -259,8 +260,9 @@ void SerialBLEInterface::disable() {
   _isEnabled = false;
   BLE_DEBUG_PRINTLN("SerialBLEInterface: disable");
 
-  disconnect();
+  Bluefruit.Advertising.restartOnDisconnect(false);
   Bluefruit.Advertising.stop();
+  disconnect();
   _last_health_check = 0;
 }
 


### PR DESCRIPTION
If client is still connected, client would automatically reconnect immediately thus keeping BLE on. When disabling bluetooth, stop advertising first to prevent clients keeping the connection open.

fixes #1933

Try this PR by [building here](https://mcimages.weebl.me?commitId=prevent-auto-restart-ble-nrf52)

Tested & works fine on T1000E too.