### PR TITLE
Fix RAK4631 SX1262 hardware pin config

### DIFF
--- a/variants/rak4631/variant.h
+++ b/variants/rak4631/variant.h
@@ -147,7 +147,7 @@ extern "C"
 // LoRa radio module pins for RAK4631
 #define  P_LORA_DIO_1 (47)
 #define  P_LORA_NSS (42)
-#define  P_LORA_RESET (-1)
+#define  P_LORA_RESET (38)
 #define  P_LORA_BUSY (46)
 #define  P_LORA_SCLK (43)
 #define  P_LORA_MISO (45)


### PR DESCRIPTION
<img width="683" height="523" alt="image" src="https://github.com/user-attachments/assets/c7156d66-c870-4933-b49f-529eb379bbef" />

<img width="1557" height="189" alt="image" src="https://github.com/user-attachments/assets/c5aafddb-47db-49b3-a832-bc45842e5162" />


Confirmed against https://github.com/meshtastic/firmware/blob/develop/variants/nrf52840/rak4631/variant.h#L212 too.