### PR TITLE
Added support for Expansion Kit to Heltec V4 OLED repeaters

### DIFF
--- a/variants/heltec_v4/platformio.ini
+++ b/variants/heltec_v4/platformio.ini
@@ -102,6 +102,28 @@ lib_deps =
   ${esp32_ota.lib_deps}
   bakercp/CRC32 @ ^2.0.0
 
+[env:heltec_v4_expansionkit_repeater]
+extends = heltec_v4_oled
+build_flags =
+  ${heltec_v4_oled.build_flags}
+  -D DISPLAY_CLASS=SSD1306Display
+  -D ADVERT_NAME='"Heltec Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+  -D ENV_PIN_SDA=4
+  -D ENV_PIN_SCL=3
+build_src_filter = ${heltec_v4_oled.build_src_filter}
+  +<helpers/ui/SSD1306Display.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${heltec_v4_oled.lib_deps}
+  ${esp32_ota.lib_deps}
+  bakercp/CRC32 @ ^2.0.0
+
 [env:heltec_v4_repeater_bridge_espnow]
 extends = heltec_v4_oled
 build_flags =


### PR DESCRIPTION
This PR is to add support for Expansion Kit to Heltec V4 OLED repeaters. 
https://heltec.org/project/wifi-lora-32-v4-expansion-housing/

This KIT uses I2C GPIOs 17/28 for OLED but uses I2C GPIOs 4,3 for sensors.
Tested working by a friend here.

