### PR TITLE
Add Heltec V4 set adc.multiplier functionality

### DIFF
--- a/variants/heltec_v4/HeltecV4Board.cpp
+++ b/variants/heltec_v4/HeltecV4Board.cpp
@@ -73,7 +73,7 @@ void HeltecV4Board::begin() {
 
     digitalWrite(PIN_ADC_CTRL, LOW);
 
-    return (5.42 * (3.3 / 1024.0) * raw) * 1000;
+    return (adc_mult * (3.3 / 1024.0) * raw) * 1000;
   }
 
   const char* HeltecV4Board::getManufacturerName() const {

--- a/variants/heltec_v4/HeltecV4Board.h
+++ b/variants/heltec_v4/HeltecV4Board.h
@@ -5,7 +5,15 @@
 #include <helpers/ESP32Board.h>
 #include <driver/rtc_io.h>
 #include "LoRaFEMControl.h"
+
+#ifndef ADC_MULTIPLIER
+  #define ADC_MULTIPLIER 5.42
+#endif
+
 class HeltecV4Board : public ESP32Board {
+
+protected:
+  float adc_mult = ADC_MULTIPLIER;
 
 public:
   RefCountedDigitalPin periph_power;
@@ -18,6 +26,14 @@ public:
   void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1);
   void powerOff() override;
   uint16_t getBattMilliVolts() override;
-  const char* getManufacturerName() const override ;
-
+  bool setAdcMultiplier(float multiplier) override {
+    if (multiplier == 0.0f) {
+      adc_mult = ADC_MULTIPLIER;
+    } else {
+      adc_mult = multiplier;
+    }
+    return true;
+  }
+  float getAdcMultiplier() const override { return adc_mult; }
+  const char* getManufacturerName() const override;
 };


### PR DESCRIPTION
Just a simple PR that adds the 'set adc.multiplier' functionality to the Heltec V4 board.
It allows you to modify the adc multiplier to better match the real measured values if needed.

All required code was already available and implemented for the 'PromicroBoard' #1133 board, this just adds the Heltec V4 to the list ;)
https://docs.meshcore.io/cli_commands/#fine-tune-the-battery-reading
https://github.com/meshcore-dev/MeshCore/pull/1133