### PR TITLE
Heltec v3 without display repeater.

### DIFF
--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -63,6 +63,7 @@ extends = Heltec_lora32_v3
 build_flags =
   ${Heltec_lora32_v3.build_flags}
   -D DISPLAY_CLASS=NullDisplayDriver
+  -D NO_DISPLAY
   -D ADVERT_NAME='"Heltec Repeater"'
   -D ADVERT_LAT=0.0
   -D ADVERT_LON=0.0

--- a/variants/heltec_v3/platformio.ini
+++ b/variants/heltec_v3/platformio.ini
@@ -57,6 +57,31 @@ lib_deps =
   ${esp32_ota.lib_deps}
   bakercp/CRC32 @ ^2.0.0
 
+
+[env:Heltec_v3_without_display_repeater]
+extends = Heltec_lora32_v3
+build_flags =
+  ${Heltec_lora32_v3.build_flags}
+  -D DISPLAY_CLASS=NullDisplayDriver
+  -D ADVERT_NAME='"Heltec Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${Heltec_lora32_v3.build_src_filter}
+  -<helpers/ui/SSD1306Display.cpp>
+  -<helpers/ui/SSD1306Display.h>
+  -<helpers/ui/Display*.cpp>
+  -<helpers/ui/Display*.h>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${Heltec_lora32_v3.lib_deps}
+  ${esp32_ota.lib_deps}
+  bakercp/CRC32 @ ^2.0.0
+
+
 [env:Heltec_v3_repeater_bridge_rs232]
 extends = Heltec_lora32_v3
 build_flags =

--- a/variants/heltec_v3/target.h
+++ b/variants/heltec_v3/target.h
@@ -8,20 +8,14 @@
 #include <helpers/AutoDiscoverRTCClock.h>
 #include <helpers/SensorManager.h>
 #include <helpers/sensors/EnvironmentSensorManager.h>
-// ---------------------------------------------------------
-// Display handling
-// If DISPLAY_CLASS is defined AND not NullDisplayDriver,
-// include display support.
-// ---------------------------------------------------------
-#if defined(DISPLAY_CLASS) && !defined(NULL_DISPLAY_DRIVER)
-  #if !defined(DISPLAY_CLASS_IS_NULL) && !defined(DISPLAY_CLASS_NULL)
-    // Only include display headers if DISPLAY_CLASS is not NullDisplayDriver
-    #if !defined(DISPLAY_CLASS) || !__has_include(<helpers/ui/NullDisplayDriver.h>)
-      // Default behavior: SSD1306Display
-      #include <helpers/ui/SSD1306Display.h>
-    #endif
-    #include <helpers/ui/MomentaryButton.h>
+
+#ifdef DISPLAY_CLASS
+  #ifdef NO_DISPLAY
+    #include <helpers/ui/NullDisplayDriver.h>
+  #else
+    #include <helpers/ui/SSD1306Display.h>
   #endif
+  #include <helpers/ui/MomentaryButton.h>
 #endif
 
 extern HeltecV3Board board;
@@ -29,12 +23,9 @@ extern WRAPPER_CLASS radio_driver;
 extern AutoDiscoverRTCClock rtc_clock;
 extern EnvironmentSensorManager sensors;
 
-// ---------------------------------------------------------
-// Display globals only if DISPLAY_CLASS is not NullDisplayDriver
-// ---------------------------------------------------------
-#if defined(DISPLAY_CLASS) && DISPLAY_CLASS != NullDisplayDriver
-extern DISPLAY_CLASS display;
-extern MomentaryButton user_btn;
+#ifdef DISPLAY_CLASS
+  extern DISPLAY_CLASS display;
+  extern MomentaryButton user_btn;
 #endif
 
 bool radio_init();

--- a/variants/heltec_v3/target.h
+++ b/variants/heltec_v3/target.h
@@ -8,9 +8,20 @@
 #include <helpers/AutoDiscoverRTCClock.h>
 #include <helpers/SensorManager.h>
 #include <helpers/sensors/EnvironmentSensorManager.h>
-#ifdef DISPLAY_CLASS
-  #include <helpers/ui/SSD1306Display.h>
-  #include <helpers/ui/MomentaryButton.h>
+// ---------------------------------------------------------
+// Display handling
+// If DISPLAY_CLASS is defined AND not NullDisplayDriver,
+// include display support.
+// ---------------------------------------------------------
+#if defined(DISPLAY_CLASS) && !defined(NULL_DISPLAY_DRIVER)
+  #if !defined(DISPLAY_CLASS_IS_NULL) && !defined(DISPLAY_CLASS_NULL)
+    // Only include display headers if DISPLAY_CLASS is not NullDisplayDriver
+    #if !defined(DISPLAY_CLASS) || !__has_include(<helpers/ui/NullDisplayDriver.h>)
+      // Default behavior: SSD1306Display
+      #include <helpers/ui/SSD1306Display.h>
+    #endif
+    #include <helpers/ui/MomentaryButton.h>
+  #endif
 #endif
 
 extern HeltecV3Board board;
@@ -18,9 +29,12 @@ extern WRAPPER_CLASS radio_driver;
 extern AutoDiscoverRTCClock rtc_clock;
 extern EnvironmentSensorManager sensors;
 
-#ifdef DISPLAY_CLASS
-  extern DISPLAY_CLASS display;
-  extern MomentaryButton user_btn;
+// ---------------------------------------------------------
+// Display globals only if DISPLAY_CLASS is not NullDisplayDriver
+// ---------------------------------------------------------
+#if defined(DISPLAY_CLASS) && DISPLAY_CLASS != NullDisplayDriver
+extern DISPLAY_CLASS display;
+extern MomentaryButton user_btn;
 #endif
 
 bool radio_init();


### PR DESCRIPTION
I have two heltec v3 without display or with broken display. When flashing with the default firmware it is not possible to configure the nodes using the browser or webclient, because the nodes are stuck in the boot process. This PR solves the problem by omitting all display related stuff. So that the nodes can start and be configured even if the display is missing or there is a fault during the initialization of the I2C bus.