### PR TITLE
Opportunistic clock sync from verified advert timestamps

### DIFF
--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -157,6 +157,8 @@ protected:
     return _prefs.multi_acks;
   }
 
+  bool shouldSyncClockFromMesh() const override { return true; }
+
 #if ENV_INCLUDE_GPS == 1
   void applyGpsPrefs() {
     sensors.setSettingValue("gps", _prefs.gps_enabled?"1":"0");

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -268,9 +268,7 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
         if (is_ok) {
           MESH_DEBUG_PRINTLN("%s Mesh::onRecvPacket(): valid advertisement received!", getLogDateTime());
 
-          // Opportunistic clock sync: if local clock is clearly wrong and the
-          // verified advert carries a sane timestamp, adopt it.  Only fires
-          // when the sub-class opts in (e.g. repeaters without hardware RTC).
+       // sync clock from verified advert if local clock is clearly wrong (for repeaters without hardware RTC)
           if (shouldSyncClockFromMesh()) {
             uint32_t local_time = _rtc->getCurrentTime();
             if (local_time < 1735689600UL          // local clock before Jan 2025 (clearly wrong)

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -267,6 +267,20 @@ DispatcherAction Mesh::onRecvPacket(Packet* pkt) {
         }
         if (is_ok) {
           MESH_DEBUG_PRINTLN("%s Mesh::onRecvPacket(): valid advertisement received!", getLogDateTime());
+
+          // Opportunistic clock sync: if local clock is clearly wrong and the
+          // verified advert carries a sane timestamp, adopt it.  Only fires
+          // when the sub-class opts in (e.g. repeaters without hardware RTC).
+          if (shouldSyncClockFromMesh()) {
+            uint32_t local_time = _rtc->getCurrentTime();
+            if (local_time < 1735689600UL          // local clock before Jan 2025 (clearly wrong)
+                && timestamp > 1735689600UL         // advert after Jan 2025
+                && timestamp < 2082758400UL) {      // advert before Jan 2036
+              _rtc->setCurrentTime(timestamp);
+              MESH_DEBUG_PRINTLN("  clock synced from advert: %lu", (unsigned long)timestamp);
+            }
+          }
+
           onAdvertRecv(pkt, id, timestamp, app_data, app_data_len);
           action = routeRecvPacket(pkt);
         } else {

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -50,6 +50,15 @@ protected:
   virtual bool filterRecvFloodPacket(Packet* packet) { return false; }
 
   /**
+   * \brief  Whether to opportunistically sync the local RTC from verified advert timestamps.
+   *     When enabled, if the local clock is clearly wrong (before Jan 2025) and a
+   *     signature-verified advert carries a sane timestamp, the local clock is updated.
+   *     Intended for GPS-less repeaters that lose their clock on power cycle.
+   * \returns  true to enable advert-based clock sync (default: false)
+   */
+  virtual bool shouldSyncClockFromMesh() const { return false; }
+
+  /**
    * \brief  Check whether this packet should be forwarded (re-transmitted) or not.
    *     Is sub-classes responsibility to make sure given packet is only transmitted ONCE (by this node)
    */

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -49,13 +49,7 @@ protected:
    */
   virtual bool filterRecvFloodPacket(Packet* packet) { return false; }
 
-  /**
-   * \brief  Whether to opportunistically sync the local RTC from verified advert timestamps.
-   *     When enabled, if the local clock is clearly wrong (before Jan 2025) and a
-   *     signature-verified advert carries a sane timestamp, the local clock is updated.
-   *     Intended for GPS-less repeaters that lose their clock on power cycle.
-   * \returns  true to enable advert-based clock sync (default: false)
-   */
+  // sync clock from verified advert if local clock is clearly wrong
   virtual bool shouldSyncClockFromMesh() const { return false; }
 
   /**


### PR DESCRIPTION
Closes #1329. Related: #2132, #1332, #1882.
 
## Problem
 
GPS-less repeaters lose their clock on every power cycle, reverting to the firmware default (~May 2024). This means their adverts carry stale timestamps until an admin manually syncs the clock via serial, the mobile app, or a remote management command. For inaccessible repeaters (rooftops, hilltops, solar-powered sites that reboot daily), manual sync is impractical.
 
## Solution
 
Add an opt-in mechanism for nodes to sync their local RTC from signature-verified advert timestamps. When a node's clock is clearly wrong (before Jan 2025) and it receives a valid advert with a sane timestamp (Jan 2025 – Jan 2036), it adopts that timestamp.
 
The sync only fires when:
1. The sub-class opts in via `shouldSyncClockFromMesh()` (defaults to `false`)
2. The local clock is before Jan 2025 (clearly wrong / default state)
3. The incoming advert timestamp passes sanity checks
4. The advert signature has already been cryptographically verified
Once the clock is set past Jan 2025, the sync stops firing — it won't overwrite a valid clock with subsequent adverts.
 
## Changes
 
**`src/Mesh.h`** — New virtual method:
```cpp
virtual bool shouldSyncClockFromMesh() const { return false; }
```
 
**`src/Mesh.cpp`** — 14 lines added after advert signature verification (inside the `PAYLOAD_TYPE_ADVERT` handler), before `onAdvertRecv()` call. Checks the opt-in gate, validates both local and incoming timestamps, and calls `setCurrentTime()` if appropriate.
 
**`examples/simple_repeater/MyMesh.h`** — Single-line override:
```cpp
bool shouldSyncClockFromMesh() const override { return true; }
```
 
## What this does NOT do
 
- Does not affect companion nodes, clients, or room servers (they don't override the method)
- Does not overwrite a valid clock — only fires when local time is clearly wrong
- Does not sync backward — a node with a stale clock can't drag others back
- Does not add any new preferences, CLI commands, or protocol changes
- Does not increase packet size or airtime

## Testing
 
1. Flash a repeater without GPS/RTC
2. Confirm clock shows default (~May 2024) on boot
3. Wait for a valid advert from any peer with correct time
4. Confirm serial output shows `clock synced from advert: <epoch>`
5. Confirm subsequent adverts do NOT trigger further syncs
6. Confirm a repeater WITH GPS/RTC is unaffected (clock already valid)

## Tested

- Station G2 repeater (both ESPNow bridge repeater and standard) - example screenshots from test:
<table>
<tr>
<td><img width="200" height="400" alt="IMG_2594" src="https://github.com/user-attachments/assets/ced0b522-27ca-4191-b21b-90fff30ba5ae" /></td>
<td><img width="200" height="400" alt="IMG_2595" src="https://github.com/user-attachments/assets/fd4c5a4b-2794-4c66-b2f6-09f183bf8758" /></td>
<td><img width="200" height="400" alt="IMG_2596" src="https://github.com/user-attachments/assets/9253cc17-e99d-4ccb-ab1d-06f38e5495fb" /></td>
</tr>
</table>

- Heltec v3 espnow bridge repeater
- T-Echo Lite repeater (no gps) - example screenshots from test:
<table>
<tr>
<td><img width="200" height="400" alt="IMG_2597" src="https://github.com/user-attachments/assets/22ee2d17-d49b-467f-bf3f-84e7fa482a8c" /></td>
<td><img width="200" height="400" alt="IMG_2598" src="https://github.com/user-attachments/assets/008dca82-24fa-4b95-9e0b-321a55327816" /></td>
<td><img width="200" height="400" alt="IMG_2599" src="https://github.com/user-attachments/assets/fcd82d07-0372-4710-b67e-882965e70a4c" /></td>
</tr>
</table>
