### PR TITLE
Update RAK 4631 entry in FAQ on new bootloader - removed "see note"

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -833,7 +833,7 @@ Currently, the following boards are supported:
 - Seeed Studio Wio Tracker L1
 - Seeed Studio XIAO nRF52840 BLE
 - Seeed Studio XIAO nRF52840 BLE SENSE
-- RAK 4631 (See note)
+- RAK 4631 
 - RAK WisMesh Tag (new 28/11/2025)
 
 ### 7.4. Q: are the MeshCore logo and font available?


### PR DESCRIPTION
Removed "see note" from RAK 4631 entry in FAQ. 

Looks like the text of supported hardware was copy/pasted and the "see note" text only makes sense when you are in the bootloader repo and the text is a link to more info about the RAK 4631.