### PR TITLE
Fix default radio.rxgain for Station G2

### DIFF
--- a/variants/station_g2/platformio.ini
+++ b/variants/station_g2/platformio.ini
@@ -28,7 +28,7 @@ build_flags =
   -D SX126X_DIO2_AS_RF_SWITCH=true
   -D SX126X_DIO3_TCXO_VOLTAGE=1.8
   -D SX126X_CURRENT_LIMIT=140
-;  -D SX126X_RX_BOOSTED_GAIN=1 - DO NOT ENABLE THIS!
+  -D SX126X_RX_BOOSTED_GAIN=0 ; Default value when 'radio.rxgain' has not been set. Must be OFF for the Station G2, see:
 ;  https://wiki.uniteng.com/en/meshtastic/station-g2#impact-of-lora-node-dense-areashigh-noise-environments-on-rf-performance
   -D DISPLAY_CLASS=SH1106Display
 build_src_filter = ${esp32_base.build_src_filter}


### PR DESCRIPTION
As @LitBomb pointed out in his [comment](https://github.com/meshcore-dev/MeshCore/issues/2118#issuecomment-4108168109) on #2118 RX Boosted Gain should not be enabled for the Station G2.

This change is a fix for #2124 to make the default of `radio.rxgain` to be OFF on the Station G2.

This restores the pre-1.14.1 behaviour with the only change being the user is now able to change the setting in the CLI.