### PR TITLE
fix(sensecap_solar): correct TX LED after remap & power-button pin changes

### DIFF
--- a/variants/sensecap_solar/SenseCapSolarBoard.cpp
+++ b/variants/sensecap_solar/SenseCapSolarBoard.cpp
@@ -49,7 +49,7 @@ void SenseCapSolarBoard::begin() {
 
 #ifdef LED_WHITE
   pinMode(LED_WHITE, OUTPUT);
-  digitalWrite(LED_WHITE, HIGH);
+  digitalWrite(LED_WHITE, LOW);
 #endif
 #ifdef LED_BLUE
   pinMode(LED_BLUE, OUTPUT);

--- a/variants/sensecap_solar/platformio.ini
+++ b/variants/sensecap_solar/platformio.ini
@@ -13,7 +13,7 @@ build_flags = ${nrf52_base.build_flags}
   -D NRF52_POWER_MANAGEMENT
   -D RADIO_CLASS=CustomSX1262
   -D WRAPPER_CLASS=CustomSX1262Wrapper
-  -D P_LORA_TX_LED=11
+  -D P_LORA_TX_LED=12
   -D P_LORA_DIO_1=1
   -D P_LORA_RESET=2
   -D P_LORA_BUSY=3


### PR DESCRIPTION
Updates the SenseCap Solar build flag `P_LORA_TX_LED` from `11` to `12` so LoRa TX activity is driven on the blue LED again, consistent with `variants/sensecap_solar/variant.h` (LED_BLUE / PIN_LED on pin 12).

SenseCap Solar LED GPIO definitions were corrected in #1689 . A later power-button–related pin mapping change e323755 , #1873 updated board wiring, but `P_LORA_TX_LED` changed to `11`, which maps to `LED_WHITE` in the current headers and caused drift between the forks. That made the white LED blink on TX, which looks like a white/blue swap even though the underlying problem was the TX LED build flag not matching the updated LED pin macros.

@ripplebiz & @liamcottle FYI and approval; so these don't get changed/overwritten in another future PR.

@Specter242 FYI; since you initiated PR #1873 

Thank you