### PR TITLE
Fix the deadhang on the P1 Pro which could occur in rare cases

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -1325,11 +1325,14 @@ void MyMesh::loop() {
 
   // is pending dirty contacts write needed?
   if (dirty_contacts_expiry && millisHasNowPassed(dirty_contacts_expiry)) {
-    if (_mgr->getOutboundTotal() == 0) {
+    if (_mgr->getOutboundTotal() > 0) {
+      dirty_contacts_expiry = futureMillis(200);  // retry shortly after outbound drains
+    } else {
+      // Suspend radio before flash I/O to prevent Softdevice flash/radio conflicts
+      // that can cause the device to hang. Radio restarts automatically on next loop.
+      _radio->suspendRadio();
       acl.save(_fs);
       dirty_contacts_expiry = 0;
-    } else {
-      dirty_contacts_expiry = futureMillis(1000); // retry when radio is idle
     }
   }
 

--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -1325,8 +1325,12 @@ void MyMesh::loop() {
 
   // is pending dirty contacts write needed?
   if (dirty_contacts_expiry && millisHasNowPassed(dirty_contacts_expiry)) {
-    acl.save(_fs);
-    dirty_contacts_expiry = 0;
+    if (_mgr->getOutboundTotal() == 0) {
+      acl.save(_fs);
+      dirty_contacts_expiry = 0;
+    } else {
+      dirty_contacts_expiry = futureMillis(1000); // retry when radio is idle
+    }
   }
 
   // update uptime

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -8,6 +8,25 @@
   static UITask ui_task(display);
 #endif
 
+// --- Software watchdog (nRF52 only) ---
+// Uses a FreeRTOS SoftwareTimer to detect main loop hangs.
+// The timer fires every 15 seconds; if loop() hasn't run since the last
+// check, we assume the system is stuck and reset. This catches Softdevice
+// lockups and other hard hangs that block the main loop.
+#if defined(NRF52_PLATFORM)
+#include <nrf_nvic.h>
+static SoftwareTimer watchdog_timer;
+static volatile bool loop_alive = false;
+
+static void watchdog_callback(TimerHandle_t _handle) {
+  (void)_handle;
+  if (!loop_alive) {
+    NVIC_SystemReset();  // main loop is stuck — reset
+  }
+  loop_alive = false;    // arm for next check
+}
+#endif
+
 StdRNG fast_rng;
 SimpleMeshTables tables;
 
@@ -103,9 +122,18 @@ void setup() {
 #if ENABLE_ADVERT_ON_BOOT == 1
   the_mesh.sendSelfAdvertisement(16000, false);
 #endif
+
+#if defined(NRF52_PLATFORM)
+  // Start software watchdog — resets device if loop() stops running for 15s
+  watchdog_timer.begin(15000, watchdog_callback);
+  watchdog_timer.start();
+#endif
 }
 
 void loop() {
+#if defined(NRF52_PLATFORM)
+  loop_alive = true;  // feed software watchdog
+#endif
   int len = strlen(command);
   while (Serial.available() && len < sizeof(command)-1) {
     char c = Serial.read();

--- a/examples/simple_room_server/MyMesh.cpp
+++ b/examples/simple_room_server/MyMesh.cpp
@@ -890,8 +890,14 @@ void MyMesh::loop() {
 
   // is pending dirty contacts write needed?
   if (dirty_contacts_expiry && millisHasNowPassed(dirty_contacts_expiry)) {
-    acl.save(_fs, MyMesh::saveFilter);
-    dirty_contacts_expiry = 0;
+    if (_mgr->getOutboundTotal() > 0) {
+      dirty_contacts_expiry = futureMillis(200);  // retry shortly after outbound drains
+    } else {
+      // Suspend radio before flash I/O to prevent Softdevice flash/radio conflicts
+      _radio->suspendRadio();
+      acl.save(_fs, MyMesh::saveFilter);
+      dirty_contacts_expiry = 0;
+    }
   }
 
   // TODO: periodically check for OLD/inactive entries in known_clients[], and evict

--- a/examples/simple_sensor/SensorMesh.cpp
+++ b/examples/simple_sensor/SensorMesh.cpp
@@ -943,7 +943,13 @@ void SensorMesh::loop() {
 
   // is there are pending dirty contacts write needed?
   if (dirty_contacts_expiry && millisHasNowPassed(dirty_contacts_expiry)) {
-    acl.save(_fs);
-    dirty_contacts_expiry = 0;
+    if (_mgr->getOutboundTotal() > 0) {
+      dirty_contacts_expiry = futureMillis(200);  // retry shortly after outbound drains
+    } else {
+      // Suspend radio before flash I/O to prevent Softdevice flash/radio conflicts
+      _radio->suspendRadio();
+      acl.save(_fs);
+      dirty_contacts_expiry = 0;
+    }
   }
 }

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -80,6 +80,12 @@ void Dispatcher::loop() {
   }
   if (!is_recv && _ms->getMillis() - radio_nonrx_start > 8000) {   // radio has not been in Rx mode for 8 seconds!
     _err_flags |= ERR_EVENT_STARTRX_TIMEOUT;
+    if (outbound) {
+      releasePacket(outbound);
+      outbound = NULL;
+    }
+    _radio->onSendFinished();
+    radio_nonrx_start = _ms->getMillis();  // reset to avoid repeated recovery
   }
 
   if (outbound) {  // waiting for outbound send to be completed

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -70,6 +70,12 @@ public:
   virtual bool isInRecvMode() const = 0;
 
   /**
+   * \brief  put radio into standby. Next recvRaw() call will restart receive.
+   *         Used to prevent radio interrupts from interfering with flash I/O.
+  */
+  virtual void suspendRadio() { }
+
+  /**
    * \returns  true if the radio is currently mid-receive of a packet.
   */
   virtual bool isReceiving() { return false; }

--- a/src/helpers/radiolib/RadioLibWrappers.h
+++ b/src/helpers/radiolib/RadioLibWrappers.h
@@ -29,6 +29,7 @@ public:
   bool isSendComplete() override;
   void onSendFinished() override;
   bool isInRecvMode() const override;
+  void suspendRadio() override { idle(); }
   bool isChannelActive();
 
   bool isReceiving() override { 


### PR DESCRIPTION
Fix a deadhang bug which results in a unresponsive repeater after a initially successful login. 


Please note, that I wrote the patch without being able to test it yet - I'll build and test it this evening.  Please consider it currently untested. 