### PR TITLE
Allows us to have custom PlatformIO envs and configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ cmake-*
 compile_commands.json
 .venv/
 venv/
-platformio_override.ini
+platformio.local.ini

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@
 [platformio]
 extra_configs =
 	variants/*/platformio.ini
-	platformio_override.ini
+	platformio.local.ini
 
 [arduino_base]
 framework = arduino


### PR DESCRIPTION
This allows us to keep a `platformio_override.ini` in the project root that we can use for custom envs or config without needing to dirty git.