### PR TITLE
fix: align bridge.source CLI names

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -901,6 +901,8 @@ region save
   - `logRx`: bridges received packets
   - `logTx`: bridges transmitted packets
 
+**Compatibility:** `rx` and `tx` are also accepted as legacy aliases for `logRx` and `logTx`
+
 **Default:** `logTx`
 
 ---

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -652,9 +652,18 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
           strcpy(reply, "Error: delay must be between 0-10000 ms");
         }
       } else if (memcmp(config, "bridge.source ", 14) == 0) {
-        _prefs->bridge_pkt_src = memcmp(&config[14], "rx", 2) == 0;
-        savePrefs();
-        strcpy(reply, "OK");
+        const char* source = &config[14];
+        if (strcmp(source, "logRx") == 0 || strcmp(source, "rx") == 0) {
+          _prefs->bridge_pkt_src = true;
+          savePrefs();
+          strcpy(reply, "OK");
+        } else if (strcmp(source, "logTx") == 0 || strcmp(source, "tx") == 0) {
+          _prefs->bridge_pkt_src = false;
+          savePrefs();
+          strcpy(reply, "OK");
+        } else {
+          strcpy(reply, "Error: source must be logRx or logTx");
+        }
 #endif
 #ifdef WITH_RS232_BRIDGE
       } else if (memcmp(config, "bridge.baud ", 12) == 0) {


### PR DESCRIPTION
## Summary
- make bridge.source accept the documented logRx and logTx values exactly
- keep rx and tx as legacy aliases for compatibility
- update the CLI docs to reflect the accepted values and aliases