### PR TITLE
Add support for Companion BLE OTA updates on nRF devices

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -801,7 +801,8 @@ Allow the browser user on it:
 13. If it fails, try turning off and on Bluetooth on your phone.  If that doesn't work, try rebooting your phone.  If you keep getting failures at the "Enabling Bootloader" step, try forgetting the NRF board in your IOS or Andriod device's bluetooth settings and re-pair it through the DFU app.
 14. Wait for the update to complete.  It can take a few minutes.   
 15. It is strongly recommended that you install and use the OTAFIX bootloader at https://github.com/oltaco/Adafruit_nRF52_Bootloader_OTAFIX. 
-16. Please see the Meshcore Blog for additional information on OTA firmware flashing: 
+16. To update a companion node over OTA, it must be running companion firmware v1.15 or greater.   
+17. Please see the Meshcore Blog for additional information on OTA firmware flashing: 
     - https://blog.meshcore.io/2026/04/06/otafix-bootloader
     - https://blog.meshcore.io/2026/04/02/nrf-ota-update
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -89,7 +89,7 @@ A list of frequently-asked questions and answers for MeshCore
   - [6.7. Q: My RAK/T1000-E/xiao\_nRF52 device seems to be corrupted, how do I wipe it clean to start fresh?](#67-q-my-rakt1000-exiao_nrf52-device-seems-to-be-corrupted-how-do-i-wipe-it-clean-to-start-fresh)
   - [6.8. Q: WebFlasher fails on Linux with failed to open](#68-q-webflasher-fails-on-linux-with-failed-to-open)
 - [7. Other Questions:](#7-other-questions)
-  - [7.1. Q: How to update nRF (RAK, T114, Seed XIAO) repeater and room server firmware over the air using the new simpler DFU app?](#71-q-how-to-update-nrf-rak-t114-seed-xiao-repeater-and-room-server-firmware-over-the-air-using-the-new-simpler-dfu-app)
+  - [7.1. Q: How to update nRF (RAK, T114, Seed XIAO) companion, repeater and room server firmware over the air using the new simpler DFU app?](#71-q-how-to-update-nrf-rak-t114-seed-xiao-companion-repeater-and-room-server-firmware-over-the-air-using-the-new-simpler-dfu-app)
     - [7.1.1 Q: Can I update Seeed Studio Wio Tracker L1 Pro using OTA?](#711-q-can-i-update-seeed-studio-wio-tracker-l1-pro-using-ota)
   - [7.2. Q: How to update ESP32-based devices over the air?](#72-q-how-to-update-esp32-based-devices-over-the-air)
   - [7.3. Q: Is there a way to lower the chance of a failed OTA device firmware update (DFU)?](#73-q-is-there-a-way-to-lower-the-chance-of-a-failed-ota-device-firmware-update-dfu)
@@ -783,13 +783,13 @@ Allow the browser user on it:
 ---
 ## 7. Other Questions:
 
-### 7.1. Q: How to update nRF (RAK, T114, Seed XIAO) repeater and room server firmware over the air using the new simpler DFU app?
+### 7.1. Q: How to update nRF (RAK, T114, Seed XIAO) companion, repeater and room server firmware over the air using the new simpler DFU app?
 
 **A:** The steps below work on both Android and iOS as nRF has made both apps' user interface the same on both platforms:
 
 1. Download nRF's DFU app from iOS App Store or Android's Play Store, you can find the app by searching for `nrf dfu`, the app's full name is `nRF Device Firmware Update`
 2. On flasher.meshcore.co.uk, download the **ZIP** version of the firmware for your nRF device (e.g. RAK or Heltec T114 or Seeed Studio's Xiao)
-3. From the MeshCore app, login remotely to the repeater you want to update with admin privilege
+3. If updating a companion, skip to step 6 below.  If updating a repeater or room server, from the MeshCore app, login remotely to the repeater you want to update with admin privilege
 4. Go to the Command Line tab, type `start ota` and hit enter.
 5. you should see `OK` to confirm the repeater device is now in OTA mode
 6. Run the DFU app,tab `Settings` on the top right corner
@@ -798,8 +798,13 @@ Allow the browser user on it:
 10. Select the device you want to update. If the device you want to update is not on the list, try enabling`OTA` on the device again
 11. If the device is not found, enable `Force Scanning` in the DFU app
 12. Tab the `Upload` to begin OTA update
-13. If it fails, try turning off and on Bluetooth on your phone.  If that doesn't work, try rebooting your phone.
-14. Wait for the update to complete.  It can take a few minutes.
+13. If it fails, try turning off and on Bluetooth on your phone.  If that doesn't work, try rebooting your phone.  If you keep getting failures at the "Enabling Bootloader" step, try forgetting the NRF board in your IOS or Andriod device's bluetooth settings and re-pair it through the DFU app.
+14. Wait for the update to complete.  It can take a few minutes.   
+15. It is strongly recommended that you install and use the OTAFIX bootloader at https://github.com/oltaco/Adafruit_nRF52_Bootloader_OTAFIX. 
+16. Please see the Meshcore Blog for additional information on OTA firmware flashing: 
+    - https://blog.meshcore.io/2026/04/06/otafix-bootloader
+    - https://blog.meshcore.io/2026/04/02/nrf-ota-update
+
 
 #### 7.1.1 Q: Can I update Seeed Studio Wio Tracker L1 Pro using OTA?
 **A:**  You can flash this safer bootloader to the Wio Tracker L1 Pro

--- a/src/helpers/nrf52/SerialBLEInterface.cpp
+++ b/src/helpers/nrf52/SerialBLEInterface.cpp
@@ -177,6 +177,11 @@ void SerialBLEInterface::begin(const char* prefix, char* name, uint32_t pin_code
 
   Bluefruit.setEventCallback(onBLEEvent);
 
+  // Register DFU on the main BLE stack so paired clients can discover it
+  // without switching the device into a separate OTA-only BLE mode first.
+  bledfu.setPermission(SECMODE_ENC_WITH_MITM, SECMODE_ENC_WITH_MITM);
+  bledfu.begin();
+
   bleuart.setPermission(SECMODE_ENC_WITH_MITM, SECMODE_ENC_WITH_MITM);
   bleuart.begin();
   bleuart.setRxCallback(onBleUartRX);

--- a/src/helpers/nrf52/SerialBLEInterface.h
+++ b/src/helpers/nrf52/SerialBLEInterface.h
@@ -8,6 +8,7 @@
 #endif
 
 class SerialBLEInterface : public BaseSerialInterface {
+  BLEDfu bledfu;
   BLEUart bleuart;
   bool _isEnabled;
   bool _isDeviceConnected;


### PR DESCRIPTION
This PR adds support for BLE OTA updates to MeshCore companion devices running on nRF based boards.
Thanks to @txkbaldlaw for the original changes. I've opened the PR on your behalf so you get credits for the commits.

When I originally looked into BLE OTA updates for companion devices a few months ago, I had made the same changes in this PR. However, I ran into several issues. One was mainly due to the outdated bootloader that comes preflashed by the factory on most devices sold by manufacturers.

The outdated bootloader would fail to update firmware with the _default settings_ provided by the nRF DFU app for Android and iOS, and because it pre-wipes the flash when the BLE OTA process is started, it was not possible to reboot the device back into MeshCore companion firmware without a full reflash via USB.

Another issue is that if you had already paired with the device on Android _without_ the changes in this PR, you would need to forget the device in Android Bluetooth settings, otherwise the OTA would fail with an error saying the device doesn't not support nRF DFU. This is most likely due to the Android device caching the BLE services/characteristics at pairing time. So an unpair/repair is needed to discover that the device supports the nRF BLE OTA service...

Please see the following list of things to keep in mind when using BLE OTA for companion devices:
- These changes will likely be in MeshCore Companion firmware v1.15.0+
- You must flash MeshCore companion firmware that contains this patch before BLE OTA is supported.
- You must unpair the MeshCore device in Android BLE settings if nRF DFU app says it doesn't support nRF DFU.
- Most nRF boards come with an outdated bootloader, which usually fails OTA and requires reflashing via USB.
- It's recommended to update to the [OTAFIX bootloader](https://github.com/oltaco/Adafruit_nRF52_Bootloader_OTAFIX) for the best experience.
- If you don't update to OTAFIX bootloader, you must set packet receipts to `4` in the nRF DFU app for OTA to work, otherwise it fails 100% of the time due to this bug: https://github.com/adafruit/Adafruit_nRF52_Bootloader/issues/306

Please see our blog posts for more information on how to update the bootloader and perform a BLE OTA update:
- https://blog.meshcore.io/2026/04/06/otafix-bootloader
- https://blog.meshcore.io/2026/04/02/nrf-ota-update

These changes have been tested on the WioTracker L1 Pro, with both the outdated bootloader and the OTAFIX bootloader.