### PR TITLE
Airtime (af) documentation update

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -483,7 +483,12 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 - `set af <value>`
 
 **Parameters:**
-- `value`: Airtime factor (0-9)
+- `value`: Airtime factor (0-9). After each transmission, the repeater enforces a silent period of approximately the on-air transmission time multiplied by the value. This results in a long-term duty cycle of roughly 1 divided by (1 plus the value). For example:
+  - `af = 1` → ~50% duty
+  - `af = 2` → ~33% duty
+  - `af = 3` → ~25% duty
+  - `af = 9` → ~10% duty  
+  Yyou are responsible for choosing a value that is appropriate for your jurisdiction and channel plan (for example EU 868 Mhz 10% duty cycle regulation).
 
 **Default:** `1.0`
 


### PR DESCRIPTION
Describes airtime (af) command parameters more clearer and reminds of jurisdiction responsibility.