### PR TITLE
fix pio upload

### DIFF
--- a/boards/rak3401.json
+++ b/boards/rak3401.json
@@ -46,7 +46,8 @@
   ],
   "debug": {
     "jlink_device": "nRF52840_xxAA",
-    "svd_path": "nrf52840.svd"
+    "svd_path": "nrf52840.svd",
+    "openocd_target": "nrf52.cfg"
   },
   "frameworks": [
     "arduino"

--- a/boards/rak4631.json
+++ b/boards/rak4631.json
@@ -46,7 +46,8 @@
   ],
   "debug": {
     "jlink_device": "nRF52840_xxAA",
-    "svd_path": "nrf52840.svd"
+    "svd_path": "nrf52840.svd",
+    "openocd_target": "nrf52.cfg"
   },
   "frameworks": [
     "arduino"


### PR DESCRIPTION
Without this PIO barks:

```
*** [upload] AssertionError : Missed target configuration for rak4631
Traceback (most recent call last):
  File "/home/nextgens/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Action.py", line 1441, in execute
    result = self.execfunction(target=target, source=rsources, env=env)
  File "/home/nextgens/.platformio/platforms/espressif32@6.11.0/builder/main.py", line 35, in BeforeUpload
    env.AutodetectUploadPort()
```