### PR TITLE
Sybren/dev fix sensecap solar led green

### DIFF
--- a/variants/sensecap_solar/SenseCapSolarBoard.cpp
+++ b/variants/sensecap_solar/SenseCapSolarBoard.cpp
@@ -47,9 +47,9 @@ void SenseCapSolarBoard::begin() {
 
   Wire.begin();
 
-#ifdef LED_GREEN
-  pinMode(LED_GREEN, OUTPUT);
-  digitalWrite(LED_GREEN, HIGH);
+#ifdef LED_WHITE
+  pinMode(LED_WHITE, OUTPUT);
+  digitalWrite(LED_WHITE, HIGH);
 #endif
 #ifdef LED_BLUE
   pinMode(LED_BLUE, OUTPUT);

--- a/variants/sensecap_solar/SenseCapSolarBoard.h
+++ b/variants/sensecap_solar/SenseCapSolarBoard.h
@@ -38,7 +38,7 @@ public:
   }
 
   void powerOff() override {
-    digitalWrite(LED_GREEN, LOW);
+    digitalWrite(LED_WHITE, LOW);
     digitalWrite(LED_BLUE, LOW);
 
 #ifdef PIN_USER_BTN


### PR DESCRIPTION
5188221584d09cd0c0d6f6ff758873c4604fd460 changed LED_RED/GREEN to
LED_WHITE/BLUE, but didn't convert all uses of LED_GREEN. This is now fixed.

