### PR TITLE
Add LilyGo T-Beam 1W SX1262 board support

### DIFF
--- a/src/helpers/esp32/TBeamBoard.cpp
+++ b/src/helpers/esp32/TBeamBoard.cpp
@@ -1,4 +1,4 @@
-#if defined(TBEAM_SUPREME_SX1262) || defined(TBEAM_SX1262) || defined(TBEAM_SX1276)
+#if defined(TBEAM_SUPREME_SX1262) || defined(TBEAM_1W_SX1262) || defined(TBEAM_SX1262) || defined(TBEAM_SX1276)
 
 #include <Arduino.h>
 #include "TBeamBoard.h"
@@ -125,11 +125,19 @@ void TBeamBoard::printPMU()
 
 bool TBeamBoard::power_init()
 {
+  #if defined(TBEAM_SUPREME_SX1262)
+    Wire1.begin(PIN_BOARD_SDA1, PIN_BOARD_SCL1);
+    delay(10);
+  #endif
+
+  delay(20);  // Give I2C bus time to stabilize before PMU access
+
   if (!PMU) {
-    #ifdef TBEAM_SUPREME_SX1262
-      PMU = new XPowersAXP2101(PMU_WIRE_PORT, PIN_BOARD_SDA1, PIN_BOARD_SCL1, I2C_PMU_ADD);
+    #if defined(TBEAM_SUPREME_SX1262)
+      PMU = new XPowersAXP2101(Wire1, PIN_BOARD_SDA1, PIN_BOARD_SCL1, I2C_PMU_ADD);
     #else
-      PMU = new XPowersAXP2101(PMU_WIRE_PORT, PIN_BOARD_SDA, PIN_BOARD_SCL, I2C_PMU_ADD);
+      MESH_DEBUG_PRINTLN("[PMU] Trying AXP2101...");
+      PMU = new XPowersAXP2101(Wire, PIN_BOARD_SDA, PIN_BOARD_SCL, I2C_PMU_ADD);
     #endif
     if (!PMU->init()) {
         MESH_DEBUG_PRINTLN("Warning: Failed to find AXP2101 power management");
@@ -140,7 +148,12 @@ bool TBeamBoard::power_init()
     }
   }
   if (!PMU) {
-    PMU = new XPowersAXP192(PMU_WIRE_PORT, PIN_BOARD_SDA, PIN_BOARD_SCL, I2C_PMU_ADD);
+    #if defined(TBEAM_SUPREME_SX1262)
+      PMU = new XPowersAXP192(Wire1, PIN_BOARD_SDA1, PIN_BOARD_SCL1, I2C_PMU_ADD);
+    #else
+      MESH_DEBUG_PRINTLN("[PMU] Trying AXP192...");
+      PMU = new XPowersAXP192(Wire, PIN_BOARD_SDA, PIN_BOARD_SCL, I2C_PMU_ADD);
+    #endif
      if (!PMU->init()) {
         MESH_DEBUG_PRINTLN("Warning: Failed to find AXP192 power management");
         delete PMU;
@@ -151,6 +164,19 @@ bool TBeamBoard::power_init()
   }
 
   if (!PMU) {
+    // XPowersLib calls Wire.end() when PMU object is deleted
+    // Need to re-initialize Wire for other I2C devices
+    #if !defined(TBEAM_SUPREME_SX1262)
+      Wire.begin(PIN_BOARD_SDA, PIN_BOARD_SCL);
+    #endif
+
+    #if defined(TBEAM_1W_SX1262) && defined(PIN_GPS_EN)
+      MESH_DEBUG_PRINTLN("PMU not found - using GPIO fallback for GPS power");
+      pinMode(PIN_GPS_EN, OUTPUT);
+      digitalWrite(PIN_GPS_EN, HIGH);
+      delay(100);
+    #endif
+
     return false;
   }
 
@@ -158,9 +184,11 @@ bool TBeamBoard::power_init()
 
   PMU->setChargingLedMode(XPOWERS_CHG_LED_CTRL_CHG);
 
-  // Set up PMU interrupts
+  // Set up PMU interrupts (T-Beam 1W has no PMU IRQ pin)
+  #ifndef TBEAM_1W_SX1262
   pinMode(PIN_PMU_IRQ, INPUT_PULLUP);
   attachInterrupt(PIN_PMU_IRQ, setPmuFlag, FALLING);
+  #endif
 
   if (PMU->getChipModel() == XPOWERS_AXP192) {
 
@@ -234,6 +262,29 @@ bool TBeamBoard::power_init()
       PMU->disablePowerOutput(XPOWERS_DLDO1);
       PMU->disablePowerOutput(XPOWERS_DLDO2);
       PMU->disablePowerOutput(XPOWERS_VBACKUP);
+    #elif defined(TBEAM_1W_SX1262)
+      // T-Beam 1W configuration
+      // Note: T-Beam 1W uses 7.4V battery and external LDO for radio
+      PMU->disablePowerOutput(XPOWERS_DCDC2);
+      PMU->disablePowerOutput(XPOWERS_DCDC3);
+      PMU->disablePowerOutput(XPOWERS_DCDC4);
+      PMU->disablePowerOutput(XPOWERS_DCDC5);
+      PMU->disablePowerOutput(XPOWERS_ALDO2);
+      PMU->disablePowerOutput(XPOWERS_ALDO4);
+      PMU->disablePowerOutput(XPOWERS_BLDO1);
+      PMU->disablePowerOutput(XPOWERS_BLDO2);
+      PMU->disablePowerOutput(XPOWERS_DLDO1);
+      PMU->disablePowerOutput(XPOWERS_DLDO2);
+
+      PMU->setPowerChannelVoltage(XPOWERS_ALDO1, 3300);  // OLED and peripheral power
+      PMU->enablePowerOutput(XPOWERS_ALDO1);
+      delay(50);
+
+      PMU->setPowerChannelVoltage(XPOWERS_ALDO3, 3300);  // GPS power
+      PMU->enablePowerOutput(XPOWERS_ALDO3);
+
+      PMU->setPowerChannelVoltage(XPOWERS_VBACKUP, 3300); // GPS RTC backup
+      PMU->enablePowerOutput(XPOWERS_VBACKUP);
     #else
       //Turn off unused power rails
       PMU->disablePowerOutput(XPOWERS_DCDC2);

--- a/src/helpers/esp32/TBeamBoard.h
+++ b/src/helpers/esp32/TBeamBoard.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(TBEAM_SUPREME_SX1262) || defined(TBEAM_SX1262) || defined(TBEAM_SX1276)
+#if defined(TBEAM_SUPREME_SX1262) || defined(TBEAM_1W_SX1262) || defined(TBEAM_SX1262) || defined(TBEAM_SX1276)
 
 // Define pin mappings BEFORE including ESP32Board.h so sleep() can use P_LORA_DIO_1
 #ifdef TBEAM_SUPREME_SX1262
@@ -43,6 +43,41 @@
   
   #define PMU_WIRE_PORT  Wire1
   #define RTC_WIRE_PORT  Wire1
+#endif
+
+#ifdef TBEAM_1W_SX1262
+  // LoRa radio module pins for TBeam 1W with SX1262 and 1W PA
+  #define  P_LORA_DIO_0   -1   //NC
+  #define  P_LORA_DIO_1    1   //SX1262 IRQ pin
+  #define  P_LORA_NSS      15  //SX1262 SS pin
+  #define  P_LORA_RESET    3   //SX1262 Reset pin
+  #define  P_LORA_BUSY     38  //SX1262 Busy pin
+  #define  P_LORA_SCLK     13  //SX1262 SCLK pin
+  #define  P_LORA_MISO     12  //SX1262 MISO pin
+  #define  P_LORA_MOSI     11  //SX1262 MOSI pin
+  #define  P_LORA_LDO_EN   40  //Radio LDO enable
+  #define  P_LORA_CTRL     21  //LNA power control
+  #define  P_LORA_TX_LED   18  //TX LED
+
+  // T-Beam 1W uses single I2C bus on GPIO 8/9 for ALL peripherals
+  #define PIN_BOARD_SDA    8   //SDA for PMU, OLED, and peripherals
+  #define PIN_BOARD_SCL    9   //SCL for PMU, OLED, and peripherals
+
+  #define PIN_PMU_IRQ      -1  //No PMU IRQ on T-Beam 1W
+
+  #define PIN_GPS_RX       5
+  #define PIN_GPS_TX       6
+  #define PIN_GPS_EN       16
+  #define PIN_GPS_PPS      7
+
+  #define PIN_FAN_CTRL     41  //Cooling fan control
+
+  //I2C addresses (single I2C bus)
+  #define I2C_OLED_ADD     0x3C  //SH1106 OLED I2C address
+  #define I2C_PMU_ADD      0x34  //AXP2101 I2C address
+  
+  #define PMU_WIRE_PORT  Wire
+  #define RTC_WIRE_PORT  Wire
 #endif
 
 #ifdef TBEAM_SX1262
@@ -88,6 +123,12 @@
 #include "helpers/ESP32Board.h"
 #include <driver/rtc_io.h>
 
+// Forward declarations for fan control (defined in target.cpp)
+#ifdef TBEAM_1W_SX1262
+extern void activate_fan();
+extern void update_fan_control();
+#endif
+
 class TBeamBoard : public ESP32Board {
 XPowersLibInterface *PMU = NULL;
 //PhysicalLayer * pl;
@@ -125,6 +166,9 @@ public:
   #ifndef TBEAM_SUPREME_SX1262
   void onBeforeTransmit() override{
     digitalWrite(P_LORA_TX_LED, LOW);   // turn TX LED on - invert pin for SX1276
+    #if defined(TBEAM_1W_SX1262) && defined(P_FAN_CTRL)
+    activate_fan();  // Activate cooling fan for 1W PA
+    #endif
   }
   void onAfterTransmit() override{
     digitalWrite(P_LORA_TX_LED, HIGH);   // turn TX LED off - invert pin for SX1276
@@ -155,7 +199,50 @@ public:
 }
 
   uint16_t getBattMilliVolts(){
-    return PMU->getBattVoltage();
+    if (PMU) {
+      return PMU->getBattVoltage();
+    }
+    
+    #ifdef TBEAM_1W_SX1262
+    // Fallback: ADC-based battery voltage reading for T-Beam 1W
+    // GPIO 4 (ADC1_CH3) - per Meshtastic firmware variant
+    const int BATTERY_ADC_PIN = 4;
+    const float ADC_REFERENCE_VOLTAGE = 3300.0;  // mV
+    const float ADC_MULTIPLIER = 2.9333;  // Per Meshtastic T-Beam 1W variant
+    const int BATTERY_SENSE_SAMPLES = 30;
+    static bool adc_initialized = false;
+    
+    if (!adc_initialized) {
+      pinMode(BATTERY_ADC_PIN, INPUT);
+      analogReadResolution(12);
+      analogSetAttenuation(ADC_11db);
+      adc_initialized = true;
+    }
+    
+    uint32_t adc_sum = 0;
+    for (int i = 0; i < BATTERY_SENSE_SAMPLES; i++) {
+      adc_sum += analogRead(BATTERY_ADC_PIN);
+      delayMicroseconds(100);
+    }
+    uint16_t adc_raw = adc_sum / BATTERY_SENSE_SAMPLES;
+    
+    float battery_voltage_f = (adc_raw / 4095.0) * ADC_REFERENCE_VOLTAGE * ADC_MULTIPLIER;
+    uint16_t battery_voltage = (uint16_t)battery_voltage_f;
+    
+    static unsigned long last_debug = 0;
+    if (millis() - last_debug > 10000) {
+      Serial.printf("[BATTERY ADC] raw=%d, voltage=%.2fV (%.0fmV)\n", adc_raw, battery_voltage_f / 1000.0, battery_voltage_f);
+      last_debug = millis();
+    }
+    
+    if (battery_voltage < 5500 || battery_voltage > 9000) {
+      return 7400;  // Out of range, return nominal
+    }
+    
+    return battery_voltage;
+    #else
+    return 0;
+    #endif
   }
 
   const char* getManufacturerName() const{

--- a/t-beam-1w.json
+++ b/t-beam-1w.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_opi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DBOARD_HAS_PSRAM",
+      "-DLILYGO_TBEAM_1W",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_USB_MODE=0",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "psram_type": "opi",
+    "hwids": [["0x303A", "0x1001"]],
+    "mcu": "esp32s3",
+    "variant": "t-beam-1w"
+  },
+  "connectivity": ["wifi", "bluetooth", "lora"],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": ["arduino"],
+  "name": "LilyGo TBeam-1W",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "http://www.lilygo.cn/",
+  "vendor": "LilyGo"
+}

--- a/variants/lilygo_tbeam_1w_SX1262/platformio.ini
+++ b/variants/lilygo_tbeam_1w_SX1262/platformio.ini
@@ -1,0 +1,129 @@
+[T_Beam_1W_SX1262]
+extends = esp32_base
+board = t_beam_1w  ; LILYGO T-Beam 1W ESP32S3 with SX1262 and 1W PA
+build_flags =
+  ${esp32_base.build_flags}
+  -I variants/lilygo_tbeam_1w_SX1262
+  -D TBEAM_1W_SX1262
+  -D SX126X_CURRENT_LIMIT=140
+  -D SX126X_RX_BOOSTED_GAIN=1
+  -D SX126X_MAX_POWER=22
+  -D SX126X_PA_RAMP_TIME=0x05
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D DISPLAY_CLASS=SH1106Display
+  -D LORA_TX_POWER=22
+  -D P_LORA_NSS=15
+  -D P_LORA_RESET=3
+  -D P_LORA_DIO_1=1
+  -D P_LORA_BUSY=38
+  -D P_LORA_SCLK=13
+  -D P_LORA_MISO=12
+  -D P_LORA_MOSI=11
+  -D P_LORA_LDO_EN=40
+  -D P_LORA_CTRL=21
+  -D P_LORA_TX_LED=18
+  -D PIN_BOARD_SDA=8
+  -D PIN_BOARD_SCL=9
+  -D PIN_GPS_RX=5
+  -D PIN_GPS_TX=6
+  -D PIN_GPS_EN=16
+  -D PIN_GPS_PPS=7
+  -D PIN_USER_BTN=0
+  -D PIN_USER_BTN2=17
+  -D P_FAN_CTRL=41
+  -D ENV_INCLUDE_GPS=1
+  -D PERSISTANT_GPS=1
+  -D ENV_SKIP_GPS_DETECT=1
+  -D GPS_BAUD_RATE=9600
+  -D BATTERY_MIN_MILLIVOLTS=6000
+  -D BATTERY_MAX_MILLIVOLTS=8400
+  -D BATTERY_SERIES_CELLS=2
+build_src_filter = ${esp32_base.build_src_filter}
+  +<../variants/lilygo_tbeam_1w_SX1262>
+  +<helpers/ui/SH1106Display.cpp>
+  +<helpers/esp32/TBeamBoard.cpp>
+  +<helpers/sensors>
+board_build.partitions = min_spiffs.csv
+lib_deps =
+  ${esp32_base.lib_deps}
+  lewisxhe/XPowersLib @ ^0.2.7
+  adafruit/Adafruit SH110X @ ^2.1.13
+  stevemarple/MicroNMEA @ ^2.0.6
+
+; === LILYGO T-Beam 1W with SX1262 environments ===
+[env:T_Beam_1W_SX1262_repeater]
+extends = T_Beam_1W_SX1262
+build_flags =
+  ${T_Beam_1W_SX1262.build_flags}
+  -D ADVERT_NAME='"T-Beam 1W SX1262 Repeater"'
+  -D ADVERT_LAT=0
+  -D ADVERT_LON=0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D MESH_PACKET_LOGGING=1
+  -D MESH_DEBUG=1
+build_src_filter = ${T_Beam_1W_SX1262.build_src_filter}
+  +<../examples/simple_repeater>
+lib_deps =
+  ${T_Beam_1W_SX1262.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:T_Beam_1W_SX1262_repeater_bridge_espnow]
+extends = T_Beam_1W_SX1262
+build_flags =
+  ${T_Beam_1W_SX1262.build_flags}
+  -D ADVERT_NAME='"T-Beam 1W ESPNow Bridge"'
+  -D ADVERT_LAT=0
+  -D ADVERT_LON=0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+  -D WITH_ESPNOW_BRIDGE=1
+;  -D BRIDGE_DEBUG=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${T_Beam_1W_SX1262.build_src_filter}
+  +<helpers/bridges/ESPNowBridge.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${T_Beam_1W_SX1262.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:T_Beam_1W_SX1262_room_server]
+extends = T_Beam_1W_SX1262
+build_flags =
+  ${T_Beam_1W_SX1262.build_flags}
+  -D ADVERT_NAME='"T-Beam 1W Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${T_Beam_1W_SX1262.build_src_filter}
+  +<../examples/simple_room_server>
+lib_deps =
+  ${T_Beam_1W_SX1262.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:T_Beam_1W_SX1262_companion_radio_ble]
+extends = T_Beam_1W_SX1262
+build_flags =
+  ${T_Beam_1W_SX1262.build_flags}
+  -I examples/companion_radio/ui-new
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D BLE_PIN_CODE=123456
+  -D OFFLINE_QUEUE_SIZE=256
+  -D BLE_DEBUG_LOGGING=1
+  -D MESH_PACKET_LOGGING=8
+  -D MESH_DEBUG=1
+  -D GPS_NMEA_DEBUG=1
+build_src_filter = ${T_Beam_1W_SX1262.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${T_Beam_1W_SX1262.lib_deps}
+  densaugeo/base64 @ ~1.4.0

--- a/variants/lilygo_tbeam_1w_SX1262/target.cpp
+++ b/variants/lilygo_tbeam_1w_SX1262/target.cpp
@@ -1,0 +1,112 @@
+#include <Arduino.h>
+#include "target.h"
+
+TBeamBoard board;
+
+static bool fanRunning = false;
+static uint32_t fanStartTime = 0;
+static const uint32_t FAN_RUN_TIME_MS = 5000; // 5 seconds after transmission
+
+#ifdef DISPLAY_CLASS
+  DISPLAY_CLASS display;
+  MomentaryButton user_btn(PIN_USER_BTN, 1000, true);
+#endif
+
+static SPIClass spi;
+
+RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, spi);
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+ESP32RTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+
+#if ENV_INCLUDE_GPS
+  #include <helpers/sensors/MicroNMEALocationProvider.h>
+  MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1);
+  EnvironmentSensorManager sensors = EnvironmentSensorManager(nmea);
+#else
+  EnvironmentSensorManager sensors;
+#endif
+
+void activate_fan() {
+  #ifdef P_FAN_CTRL
+    digitalWrite(P_FAN_CTRL, HIGH);
+    fanRunning = true;
+    fanStartTime = millis();
+    
+   // #ifdef DEBUG_FAN
+    //Serial.printf("[FAN] Activated at %lu ms\n", fanStartTime);
+    //#endif
+  #endif
+}
+void update_fan_control() {
+  #ifdef P_FAN_CTRL
+    if (fanRunning) {
+      uint32_t currentTime = millis();
+      uint32_t elapsed;
+      
+      // Handle millis() overflow
+      if (currentTime >= fanStartTime) {
+        elapsed = currentTime - fanStartTime;
+      } else {
+        elapsed = (UINT32_MAX - fanStartTime) + currentTime;
+      }
+      
+      if (elapsed >= FAN_RUN_TIME_MS) {
+        digitalWrite(P_FAN_CTRL, LOW);
+        fanRunning = false;
+        
+       // #ifdef DEBUG_FAN
+       // Serial.printf("[FAN] Deactivated after %lu ms\n", elapsed);
+       // #endif
+      }
+    }
+  #endif
+}
+
+bool radio_init() {
+  // Enable the radio LDO (must be HIGH to power on radio)
+  pinMode(P_LORA_LDO_EN, OUTPUT);
+  digitalWrite(P_LORA_LDO_EN, HIGH);
+  delay(10);  // Give LDO time to stabilize
+  
+  // Configure LNA control pin (LOW during TX/sleep, HIGH during RX)
+  pinMode(P_LORA_CTRL, OUTPUT);
+  digitalWrite(P_LORA_CTRL, HIGH);  // Start in RX mode (LNA on)
+  
+  // Enable cooling fan control
+  #ifdef P_FAN_CTRL
+  pinMode(P_FAN_CTRL, OUTPUT);
+  digitalWrite(P_FAN_CTRL, LOW);  // Turn off fan initially
+  #endif
+  
+  fallback_clock.begin();
+  rtc_clock.begin(Wire);  // T-Beam 1W uses single I2C bus on Wire
+  
+  // Reset fan timer
+  fanRunning = false;
+  fanStartTime = 0;
+  
+  return radio.std_init(&spi);
+}
+
+uint32_t radio_get_rng_seed() {
+  return radio.random(0x7FFFFFFF);
+}
+
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr) {
+  radio.setFrequency(freq);
+  radio.setSpreadingFactor(sf);
+  radio.setBandwidth(bw);
+  radio.setCodingRate(cr);
+}
+
+void radio_set_tx_power(uint8_t dbm) {
+  radio.setOutputPower(dbm);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);  // create new random identity
+}

