### PR TITLE
docs: align gps output description with CLI

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -811,7 +811,9 @@ region save
 
 **Default:** `off`
 
-**Note:** Output format: `{status}, {fix}, {sat count}` (when enabled)
+**Note:** Output format:
+- `off` when the GPS hardware is disabled
+- `on, {active|deactivated}, {fix|no fix}, {sat count} sats` when the GPS hardware is enabled
 
 ---
 


### PR DESCRIPTION
## Summary
- update the GPS command docs to match the current CLI output
- document the enabled and disabled output forms explicitly

## Testing
- `git diff --check`