### PR TITLE
Insufficient Default Backoff Settings: rxdelay, txdelay, direct.txdelay

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -856,9 +856,9 @@ MyMesh::MyMesh(mesh::MainBoard &board, mesh::Radio &radio, mesh::MillisecondCloc
   // defaults
   memset(&_prefs, 0, sizeof(_prefs));
   _prefs.airtime_factor = 1.0;
-  _prefs.rx_delay_base = 0.0f;   // turn off by default, was 10.0;
-  _prefs.tx_delay_factor = 0.5f; // was 0.25f
-  _prefs.direct_tx_delay_factor = 0.3f; // was 0.2
+  _prefs.rx_delay_base = 3.0f;   // off by default, was 10.0, was 0.0
+  _prefs.tx_delay_factor = 1.6f; // was 0.25f, was 0.5f
+  _prefs.direct_tx_delay_factor = 1.0f; // was zero, was 0.3
   StrHelper::strncpy(_prefs.node_name, ADVERT_NAME, sizeof(_prefs.node_name));
   _prefs.node_lat = ADVERT_LAT;
   _prefs.node_lon = ADVERT_LON;


### PR DESCRIPTION
The current default values are:
_prefs.rx_delay_base = 0.0f; // turn off by default, was 10.0;
_prefs.tx_delay_factor = 0.5f; // was 0.25f
_prefs.direct_tx_delay_factor = 0.3f; // was 0.2

These control the Random Backoff behavior of a repeater, which reduces the probability of a collision between neighbor repeaters.

Backoff is essential in avoiding collisions. Many repeater owners are not aware of this capability and do not change them, this leaves the mesh under configured in order to avoid collisions. The default values are too low and are not providing any significant backoff for the Mesh.

The default value for rx_delay = 0, which is off. So, this mechanism is not being utilized. A recommended minimum value for rxdelay is 3

The default value for direct.x_delay = 0.3, which is provides 2 backoff slots, which has a high probability of a collision. A recommended minimum value for direct.x_delay is 1 which will provide 5 backoff slots and reduces the probability of a collision.

The default value for tx_delay = 0.5, which is provides 2 backoff slots, additional backoff slots will reduce the probability of a collision. A recommended minimum value for txdelay is 1.6 which provides 8 backoff slots and reduces the probability of a collision.

These all are configurable using CLI commands so users are still free to select their own preferred values and can turn them off.

Enabling some level of backoff will improve the performance of the Mesh.