### PR TITLE
Update script link in FAQ 4.7 to the repo of the fork

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -402,7 +402,7 @@ Another way to download map tiles is to use this Python script to get the tiles 
 <https://github.com/fistulareffigy/MTD-Script>
 
 There is also a modified script that adds additional error handling and parallel downloads:
-<https://discord.com/channels/826570251612323860/1330643963501351004/1338775811548905572>
+<https://github.com/TheBestJohn/MTD-Script>
 
 UK map tiles are available separately from Andy Kirby on his discord server:
 <https://discord.com/channels/826570251612323860/1330643963501351004/1331346597367386224>


### PR DESCRIPTION
The link to the modified MTD-Script with resume and parallelization links to a Discord message that is inaccessible if you are not in the Discord server it is from. There is a fork of the original MTD-Script repository that appears to be what is described, so I think it would be better to link directly to the repository.