### PR TITLE
prevent a oob via serial or lora - causing a crash and hardware interaction

### DIFF
--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -726,7 +726,7 @@ void CommonCLI::handleSetCmd(uint32_t sender_timestamp, char* command, char* rep
       strcpy(reply, "Error: unsupported by this board");
     };
   } else {
-    sprintf(reply, "unknown config: %s", config);
+    snprintf(reply, CLI_REPLY_MAX, "unknown config: %.128s", config);
   }
 }
 
@@ -784,10 +784,10 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
   } else if (memcmp(config, "direct.txdelay", 14) == 0) {
     sprintf(reply, "> %s", StrHelper::ftoa(_prefs->direct_tx_delay_factor));
   } else if (memcmp(config, "owner.info", 10) == 0) {
-    *reply++ = '>';
-    *reply++ = ' ';
+    char* reply_end = reply + CLI_REPLY_MAX - 1;  // leave room for null
+    *reply++ = '>'; *reply++ = ' ';
     const char* sp = _prefs->owner_info;
-    while (*sp) {
+    while (*sp && reply < reply_end) {
       *reply++ = (*sp == '\n') ? '|' : *sp;    // translate newline back to orig '|'
       sp++;
     }
@@ -887,7 +887,7 @@ void CommonCLI::handleGetCmd(uint32_t sender_timestamp, char* command, char* rep
     strcpy(reply, "ERROR: Power management not supported");
 #endif
   } else {
-    sprintf(reply, "??: %s", config);
+    snprintf(reply, CLI_REPLY_MAX, "??: %.128s", config);
   }
 }
 

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -10,6 +10,10 @@
 #define WITH_BRIDGE
 #endif
 
+// Smallest reply buffer among all callers (serial main.cpp: char reply[160]).
+// Used by snprintf() in CLI handlers to prevent stack buffer overflows.
+#define CLI_REPLY_MAX  160
+
 #define ADVERT_LOC_NONE       0
 #define ADVERT_LOC_SHARE      1
 #define ADVERT_LOC_PREFS      2


### PR DESCRIPTION
a possible attacker could crash a repeater/roomserver with a oob write. 

this minimal approch will prevent that in the future. This PR is a possible solution for #2348. 