### PR TITLE
Fix Heltec Wireless Paper battery reading

### DIFF
--- a/variants/heltec_v3/HeltecV3Board.h
+++ b/variants/heltec_v3/HeltecV3Board.h
@@ -11,6 +11,9 @@
 #ifndef PIN_ADC_CTRL              // set in platformio.ini for Heltec Wireless Tracker (2)
   #define  PIN_ADC_CTRL    37
 #endif
+#ifndef ADC_MULTIPLIER  //default ADC multiplier
+  #define ADC_MULTIPLIER 5.42
+#endif
 #define  PIN_ADC_CTRL_ACTIVE    LOW
 #define  PIN_ADC_CTRL_INACTIVE  HIGH
 
@@ -88,7 +91,7 @@ public:
 
     digitalWrite(PIN_ADC_CTRL, !adc_active_state);
 
-    return (5.42 * (3.3 / 1024.0) * raw) * 1000;
+    return (ADC_MULTIPLIER * (3.3 / 1024.0) * raw) * 1000;
   }
 
   const char* getManufacturerName() const override {

--- a/variants/heltec_v3/HeltecV3Board.h
+++ b/variants/heltec_v3/HeltecV3Board.h
@@ -11,7 +11,7 @@
 #ifndef PIN_ADC_CTRL              // set in platformio.ini for Heltec Wireless Tracker (2)
   #define  PIN_ADC_CTRL    37
 #endif
-#ifndef ADC_MULTIPLIER  //default ADC multiplier
+#ifndef ADC_MULTIPLIER            //default ADC multiplier
   #define ADC_MULTIPLIER 5.42
 #endif
 #define  PIN_ADC_CTRL_ACTIVE    LOW

--- a/variants/heltec_wireless_paper/platformio.ini
+++ b/variants/heltec_wireless_paper/platformio.ini
@@ -22,6 +22,7 @@ build_flags =
   ;-D PIN_BOARD_SCL=18               ; same GPIO as P_LORA_TX_LED
   -D PIN_USER_BTN=0
   -D PIN_VEXT_EN=45
+  -D ADC_MULTIPLIER=8.4
   -D PIN_VBAT_READ=20
   -D PIN_ADC_CTRL=19
   -D SX126X_DIO2_AS_RF_SWITCH=true


### PR DESCRIPTION
Got tired of waiting for #1584 and #1264 to fix the issues so I created this PR from the information on #1584. I decided to use @oltaco suggestion as it looks cleaner. No need to define ADC_MULTIPLIER for heltec_v3 and heltec_tracker tho, as they will use the default value.