### PR TITLE
Documented get/set radio.rxgain + discover.neighbors

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -106,6 +106,13 @@ This document provides an overview of CLI commands that can be sent to MeshCore 
 
 ---
 
+### Discover zero hop neighbors
+
+**Usage:** 
+- `discover.neighbors`
+
+---
+
 ## Statistics
 
 ### Clear Stats


### PR DESCRIPTION
Discovered but #2118, the default `radio.rxgain` is OFF after upgrading from a previous version to v1.14.1
This is solved in dev, #2124