### PR TITLE
Add MeshCore website to splash screen

### DIFF
--- a/examples/companion_radio/ui-new/UITask.cpp
+++ b/examples/companion_radio/ui-new/UITask.cpp
@@ -57,13 +57,21 @@ public:
     int logoWidth = 128;
     display.drawXbm((display.width() - logoWidth) / 2, 3, meshcore_logo, logoWidth, 13);
 
+    // meshcore website
+    const char* website = "https://meshcore.io";
+    display.setColor(DisplayDriver::LIGHT);
+    display.setTextSize(1);
+    uint16_t websiteWidth = display.getTextWidth(website);
+    display.setCursor((display.width() - websiteWidth) / 2, 22);
+    display.print(website);
+
     // version info
     display.setColor(DisplayDriver::LIGHT);
-    display.setTextSize(2);
-    display.drawTextCentered(display.width()/2, 22, _version_info);
+    display.setTextSize(1);
+    display.drawTextCentered(display.width()/2, 35, _version_info);
 
     display.setTextSize(1);
-    display.drawTextCentered(display.width()/2, 42, FIRMWARE_BUILD_DATE);
+    display.drawTextCentered(display.width()/2, 48, FIRMWARE_BUILD_DATE);
 
     return 1000;
   }

--- a/examples/simple_repeater/UITask.cpp
+++ b/examples/simple_repeater/UITask.cpp
@@ -52,17 +52,25 @@ void UITask::renderCurrScreen() {
     int logoWidth = 128;
     _display->drawXbm((_display->width() - logoWidth) / 2, 3, meshcore_logo, logoWidth, 13);
 
+    // meshcore website
+    const char* website = "https://meshcore.io";
+    _display->setColor(DisplayDriver::LIGHT);
+    _display->setTextSize(1);
+    uint16_t websiteWidth = _display->getTextWidth(website);
+    _display->setCursor((_display->width() - websiteWidth) / 2, 22);
+    _display->print(website);
+
     // version info
     _display->setColor(DisplayDriver::LIGHT);
     _display->setTextSize(1);
     uint16_t versionWidth = _display->getTextWidth(_version_info);
-    _display->setCursor((_display->width() - versionWidth) / 2, 22);
+    _display->setCursor((_display->width() - versionWidth) / 2, 35);
     _display->print(_version_info);
 
     // node type
     const char* node_type = "< Repeater >";
     uint16_t typeWidth = _display->getTextWidth(node_type);
-    _display->setCursor((_display->width() - typeWidth) / 2, 35);
+    _display->setCursor((_display->width() - typeWidth) / 2, 48);
     _display->print(node_type);
   } else {  // home screen
     // node name

--- a/examples/simple_room_server/UITask.cpp
+++ b/examples/simple_room_server/UITask.cpp
@@ -52,17 +52,25 @@ void UITask::renderCurrScreen() {
     int logoWidth = 128;
     _display->drawXbm((_display->width() - logoWidth) / 2, 3, meshcore_logo, logoWidth, 13);
 
+    // meshcore website
+    const char* website = "https://meshcore.io";
+    _display->setColor(DisplayDriver::LIGHT);
+    _display->setTextSize(1);
+    uint16_t websiteWidth = _display->getTextWidth(website);
+    _display->setCursor((_display->width() - websiteWidth) / 2, 22);
+    _display->print(website);
+
     // version info
     _display->setColor(DisplayDriver::LIGHT);
     _display->setTextSize(1);
     uint16_t versionWidth = _display->getTextWidth(_version_info);
-    _display->setCursor((_display->width() - versionWidth) / 2, 22);
+    _display->setCursor((_display->width() - versionWidth) / 2, 35);
     _display->print(_version_info);
 
     // node type
     const char* node_type = "< Room Server >";
     uint16_t typeWidth = _display->getTextWidth(node_type);
-    _display->setCursor((_display->width() - typeWidth) / 2, 35);
+    _display->setCursor((_display->width() - typeWidth) / 2, 48);
     _display->print(node_type);
   } else {  // home screen
     // node name

--- a/examples/simple_sensor/UITask.cpp
+++ b/examples/simple_sensor/UITask.cpp
@@ -52,17 +52,25 @@ void UITask::renderCurrScreen() {
     int logoWidth = 128;
     _display->drawXbm((_display->width() - logoWidth) / 2, 3, meshcore_logo, logoWidth, 13);
 
+    // meshcore website
+    const char* website = "https://meshcore.io";
+    _display->setColor(DisplayDriver::LIGHT);
+    _display->setTextSize(1);
+    uint16_t websiteWidth = _display->getTextWidth(website);
+    _display->setCursor((_display->width() - websiteWidth) / 2, 22);
+    _display->print(website);
+
     // version info
     _display->setColor(DisplayDriver::LIGHT);
     _display->setTextSize(1);
     uint16_t versionWidth = _display->getTextWidth(_version_info);
-    _display->setCursor((_display->width() - versionWidth) / 2, 22);
+    _display->setCursor((_display->width() - versionWidth) / 2, 35);
     _display->print(_version_info);
 
     // node type
     const char* node_type = "< Sensor >";
     uint16_t typeWidth = _display->getTextWidth(node_type);
-    _display->setCursor((_display->width() - typeWidth) / 2, 35);
+    _display->setCursor((_display->width() - typeWidth) / 2, 48);
     _display->print(node_type);
   } else {  // home screen
     // node name


### PR DESCRIPTION
This PR adds the MeshCore website URL to the splash screen shown during boot.

It has been added to the following firmware types:

- companion
- repeater
- room server
- sensor

| Before | After |
|--------|--------|
| <img width="200" alt="20260428_171056" src="https://github.com/user-attachments/assets/b5d36ef1-0fef-4e66-9883-fc492f1e046b" /> | <img width="200" alt="20260428_171239" src="https://github.com/user-attachments/assets/191661cb-c021-42ea-bcb0-ab5ba3fbfe57" /> |
| <img width="200" alt="20260428_155754" src="https://github.com/user-attachments/assets/4f1d1010-339a-44bd-907c-3949a53181f4" /> | <img width="200" alt="20260428_163610" src="https://github.com/user-attachments/assets/43673f62-a056-4b21-a752-622b795be157" /> |