### PR TITLE
Add board files for nRF52840 Dongle (pca10059)

### DIFF
--- a/boards/nrf52840_dongle.json
+++ b/boards/nrf52840_dongle.json
@@ -1,0 +1,38 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "nrf52840_dongle.ld"
+    },
+    "core": "nRF5",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DARDUINO_NRF52840_PCA10059 -DNRF52840_XXAA",
+    "f_cpu": "64000000L",
+    "mcu": "nrf52840",
+    "variant": "pca10059",
+    "bsp": {
+      "name": "adafruit"
+    },
+    "softdevice": {
+      "sd_flags": "-DS140",
+      "sd_name": "s140",
+      "sd_version": "7.3.0",
+      "sd_fwid": "0x123"
+    }
+  },
+  "connectivity": [
+    "bluetooth"
+  ],
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "NRF52840 Dongle",
+  "upload": {
+    "maximum_ram_size": 248832,
+    "maximum_size": 815104,
+    "require_upload_port": true,
+    "speed": 115200,
+    "protocol": "jlink"
+  },
+  "url": "https://os.mbed.com/platforms/Nordic-nRF52840-DK/",
+  "vendor": "Nordic"
+}

--- a/boards/nrf52840_dongle.ld
+++ b/boards/nrf52840_dongle.ld
@@ -5,9 +5,7 @@ GROUP(-lgcc -lc -lnosys)
 
 MEMORY
 {
-  /* Leave space for an InternalFilesystem at 0x80000 - 0x87000,
-   * before the DFU bootloader.
-   */
+  /* Leave space after 0x80000 for the DFU bootloader. */
   FLASH (rx)     : ORIGIN = 0x27000, LENGTH = 0x87000 - 0x27000
 
   /* SRAM required by Softdevice depend on

--- a/boards/nrf52840_dongle.ld
+++ b/boards/nrf52840_dongle.ld
@@ -1,0 +1,41 @@
+/* Linker script to configure memory regions. */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  /* Leave space for an InternalFilesystem at 0x80000 - 0x87000,
+   * before the DFU bootloader.
+   */
+  FLASH (rx)     : ORIGIN = 0x27000, LENGTH = 0x87000 - 0x27000
+
+  /* SRAM required by Softdevice depend on
+   * - Attribute Table Size (Number of Services and Characteristics)
+   * - Vendor UUID count
+   * - Max ATT MTU
+   * - Concurrent connection peripheral + central + secure links
+   * - Event Len, HVN queue, Write CMD queue
+   */
+  RAM (rwx) :  ORIGIN = 0x20006000, LENGTH = 0x20040000 - 0x20006000
+}
+
+SECTIONS
+{
+  . = ALIGN(4);
+  .svc_data :
+  {
+    PROVIDE(__start_svc_data = .);
+    KEEP(*(.svc_data))
+    PROVIDE(__stop_svc_data = .);
+  } > RAM
+
+  .fs_data :
+  {
+    PROVIDE(__start_fs_data = .);
+    KEEP(*(.fs_data))
+    PROVIDE(__stop_fs_data = .);
+  } > RAM
+} INSERT AFTER .data;
+
+INCLUDE "nrf52_common.ld"


### PR DESCRIPTION
This adds a board definition and linker script for the nRF52840 Dongle. I have chosen SoftDevice 7.3.0 for the SoftDevice version, because it is the most recent supported by MeshCore. The linker script assumes that addresses upwards of 0x80000 are occupied by the DFU bootloader that comes on the nRF52840 Dongle by default. The linker script does not work with MeshCore out of the box, because it does not leave any room for an InternalFileSystem.

I intended to open this PR on my fork, not here on upstream. I will leave it open for a bit in case anyone wants to look at it, but I expect this change to be rejected here.