--- a/variants/lilygo_tbeam_1w_SX1262/target.h
+++ b/variants/lilygo_tbeam_1w_SX1262/target.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <helpers/esp32/TBeamBoard.h>
+#include <helpers/radiolib/CustomSX1262Wrapper.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/sensors/EnvironmentSensorManager.h>
+
+#ifdef DISPLAY_CLASS
+  #include <helpers/ui/SH1106Display.h>
+  extern DISPLAY_CLASS display;
+  #include <helpers/ui/MomentaryButton.h>
+  extern MomentaryButton user_btn;
+#endif
+
+extern TBeamBoard board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern EnvironmentSensorManager sensors;
+
+bool radio_init();
+uint32_t radio_get_rng_seed();
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr);
+void radio_set_tx_power(uint8_t dbm);
+mesh::LocalIdentity radio_new_identity();
+void activate_fan();           // Activate cooling fan
+void update_fan_control();     // Update fan state (call in main loop)


### PR DESCRIPTION
Adds board variant and TBeamBoard integration for the LilyGo T-Beam 1W with SX1262 radio and 1W power amplifier.

New files:
•  variants/lilygo_tbeam_1w_SX1262/ — variant with Companion BLE, Repeater, Room Server, and ESPNow Bridge environments
•  t-beam-1w.json — board definition (ESP32-S3, 16MB flash)

Modified files:
•  src/helpers/esp32/TBeamBoard.h — pin definitions, ADC battery fallback (2S Li-ion), fan control hooks
•  src/helpers/esp32/TBeamBoard.cpp — PMU power rail config, GPIO GPS fallback, PMU IRQ guard

Hardware details:
•  ESP32-S3 with SX1262 + 1W PA
•  AXP2101 PMU on single I2C bus (GPIO 8/9)
•  2S Li-ion battery (7.4V nominal) with ADC voltage sensing fallback
•  Temperature-based fan control for PA cooling
•  SH1106 OLED display