### PR TITLE
Add sanity build for LR1110 and SX1276 too

### DIFF
--- a/.github/workflows/pr-build-check.yml
+++ b/.github/workflows/pr-build-check.yml
@@ -39,6 +39,10 @@ jobs:
           - wio-e5-mini_repeater
           # ESP32-C6
           - LilyGo_Tlora_C6_repeater_
+          # LR1110 (nRF52)
+          - wio_wm1110_repeater
+          # SX1276 (ESP32)
+          - Tbeam_SX1276_repeater
 
     steps:
       - name: Clone Repo


### PR DESCRIPTION
We had all the arches covered, but [here](https://github.com/jbrazio/MeshCore/pull/2) I noticed that LR1110 not building wasn't being caught. Add builds for both LR1110 and SX1276 chips.