### PR TITLE
Fix: Re-queue packet on send failure instead of dropping it

### DIFF
--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -60,7 +60,7 @@ uint32_t Dispatcher::getCADFailRetryDelay() const {
   return 200;
 }
 uint32_t Dispatcher::getCADFailMaxDuration() const {
-  return 6000;   // 6 seconds
+  return 8000;   // 8 seconds
 }
 
 void Dispatcher::loop() {

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -332,9 +332,11 @@ void Dispatcher::checkSend() {
         logTxFail(outbound, outbound->getRawLength());
 
         // re-queue instead of dropping so the packet gets another chance
-        _mgr->queueOutbound(outbound, 0, futureMillis(getCADFailRetryDelay()));
+        int retry_delay = getCADFailRetryDelay();
+        unsigned long retry_time = futureMillis(retry_delay);
+        _mgr->queueOutbound(outbound, 0, retry_time);
         outbound = NULL;
-        next_tx_time = futureMillis(getCADFailRetryDelay());
+        next_tx_time = retry_time;
         return;
       }
       outbound_expiry = futureMillis(max_airtime);

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -60,7 +60,7 @@ uint32_t Dispatcher::getCADFailRetryDelay() const {
   return 200;
 }
 uint32_t Dispatcher::getCADFailMaxDuration() const {
-  return 4000;   // 4 seconds
+  return 6000;   // 6 seconds
 }
 
 void Dispatcher::loop() {

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -330,9 +330,11 @@ void Dispatcher::checkSend() {
         MESH_DEBUG_PRINTLN("%s Dispatcher::loop(): ERROR: send start failed!", getLogDateTime());
 
         logTxFail(outbound, outbound->getRawLength());
-  
-        releasePacket(outbound);  // return to pool
+
+        // re-queue instead of dropping so the packet gets another chance
+        _mgr->queueOutbound(outbound, 0, futureMillis(getCADFailRetryDelay()));
         outbound = NULL;
+        next_tx_time = futureMillis(getCADFailRetryDelay());
         return;
       }
       outbound_expiry = futureMillis(max_airtime);


### PR DESCRIPTION
Currently when the CAD timeout's due to high traffic, the packet is force sent after 4 seconds. If StartSendRaw fails due to the radio being busy (likely to be due to channel activity still) the packet is dropped. This change makes it so that instead of dropping the packet entirely, it is requeued with a delay and retried. This seems to be why some of my high traffic nodes with 20+ neighbours have become unreliable of late.